### PR TITLE
New appproach to exposing Rust data types through `wasm-bindgen`

### DIFF
--- a/catlog/Cargo.toml
+++ b/catlog/Cargo.toml
@@ -5,14 +5,19 @@ authors = ["Evan Patterson"]
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+serde = ["dep:serde", "nonempty/serialize", "ustr/serde"]
+serde-wasm = ["serde", "dep:wasm-bindgen", "dep:tsify-next"]
 
 [dependencies]
-archery = "1.2.0"
+archery = "1"
 derivative = "2"
 derive_more = "0.99"
 nonempty = "0.10"
 ref-cast = "1"
-smallvec = "1.13.2"
+serde = { version = "1", features = ["derive"], optional = true }
+smallvec = "1"
 thiserror = "1"
+tsify-next = { version = "0.5", features = ["js"], optional = true }
 ustr = "1"
+wasm-bindgen = { version = "0.2.92", optional = true }

--- a/catlog/src/dbl/theory.rs
+++ b/catlog/src/dbl/theory.rs
@@ -268,11 +268,11 @@ where C::Ob: Clone, C::Hom: Clone, {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::one::fin_category::{self, FinCategory};
+    use crate::one::fin_category::*;
 
     #[test]
     fn discrete_dbl_theory() {
-        type Hom<V,E> = fin_category::Hom<V,E>;
+        type Hom<V,E> = FinHom<V,E>;
 
         let mut sgn: FinCategory<char,char> = Default::default();
         sgn.add_ob_generator('*');
@@ -280,7 +280,7 @@ mod tests {
         sgn.set_composite('n', 'n', Hom::Id('*'));
 
         let thy = DiscreteDblTheory::from(sgn);
-        assert!(thy.has_ob_type(&fin_category::Ob('*')));
+        assert!(thy.has_ob_type(&'*'));
         assert!(thy.has_mor_type(&Hom::Generator('n')));
         assert_eq!(thy.basic_ob_types().count(), 1);
         assert_eq!(thy.basic_mor_types().count(), 1);

--- a/catlog/src/one/fin_category.rs
+++ b/catlog/src/one/fin_category.rs
@@ -6,6 +6,11 @@ use derivative::Derivative;
 use ref_cast::RefCast;
 use ustr::{Ustr, IdentityHasher};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde-wasm")]
+use tsify_next::Tsify;
+
 use crate::zero::{Mapping, HashColumn};
 use super::path::Path;
 use super::graph::*;
@@ -17,11 +22,18 @@ This wrapper type is just for clarity. We prohibit equations between objects, so
 objects and object generators coincide.
 */
 #[derive(Clone,Debug,Copy,PartialEq,Eq,Hash,RefCast)]
+#[cfg_attr(feature = "serde", derive(Serialize,Deserialize))]
+#[cfg_attr(feature = "serde-wasm", derive(Tsify))]
+#[cfg_attr(feature = "serde-wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[repr(transparent)]
 pub struct Ob<V>(pub V);
 
 /// Morphism in a finite category.
 #[derive(Clone,Debug,Copy,PartialEq,Eq,Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize,Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "tag", content = "content"))]
+#[cfg_attr(feature = "serde-wasm", derive(Tsify))]
+#[cfg_attr(feature = "serde-wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum Hom<V,E> {
     /// Identity morphism on an object.
     Id(V),

--- a/catlog/src/one/path.rs
+++ b/catlog/src/one/path.rs
@@ -2,6 +2,11 @@
 
 use nonempty::{NonEmpty, nonempty};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde-wasm")]
+use tsify_next::Tsify;
+
 use super::graph::Graph;
 
 /** A path in a [graph](Graph) or [category](crate::one::category::Category).
@@ -25,6 +30,10 @@ case analysis on the edge sequence anyway to determine whether, say,
 the two cases in the data structure itself.
 */
 #[derive(Clone,Debug,PartialEq,Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize,Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "tag", content = "content"))]
+#[cfg_attr(feature = "serde-wasm", derive(Tsify))]
+#[cfg_attr(feature = "serde-wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum Path<V,E> {
     /// The identity, or empty, path at a vertex.
     Id(V),

--- a/catlog/src/stdlib/theories.rs
+++ b/catlog/src/stdlib/theories.rs
@@ -3,10 +3,11 @@
 use std::sync::OnceLock;
 use ustr::ustr;
 
-use crate::one::fin_category::{self, UstrFinCategory};
+use crate::one::fin_category::*;
 use crate::dbl::theory::DiscreteDblTheory;
 
 type UstrDiscreteDblThy = DiscreteDblTheory<UstrFinCategory>;
+
 
 /** The theory of categories, aka the trivial double theory.
 
@@ -51,7 +52,7 @@ pub fn th_signed_category() -> &'static UstrDiscreteDblThy {
         let (x, n) = (ustr("object"), ustr("negative"));
         sgn.add_ob_generator(x);
         sgn.add_hom_generator(n, x, x);
-        sgn.set_composite(n, n, fin_category::Hom::Id(x));
+        sgn.set_composite(n, n, FinHom::Id(x));
         DiscreteDblTheory::from(sgn)
     })
 }

--- a/catlog/src/stdlib/theories.rs
+++ b/catlog/src/stdlib/theories.rs
@@ -17,21 +17,21 @@ pub fn th_category() -> &'static UstrDiscreteDblThy {
 
     TH_CATEGORY.get_or_init(|| {
         let mut cat: UstrFinCategory = Default::default();
-        cat.add_ob_generator(ustr("x"));
+        cat.add_ob_generator(ustr("object"));
         DiscreteDblTheory::from(cat)
     })
 }
 
-/** The theory of profunctors.
+/** The theory of database schemas with attributes.
 
 As a double category, this is the "walking proarrow".
  */
-pub fn th_profunctor() -> &'static UstrDiscreteDblThy {
-    static TH_PROFUNCTOR: OnceLock<UstrDiscreteDblThy> = OnceLock::new();
+pub fn th_schema() -> &'static UstrDiscreteDblThy {
+    static TH_SCHEMA: OnceLock<UstrDiscreteDblThy> = OnceLock::new();
 
-    TH_PROFUNCTOR.get_or_init(|| {
+    TH_SCHEMA.get_or_init(|| {
         let mut cat: UstrFinCategory = Default::default();
-        let (x, y, p) = (ustr("x"), ustr("y"), ustr("p"));
+        let (x, y, p) = (ustr("entity"), ustr("attr_type"), ustr("attr"));
         cat.add_ob_generator(x);
         cat.add_ob_generator(y);
         cat.add_hom_generator(p, x, y);
@@ -48,7 +48,7 @@ pub fn th_signed_category() -> &'static UstrDiscreteDblThy {
 
     TH_SIGNED_CATEGORY.get_or_init(|| {
         let mut sgn: UstrFinCategory = Default::default();
-        let (x, n) = (ustr("x"), ustr("n"));
+        let (x, n) = (ustr("object"), ustr("negative"));
         sgn.add_ob_generator(x);
         sgn.add_hom_generator(n, x, x);
         sgn.set_composite(n, n, fin_category::Hom::Id(x));
@@ -64,7 +64,7 @@ mod tests {
     #[test]
     fn theories() {
         assert_eq!(th_category().basic_ob_types().count(), 1);
-        assert_eq!(th_profunctor().basic_ob_types().count(), 2);
+        assert_eq!(th_schema().basic_ob_types().count(), 2);
         assert_eq!(th_signed_category().basic_mor_types().count(), 1);
     }
 }

--- a/frontend/catlog-wasm/Cargo.toml
+++ b/frontend/catlog-wasm/Cargo.toml
@@ -11,18 +11,14 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-catlog = { path = "../../catlog" }
-getrandom = { version = "0.2", features = ["js"] }
-wasm-bindgen = "0.2.84"
-
-# The `console_error_panic_hook` crate provides better debugging of panics by
-# logging them with `console.error`. This is great for development, but requires
-# all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
-# code size when deploying.
+catlog = { path = "../../catlog", features = ["serde-wasm"] }
 console_error_panic_hook = { version = "0.1.7", optional = true }
-ustr = "1.0.0"
+getrandom = { version = "0.2", features = ["js"] }
 js-sys = "0.3.69"
-derivative = "2.2.0"
+serde = { version = "1", features = ["derive"] }
+tsify-next = { version = "0.5", features = ["js"] }
+ustr = "1"
+wasm-bindgen = "0.2.92"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.34"

--- a/frontend/catlog-wasm/src/theories.rs
+++ b/frontend/catlog-wasm/src/theories.rs
@@ -2,55 +2,24 @@
 
 use wasm_bindgen::prelude::*;
 
-use ustr::ustr;
-use catlog::one::fin_category::*;
 use catlog::stdlib::theories;
 use super::theory::DiscreteDblTheory;
 
 
-/// The theory of a (functional) olog a la Spivak and Kent.
-#[wasm_bindgen(js_name = thSimpleOlog)]
+/// The theory of categories.
+#[wasm_bindgen(js_name = thCategory)]
 pub fn th_category() -> DiscreteDblTheory {
-    let mut th = DiscreteDblTheory::new(theories::th_category());
-    th.bind_ob_type("type", Ob(ustr("x")));
-    th.bind_mor_type("aspect", Hom::Id(ustr("x")));
-    th
+    DiscreteDblTheory::new(theories::th_category())
 }
 
-/// The theory of a schema (with data attributes).
-#[wasm_bindgen(js_name = thSimpleSchema)]
+/// The theory of database schemas with attributes.
+#[wasm_bindgen(js_name = thSchema)]
 pub fn th_schema() -> DiscreteDblTheory {
-    let mut th = DiscreteDblTheory::new(theories::th_profunctor());
-    th.bind_ob_type("entity", Ob(ustr("x")));
-    th.bind_mor_type("map", Hom::Id(ustr("x")));
-    th.bind_ob_type("attr_type", Ob(ustr("y")));
-    th.bind_mor_type("attr_op", Hom::Id(ustr("y")));
-    th.bind_mor_type("attr", Hom::Generator(ustr("p")));
-    th
+    DiscreteDblTheory::new(theories::th_schema())
 }
 
-/// The theory of a signed category.
+/// The theory of signed categories.
 #[wasm_bindgen(js_name = thSignedCategory)]
 pub fn th_signed_category() -> DiscreteDblTheory {
-    let mut th = DiscreteDblTheory::new(theories::th_signed_category());
-    th.bind_ob_type("object", Ob(ustr("x")));
-    th.bind_mor_type("positive", Hom::Id(ustr("x")));
-    th.bind_mor_type("negative", Hom::Generator(ustr("n")));
-    th
-}
-
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn theories() {
-        th_category();
-        th_signed_category();
-
-        let th = th_schema();
-        assert_eq!(th.src("attr"), "entity");
-        assert_eq!(th.tgt("attr"), "attr_type");
-    }
+    DiscreteDblTheory::new(theories::th_signed_category())
 }

--- a/frontend/catlog-wasm/src/theory.rs
+++ b/frontend/catlog-wasm/src/theory.rs
@@ -18,21 +18,19 @@ type UstrDiscreteDblThy = dbl_theory::DiscreteDblTheory<UstrFinCategory>;
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen]
-    fn tsOb() -> Ob<Ustr>;
-    #[wasm_bindgen]
-    fn tsHom() -> Hom<Ustr, Ustr>;
+    fn tsFinHom() -> FinHom<Ustr, Ustr>;
 }
 
 
 /// Object type in discrete double theory.
 #[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
-pub struct ObType(Ob<Ustr>);
+pub struct ObType(Ustr);
 
 /// Morphism type in discrete double theory.
 #[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
-pub struct MorType(Hom<Ustr, Ustr>);
+pub struct MorType(FinHom<Ustr, Ustr>);
 
 /** Wasm bindings for a discrete double theory.
 

--- a/frontend/catlog-wasm/src/theory.rs
+++ b/frontend/catlog-wasm/src/theory.rs
@@ -14,7 +14,22 @@ use catlog::dbl::theory::{self as dbl_theory, DblTheory};
 type UstrDiscreteDblThy = dbl_theory::DiscreteDblTheory<UstrFinCategory>;
 
 
-// XXX: Why do I need this?
+/** Produce type defs for dependencies supporting `serde` but not `tsify`.
+
+Somewhat amazingly, the type system in TypeScript can express the constraint
+that an array be nonempty, with certain usage caveats:
+
+https://stackoverflow.com/q/56006111
+
+For now, though, we will not attempt to enforce this in the TypeScript layer.
+ */
+#[wasm_bindgen(typescript_custom_section)]
+const TS_APPEND_CONTENT: &'static str = r#"
+export type Ustr = string;
+export type NonEmpty<T> = Array<T>;
+"#;
+
+// XXX: It seems like tsify should find the following on its own.
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen]

--- a/frontend/catlog-wasm/src/theory.rs
+++ b/frontend/catlog-wasm/src/theory.rs
@@ -1,104 +1,92 @@
-//! Wasm bindings for double theories.
+//! Wasm bindings for discrete double theories.
 
 use std::hash::Hash;
 use std::collections::HashMap;
-use derivative::Derivative;
 
+use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
+use tsify_next::Tsify;
 
-use ustr::{Ustr};
+use ustr::Ustr;
 use catlog::one::fin_category::*;
 use catlog::dbl::theory::{self as dbl_theory, DblTheory};
 
-
 type UstrDiscreteDblThy = dbl_theory::DiscreteDblTheory<UstrFinCategory>;
-type ObType = Ob<Ustr>;
-type MorType = Hom<Ustr, Ustr>;
+
+
+// XXX: Why do I need this?
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen]
+    fn tsOb() -> Ob<Ustr>;
+    #[wasm_bindgen]
+    fn tsHom() -> Hom<Ustr, Ustr>;
+}
+
+
+/// Object type in discrete double theory.
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct ObType(Ob<Ustr>);
+
+/// Morphism type in discrete double theory.
+#[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct MorType(Hom<Ustr, Ustr>);
 
 /** Wasm bindings for a discrete double theory.
 
-All object and morphism types (both basic and homs) are assigned string
-identifiers for JavaScript.
- */
+This is a thin wrapper around the theory from `catlog`
+*/
 #[wasm_bindgen]
 pub struct DiscreteDblTheory {
     theory: &'static UstrDiscreteDblThy,
-    ob_types: JsIdMap<ObType>,
-    mor_types: JsIdMap<MorType>,
+    ob_type_index: HashMap<ObType, usize>,
+    mor_type_index: HashMap<MorType, usize>,
 }
 
 #[wasm_bindgen]
 impl DiscreteDblTheory {
     pub(crate) fn new(theory: &'static UstrDiscreteDblThy) -> DiscreteDblTheory {
         DiscreteDblTheory {
-            theory: theory,
-            ob_types: Default::default(), mor_types: Default::default(),
+            theory: theory, ob_type_index: Default::default(),
+            mor_type_index: Default::default(),
         }
     }
 
-    /// Bind an object type with metadata.
-    pub(crate) fn bind_ob_type(&mut self, id: &str, ob_type: ObType) {
-        assert!(self.theory.has_ob_type(&ob_type));
-        self.ob_types.bind(id.to_string(), ob_type);
+    /// Index of an object type, if set.
+    #[wasm_bindgen(js_name = "obTypeIndex")]
+    pub fn ob_type_index(&self, x: &ObType) -> Option<usize> {
+        self.ob_type_index.get(x).copied()
     }
 
-    /// Bind a morphism type with metadata.
-    pub(crate) fn bind_mor_type(&mut self, id: &str, mor_type: MorType) {
-        assert!(self.theory.has_mor_type(&mor_type));
-        self.mor_types.bind(id.to_string(), mor_type);
+    /// Index of a morphism type, if set.
+    #[wasm_bindgen(js_name = "morTypeIndex")]
+    pub fn mor_type_index(&self, m: &MorType) -> Option<usize> {
+        self.mor_type_index.get(m).copied()
     }
 
-    /// Array of object types.
-    #[wasm_bindgen(js_name = obTypes)]
-    pub fn ob_types(&self) -> Vec<String> {
-        self.ob_types.iter_ids().cloned().collect()
+    /// Set the index of an object type.
+    #[wasm_bindgen(js_name = "setObTypeIndex")]
+    pub fn set_ob_type_index(&mut self, x: ObType, i: usize) {
+        self.ob_type_index.insert(x, i);
     }
 
-    /// Array of morphism types.
-    #[wasm_bindgen(js_name = morTypes)]
-    pub fn mor_types(&self) -> Vec<String> {
-        self.mor_types.iter_ids().cloned().collect()
+    /// Set the index of a morphism type.
+    #[wasm_bindgen(js_name = "setMorTypeIndex")]
+    pub fn set_mor_type_index(&mut self, m: MorType, i: usize) {
+        self.mor_type_index.insert(m, i);
     }
 
     /// Source of a morphism type.
     #[wasm_bindgen]
-    pub fn src(&self, id: &str) -> String {
-        let src = self.theory.src(self.mor_types.by_id(id));
-        self.ob_types.id_of(&src).clone()
+    pub fn src(&self, m: MorType) -> ObType {
+        ObType(self.theory.src(&m.0))
     }
 
     /// Target of a morphism type.
     #[wasm_bindgen]
-    pub fn tgt(&self, id: &str) -> String {
-        let tgt = self.theory.tgt(self.mor_types.by_id(id));
-        self.ob_types.id_of(&tgt).clone()
-    }
-}
-
-
-/// Bidirectional mapping with JavaScript-friendly identifiers (strings).
-#[derive(Derivative)]
-#[derivative(Default(bound=""))]
-struct JsIdMap<T> {
-    from_id: HashMap<String, T>,
-    to_id: HashMap<T, String>,
-}
-
-impl<T> JsIdMap<T> where T: Eq+Hash+Clone {
-    fn bind(&mut self, id: String, x: T) {
-        let prev = self.from_id.insert(id.clone(), x.clone());
-        assert!(prev.is_none());
-        let prev = self.to_id.insert(x, id);
-        assert!(prev.is_none());
-    }
-
-    fn get_id_of(&self, x: &T) -> Option<&String> { self.to_id.get(x) }
-    fn get_by_id(&self, id: &str) -> Option<&T> { self.from_id.get(id) }
-
-    fn id_of(&self, t: &T) -> &String { self.get_id_of(t).unwrap() }
-    fn by_id(&self, id: &str) -> &T { self.get_by_id(id).unwrap() }
-
-    fn iter_ids(&self) -> impl Iterator<Item = &String> {
-        self.from_id.keys()
+    pub fn tgt(&self, m: MorType) -> ObType {
+        ObType(self.theory.tgt(&m.0))
     }
 }

--- a/frontend/catlog-wasm/src/theory.rs
+++ b/frontend/catlog-wasm/src/theory.rs
@@ -36,7 +36,9 @@ pub struct MorType(Hom<Ustr, Ustr>);
 
 /** Wasm bindings for a discrete double theory.
 
-This is a thin wrapper around the theory from `catlog`
+Besides being a thin wrapper around the theory from `catlog`, this struct allows
+numerical indices to be set for types in the theory, compensating for the lack
+of hash maps with arbitrary keys in JavaScript.
 */
 #[wasm_bindgen]
 pub struct DiscreteDblTheory {

--- a/frontend/src/model/model_editor.tsx
+++ b/frontend/src/model/model_editor.tsx
@@ -1,5 +1,5 @@
 import { DocHandle } from "@automerge/automerge-repo";
-import { createSignal, Show } from "solid-js";
+import { createMemo, createSignal, Show } from "solid-js";
 import Resizable from "@corvu/resizable";
 
 import { GraphvizSVG } from "../visualization";
@@ -21,10 +21,11 @@ export function ModelEditor(props: {
 }) {
     const [editorRef, setEditorRef] = createSignal<ModelNotebookRef>();
 
-    const modelGraph = () => {
+    // Use memo to avoid unnecesary re-rendering with Graphviz.
+    const modelGraph = createMemo(() => {
         const [model, theory] = [editorRef()?.model(), editorRef()?.theory()];
         return model && theory && modelToGraphviz(model, theory);
-    };
+    });
 
     return <Resizable class="growable-container">
         <Resizable.Panel class="content-panel" collapsible

--- a/frontend/src/model/model_graph.ts
+++ b/frontend/src/model/model_graph.ts
@@ -1,6 +1,6 @@
 import type * as Viz from "@viz-js/viz";
 
-import { MorTypeMeta, TheoryMeta, TypeMeta } from "../theory";
+import { getMorTypeMeta, getObTypeMeta, TheoryMeta, TypeMeta } from "../theory";
 import { isoObjectId, isoMorphismId, ModelNotebook } from "./types";
 
 import styles from "../theory/styles.module.css";
@@ -31,7 +31,7 @@ export function modelToGraphviz(
 
         if (judgment.tag === "object") {
             const { id, name } = judgment;
-            const meta = theory.types.get(judgment.type);
+            const meta = getObTypeMeta(theory, judgment.type);
             nodes.push({
                 name: isoObjectId.unwrap(id),
                 attributes: {
@@ -44,7 +44,7 @@ export function modelToGraphviz(
         } else if (judgment.tag === "morphism") {
             const { id, name, dom, cod } = judgment;
             if (!dom || !cod) { continue; }
-            const meta = theory.types.get(judgment.type) as MorTypeMeta;
+            const meta = getMorTypeMeta(theory, judgment.type);
             edges.push({
                 head: isoObjectId.unwrap(cod),
                 tail: isoObjectId.unwrap(dom),

--- a/frontend/src/model/model_graph.ts
+++ b/frontend/src/model/model_graph.ts
@@ -1,6 +1,6 @@
 import type * as Viz from "@viz-js/viz";
 
-import { getMorTypeMeta, getObTypeMeta, TheoryMeta, TypeMeta } from "../theory";
+import { TheoryMeta, TypeMeta } from "../theory";
 import { isoObjectId, isoMorphismId, ModelNotebook } from "./types";
 
 import styles from "../theory/styles.module.css";
@@ -31,7 +31,7 @@ export function modelToGraphviz(
 
         if (judgment.tag === "object") {
             const { id, name } = judgment;
-            const meta = getObTypeMeta(theory, judgment.type);
+            const meta = theory.getObTypeMeta(judgment.type);
             nodes.push({
                 name: isoObjectId.unwrap(id),
                 attributes: {
@@ -44,7 +44,7 @@ export function modelToGraphviz(
         } else if (judgment.tag === "morphism") {
             const { id, name, dom, cod } = judgment;
             if (!dom || !cod) { continue; }
-            const meta = getMorTypeMeta(theory, judgment.type);
+            const meta = theory.getMorTypeMeta(judgment.type);
             edges.push({
                 head: isoObjectId.unwrap(cod),
                 tail: isoObjectId.unwrap(dom),

--- a/frontend/src/model/model_notebook_editor.tsx
+++ b/frontend/src/model/model_notebook_editor.tsx
@@ -163,8 +163,8 @@ function modelCellConstructors(theory?: TheoryMeta): ModelCellConstructor[] {
             name, description,
             shortcut: shortcut && [modifier, ...shortcut],
             construct: typ.tag === "ob_type" ?
-                () => newFormalCell(newObjectDecl(typ.id)) :
-                () => newFormalCell(newMorphismDecl(typ.id)),
+                () => newFormalCell(newObjectDecl(typ.obType)) :
+                () => newFormalCell(newMorphismDecl(typ.morType)),
         });
     }
 

--- a/frontend/src/model/morphism_cell_editor.tsx
+++ b/frontend/src/model/morphism_cell_editor.tsx
@@ -1,5 +1,6 @@
 import { createEffect, useContext } from "solid-js";
 
+import { getMorTypeMeta } from "../theory";
 import { MorphismDecl } from "./types";
 import { CellActions } from "../notebook";
 import { InlineInput } from "../components";
@@ -8,7 +9,6 @@ import { ObjectIdInput} from "./object_cell_editor";
 
 
 import "./morphism_cell_editor.css";
-import { MorTypeMeta } from "../theory";
 
 
 export function MorphismCellEditor(props: {
@@ -31,8 +31,10 @@ export function MorphismCellEditor(props: {
     const theory = useContext(TheoryContext);
     const objectIndex = useContext(ObjectIndexContext);
 
-    const typeMeta = () =>
-        theory?.()?.types.get(props.morphism.type) as MorTypeMeta | undefined;
+    const typeMeta = () => {
+        const th = theory?.();
+        return th && getMorTypeMeta(th, props.morphism.type);
+    }
     const nameClasses = () =>
         ["morphism-decl-name", ...typeMeta()?.textClasses ?? []];
     const arrowClasses = () => {

--- a/frontend/src/model/morphism_cell_editor.tsx
+++ b/frontend/src/model/morphism_cell_editor.tsx
@@ -1,6 +1,5 @@
 import { createEffect, useContext } from "solid-js";
 
-import { getMorTypeMeta } from "../theory";
 import { MorphismDecl } from "./types";
 import { CellActions } from "../notebook";
 import { InlineInput } from "../components";
@@ -31,10 +30,7 @@ export function MorphismCellEditor(props: {
     const theory = useContext(TheoryContext);
     const objectIndex = useContext(ObjectIndexContext);
 
-    const typeMeta = () => {
-        const th = theory?.();
-        return th && getMorTypeMeta(th, props.morphism.type);
-    }
+    const typeMeta = () => theory?.()?.getMorTypeMeta(props.morphism.type);
     const nameClasses = () =>
         ["morphism-decl-name", ...typeMeta()?.textClasses ?? []];
     const arrowClasses = () => {

--- a/frontend/src/model/object_cell_editor.tsx
+++ b/frontend/src/model/object_cell_editor.tsx
@@ -5,7 +5,7 @@ import { IndexedMap } from "../util/indexing";
 import { ObjectDecl, ObjectId } from "./types";
 import { CellActions } from "../notebook";
 import { InlineInput, InlineInputOptions } from "../components";
-import { getObTypeMeta, TheoryMeta } from "../theory";
+import { TheoryMeta } from "../theory";
 import { TheoryContext } from "./model_context";
 
 import "./object_cell_editor.css";
@@ -97,7 +97,7 @@ export function ObjectIdInput(allProps: {
 
 
 function extraClasses(theory: TheoryMeta | undefined, typ: ObType): string[] {
-    const typeMeta = theory && getObTypeMeta(theory, typ);
+    const typeMeta = theory?.getObTypeMeta(typ);
     return [
         ...typeMeta?.cssClasses ?? [],
         ...typeMeta?.textClasses ?? [],

--- a/frontend/src/model/object_cell_editor.tsx
+++ b/frontend/src/model/object_cell_editor.tsx
@@ -1,10 +1,11 @@
 import { createEffect, createSignal, splitProps, useContext } from "solid-js";
 
+import { ObType } from "catlog-wasm";
 import { IndexedMap } from "../util/indexing";
 import { ObjectDecl, ObjectId } from "./types";
 import { CellActions } from "../notebook";
 import { InlineInput, InlineInputOptions } from "../components";
-import { TheoryMeta } from "../theory";
+import { getObTypeMeta, TheoryMeta } from "../theory";
 import { TheoryContext } from "./model_context";
 
 import "./object_cell_editor.css";
@@ -49,7 +50,7 @@ export function ObjectCellEditor(props: {
 export function ObjectIdInput(allProps: {
     objectId: ObjectId | null;
     setObjectId: (id: ObjectId | null) => void;
-    objectType?: string;
+    objectType?: ObType;
     objectIndex?: IndexedMap<ObjectId,string>;
 } & InlineInputOptions) {
     const [props, inputProps] = splitProps(allProps, [
@@ -95,8 +96,8 @@ export function ObjectIdInput(allProps: {
 }
 
 
-function extraClasses(theory?: TheoryMeta, typ?: string): string[] {
-    const typeMeta = typ ? theory?.types.get(typ) : undefined;
+function extraClasses(theory: TheoryMeta | undefined, typ: ObType): string[] {
+    const typeMeta = theory && getObTypeMeta(theory, typ);
     return [
         ...typeMeta?.cssClasses ?? [],
         ...typeMeta?.textClasses ?? [],

--- a/frontend/src/model/object_cell_editor.tsx
+++ b/frontend/src/model/object_cell_editor.tsx
@@ -96,8 +96,8 @@ export function ObjectIdInput(allProps: {
 }
 
 
-function extraClasses(theory: TheoryMeta | undefined, typ: ObType): string[] {
-    const typeMeta = theory?.getObTypeMeta(typ);
+function extraClasses(theory: TheoryMeta | undefined, typ?: ObType): string[] {
+    const typeMeta = typ ? theory?.getObTypeMeta(typ) : undefined;
     return [
         ...typeMeta?.cssClasses ?? [],
         ...typeMeta?.textClasses ?? [],

--- a/frontend/src/model/types.ts
+++ b/frontend/src/model/types.ts
@@ -1,5 +1,6 @@
 import { Newtype, iso } from "newtype-ts";
 
+import { MorType, ObType } from "catlog-wasm";
 import { generateId } from "../util/id";
 import { TheoryId } from "../theory";
 import { Notebook } from "../notebook";
@@ -39,10 +40,10 @@ export type ObjectDecl = {
     name: string;
 
     // Identifier of object type in double theory.
-    type: string;
+    type: ObType;
 };
 
-export const newObjectDecl = (type: string): ObjectDecl => ({
+export const newObjectDecl = (type: ObType): ObjectDecl => ({
     tag: "object",
     id: isoObjectId.wrap(generateId()),
     name: "",
@@ -66,7 +67,7 @@ export type MorphismDecl = {
     name: string;
 
     // Identifier of morphism type in double theory.
-    type: string;
+    type: MorType;
 
     // Domain of morphism.
     dom: ObjectId | null;
@@ -75,7 +76,7 @@ export type MorphismDecl = {
     cod: ObjectId | null;
 };
 
-export const newMorphismDecl = (type: string): MorphismDecl => ({
+export const newMorphismDecl = (type: MorType): MorphismDecl => ({
     tag: "morphism",
     id: isoMorphismId.wrap(generateId()),
     name: "",

--- a/frontend/src/theory/theories.ts
+++ b/frontend/src/theory/theories.ts
@@ -1,7 +1,7 @@
 import * as catlog from "catlog-wasm";
 
 import { uniqueIndexArray } from "../util/indexing";
-import { createTheoryMeta } from "./types";
+import { TheoryMeta } from "./types";
 
 import styles from "./styles.module.css";
 import svgStyles from "./svg_styles.module.css";
@@ -18,7 +18,7 @@ export const stdTheories = () => uniqueIndexArray([
 ], th => th.id);
 
 
-const thSimpleOlog = () => createTheoryMeta({
+const thSimpleOlog = () => new TheoryMeta({
     id: "simple-olog",
     name: "Olog",
     description: "Ontology log, a simple conceptual model",
@@ -43,7 +43,7 @@ const thSimpleOlog = () => createTheoryMeta({
     ],
 });
 
-const thSimpleSchema = () => createTheoryMeta({
+const thSimpleSchema = () => new TheoryMeta({
     id: "schema",
     name: "Schema",
     description: "Schema for a categorical database",
@@ -92,7 +92,7 @@ const thSimpleSchema = () => createTheoryMeta({
     ],
 });
 
-const thRegNet = () => createTheoryMeta({
+const thRegNet = () => new TheoryMeta({
     id: "reg-net",
     name: "Regulatory network",
     theory: catlog.thSignedCategory,

--- a/frontend/src/theory/theories.ts
+++ b/frontend/src/theory/theories.ts
@@ -22,11 +22,11 @@ const thSimpleOlog = () => createTheoryMeta({
     id: "simple-olog",
     name: "Olog",
     description: "Ontology log, a simple conceptual model",
-    theory: catlog.thSimpleOlog(),
+    theory: catlog.thCategory,
     types: [
         {
             tag: "ob_type",
-            id: "type",
+            obType: "object",
             name: "Type",
             description: "Type or class of things",
             shortcut: ["O"],
@@ -35,7 +35,7 @@ const thSimpleOlog = () => createTheoryMeta({
         },
         {
             tag: "mor_type",
-            id: "aspect",
+            morType: {tag: "Id", content: "object"},
             name: "Aspect",
             description: "Aspect or property of a thing",
             shortcut: ["M"],
@@ -44,14 +44,14 @@ const thSimpleOlog = () => createTheoryMeta({
 });
 
 const thSimpleSchema = () => createTheoryMeta({
-    id: "simple-schema",
+    id: "schema",
     name: "Schema",
     description: "Schema for a categorical database",
-    theory: catlog.thSimpleSchema(),
+    theory: catlog.thSchema,
     types: [
         {
             tag: "ob_type",
-            id: "entity",
+            obType: "entity",
             name: "Entity",
             description: "Type of entity or thing",
             shortcut: ["O"],
@@ -61,7 +61,7 @@ const thSimpleSchema = () => createTheoryMeta({
         },
         {
             tag: "mor_type",
-            id: "map",
+            morType: {tag: "Id", content: "entity"},
             name: "Mapping",
             description: "Many-to-one relation between entities",
             shortcut: ["M"],
@@ -69,7 +69,7 @@ const thSimpleSchema = () => createTheoryMeta({
         },
         {
             tag: "mor_type",
-            id: "attr",
+            morType: {tag: "Generator", content: "attr"},
             name: "Attribute",
             description: "Data attribute of an entity",
             shortcut: ["A"],
@@ -77,14 +77,14 @@ const thSimpleSchema = () => createTheoryMeta({
         },
         {
             tag: "ob_type",
-            id: "attr_type",
+            obType: "attr_type",
             name: "Attribute type",
             description: "Data type for an attribute",
             textClasses: [styles.code],
         },
         {
             tag: "mor_type",
-            id: "attr_op",
+            morType: {tag: "Id", content: "attr_type"},
             name: "Operation",
             description: "Operation on data types for attributes",
             textClasses: [styles.code],
@@ -95,25 +95,25 @@ const thSimpleSchema = () => createTheoryMeta({
 const thRegNet = () => createTheoryMeta({
     id: "reg-net",
     name: "Regulatory network",
-    theory: catlog.thSignedCategory(),
+    theory: catlog.thSignedCategory,
     onlyFree: true,
     types: [
         {
             tag: "ob_type",
-            id: "object",
+            obType: "object",
             name: "Species",
             description: "Biochemical species in the network",
         },
         {
             tag: "mor_type",
-            id: "positive",
+            morType: {tag: "Id", content: "object"},
             name: "Promotion",
             description: "Positive interaction: activates or promotes",
             arrowStyle: "to",
         },
         {
             tag: "mor_type",
-            id: "negative",
+            morType: {tag: "Generator", content: "negative"},
             name: "Inhibition",
             description: "Negative interaction: represses or inhibits",
             arrowStyle: "flat",


### PR DESCRIPTION
We are now using the famous Rust package `serde` in conjunction with `wasm-bindgen`, `serde-wasm-bindgen`, and `tsify`. Being able to easily transfer Rust structs and enums to/from Wasm simplifies the bindings, while providing a path for future developments that will require transferring expressions between the frontend and the code.