### PR TITLE
Wasm bindings for models of discrete double theories

### DIFF
--- a/catlog/src/dbl/model.rs
+++ b/catlog/src/dbl/model.rs
@@ -187,6 +187,39 @@ pub struct DiscreteDblModel<V, E, Cat: FgCategory> {
     mor_types: IndexedHashColumn<E,Cat::Hom>,
 }
 
+impl<V,E,Cat> DiscreteDblModel<V,E,Cat>
+where V: Eq+Clone+Hash, E: Eq+Clone+Hash, Cat: FgCategory,
+      Cat::Ob: Eq+Clone+Hash, Cat::Hom: Eq+Clone+Hash {
+
+    /// Creates an empty model of the given theory.
+    pub fn new(theory: Arc<DiscreteDblTheory<Cat>>) -> Self {
+        Self { theory, category: Default::default(),
+               ob_types: Default::default(), mor_types: Default::default() }
+    }
+
+    /// Adds a basic object to the model.
+    pub fn add_ob(&mut self, x: V, typ: Cat::Ob) {
+        self.category.add_ob_generator(x.clone());
+        self.ob_types.set(x, typ);
+    }
+
+    /// Adds a basic morphism to the model.
+    pub fn add_mor(&mut self, f: E, typ: Cat::Hom) {
+        self.category.make_hom_generator(f.clone());
+        self.mor_types.set(f, typ);
+    }
+
+    /// Updates the domain of a morphism, setting or unsetting it.
+    pub fn update_dom(&mut self, f: E, x: Option<V>) -> Option<V> {
+        self.category.update_dom(f, x)
+    }
+
+    /// Updates the codomain of a morphism, setting or unsetting it.
+    pub fn update_cod(&mut self, f: E, x: Option<V>) -> Option<V> {
+        self.category.update_cod(f, x)
+    }
+}
+
 impl<V,E,Cat> DblModel for DiscreteDblModel<V,E,Cat>
 where V: Eq+Clone+Hash, E: Eq+Clone+Hash, Cat: FgCategory,
       Cat::Ob: Eq+Clone+Hash, Cat::Hom: Eq+Clone+Hash {

--- a/catlog/src/lib.rs
+++ b/catlog/src/lib.rs
@@ -19,7 +19,10 @@ sufficiently useful in their own right, they may be spun off into their own
 packages.
 */
 
-#![allow(mixed_script_confusables)] // Unicode identifiers.
+// Unicode identifiers.
+#![allow(mixed_script_confusables)]
+#![allow(confusable_idents)]
+
 #![warn(missing_docs)]
 
 pub mod validate;

--- a/catlog/src/lib.rs
+++ b/catlog/src/lib.rs
@@ -2,12 +2,12 @@
 
 # Organization
 
-While the purpose of this package is to implement double theories and models,
-having a certain amount of lower-dimensional category theory is inevitably
-useful as a foundation. For instance, the starting point for a double graph or a
-[double computad](crate::dbl::computad) is a pair of graphs that share a set of
-vertices. The package is organized into top-level modules according to
-dimensionality:
+While the purpose of this package is to implement double theories and their
+models and morphisms, having a certain amount of lower-dimensional category
+theory is inevitably useful as a foundation. For instance, the starting point
+for a double graph or a [double computad](crate::dbl::computad) is a pair of
+graphs that share a set of vertices. The package is organized into top-level
+modules according to dimensionality:
 
 0. [`zero`]: Sets and mappings, known semi-seriously as zero-dimensional
    category theory.

--- a/catlog/src/one/category.rs
+++ b/catlog/src/one/category.rs
@@ -194,13 +194,13 @@ impl<G: FinGraph> FgCategory for FreeCategory<G> where G::V: Eq+Clone {
         self.0.vertices()
     }
     fn hom_generators(&self) -> impl Iterator<Item = Self::Hom> {
-        self.0.edges().map(|e| Path::single(e))
+        self.0.edges().map(Path::single)
     }
     fn generators_with_dom(&self, x: &G::V) -> impl Iterator<Item = Self::Hom> {
-        self.0.out_edges(x).map(|e| Path::single(e))
+        self.0.out_edges(x).map(Path::single)
     }
     fn generators_with_cod(&self, x: &G::V) -> impl Iterator<Item = Self::Hom> {
-        self.0.in_edges(x).map(|e| Path::single(e))
+        self.0.in_edges(x).map(Path::single)
     }
 }
 

--- a/catlog/src/one/fin_category.rs
+++ b/catlog/src/one/fin_category.rs
@@ -193,6 +193,16 @@ where V: Eq+Clone+Hash, E: Eq+Clone+Hash {
         self.generators.make_edge(e)
     }
 
+    /// Updates the domain of a morphism generator, setting or unsetting it.
+    pub fn update_dom(&mut self, e: E, v: Option<V>) -> Option<V> {
+        self.generators.update_src(e, v)
+    }
+
+    /// Updates the codomain of a morphism generator, setting or unsetting it.
+    pub fn update_cod(&mut self, e: E, v: Option<V>) -> Option<V> {
+        self.generators.update_tgt(e, v)
+    }
+
     /// Iterates over path equations in the presentation.
     pub fn equations(&self) -> impl Iterator<Item = &PathEq<V,E>> {
         self.equations.iter()

--- a/catlog/src/one/fin_category.rs
+++ b/catlog/src/one/fin_category.rs
@@ -250,13 +250,13 @@ where V: Eq+Clone+Hash, E: Eq+Clone+Hash {
         self.generators.vertices()
     }
     fn hom_generators(&self) -> impl Iterator<Item = Self::Hom> {
-        self.generators.edges().map(|e| Path::single(e))
+        self.generators.edges().map(Path::single)
     }
     fn generators_with_dom(&self, x: &V) -> impl Iterator<Item = Self::Hom> {
-        self.generators.out_edges(x).map(|e| Path::single(e))
+        self.generators.out_edges(x).map(Path::single)
     }
     fn generators_with_cod(&self, x: &V) -> impl Iterator<Item = Self::Hom> {
-        self.generators.in_edges(x).map(|e| Path::single(e))
+        self.generators.in_edges(x).map(Path::single)
     }
 }
 

--- a/catlog/src/one/fin_category.rs
+++ b/catlog/src/one/fin_category.rs
@@ -161,7 +161,6 @@ equations. A morphism in the presented category is an equivalence class of paths
 in the graph, so strictly speaking we work with representatives rather than
 morphism themselves.
 
-TODO: Add hom generator with optional (co)domain.
 TODO: Validate generators and path equations.
  */
 #[derive(Clone,Derivative)]
@@ -187,6 +186,11 @@ where V: Eq+Clone+Hash, E: Eq+Clone+Hash {
     /// Adds a morphism generator, returning whether it is new.
     pub fn add_hom_generator(&mut self, e: E, dom: V, cod: V) -> bool {
         self.generators.add_edge(e, dom, cod)
+    }
+
+    /// Adds a morphism generator without initializing its (co)domain.
+    pub fn make_hom_generator(&mut self, e: E) -> bool {
+        self.generators.make_edge(e)
     }
 
     /// Iterates over path equations in the presentation.

--- a/catlog/src/one/graph.rs
+++ b/catlog/src/one/graph.rs
@@ -235,10 +235,16 @@ impl SkelGraph {
 
     /// Adds a new edge to the graph and returns it.
     pub fn add_edge(&mut self, src: usize, tgt: usize) -> usize {
-        let e = self.ne;
-        self.ne += 1;
+        let e = self.make_edge();
         self.src_map.set(e, src);
         self.tgt_map.set(e, tgt);
+        e
+    }
+
+    /// Adds a new edge without initializing its source or target.
+    pub fn make_edge(&mut self) -> usize {
+        let e = self.ne;
+        self.ne += 1;
         e
     }
 
@@ -320,6 +326,11 @@ where V: Eq+Hash+Clone, E: Eq+Hash+Clone, S: BuildHasher {
     pub fn add_edge(&mut self, e: E, src: V, tgt: V) -> bool {
         self.src_map.set(e.clone(), src);
         self.tgt_map.set(e.clone(), tgt);
+        self.make_edge(e)
+    }
+
+    /// Adds an edge without initializing its source or target.
+    pub fn make_edge(&mut self, e: E) -> bool {
         self.edge_set.insert(e)
     }
 }

--- a/catlog/src/one/graph.rs
+++ b/catlog/src/one/graph.rs
@@ -1,4 +1,10 @@
-//! Graphs, finite and infinite.
+/*! Graphs, finite and infinite.
+
+Graphs are the fundamental combinatorial structure in category theory and a
+basic building block for higher dimensional categories. We thus aim to provide a
+flexible set of traits and structs for graphs as they are used in category
+theory.
+ */
 
 use std::hash::{Hash, BuildHasher, BuildHasherDefault, RandomState};
 
@@ -80,7 +86,8 @@ pub trait FinGraph: Graph {
 Such a graph is defined in the styles of "C-sets" by two [finite sets](FinSet)
 and two [columns](Column). Note that this trait does *not* extend [`Graph`]. To
 derive an implementation, implement the further trait
-[`ColumnarGraphImplGraph`].
+[`ColumnarGraphImplGraph`]. It also does not assume that the graph is mutable;
+for that, implement the trait [`ColumnarGraphMut`].
  */
 pub trait ColumnarGraph {
     /// Type of vertices in the columnar graph.
@@ -121,6 +128,38 @@ pub trait ColumnarGraph {
         let tgts = Function(self.tgt_map(), dom, cod).iter_invalid().map(
             |e| InvalidGraphData::Tgt(e.take()));
         srcs.chain(tgts)
+    }
+}
+
+/** Columnar graph with mutable columns.
+ */
+pub trait ColumnarGraphMut: ColumnarGraph {
+    /// Variant of [`src_map`](ColumnarGraph::src_map) that returns a mutable
+    /// reference.
+    fn src_map_mut(&mut self) -> &mut impl Column<Dom = Self::E, Cod = Self::V>;
+
+    /// Variant of [`tgt_map`](ColumnarGraph::tgt_map) that returns a mutable
+    /// reference.
+    fn tgt_map_mut(&mut self) -> &mut impl Column<Dom = Self::E, Cod = Self::V>;
+
+    /// Sets the source of an edge.
+    fn set_src(&mut self, e: Self::E, v: Self::V) -> Option<Self::V> {
+        self.src_map_mut().set(e, v)
+    }
+
+    /// Sets the target of an edge.
+    fn set_tgt(&mut self, e: Self::E, v: Self::V) -> Option<Self::V> {
+        self.tgt_map_mut().set(e, v)
+    }
+
+    /// Updates the source of an edge, setting or unsetting it.
+    fn update_src(&mut self, e: Self::E, v: Option<Self::V>) -> Option<Self::V> {
+        self.src_map_mut().update(e, v)
+    }
+
+    /// Updates the source of an edge, setting or unsetting it.
+    fn update_tgt(&mut self, e: Self::E, v: Option<Self::V>) -> Option<Self::V> {
+        self.tgt_map_mut().update(e, v)
     }
 }
 
@@ -212,10 +251,20 @@ impl ColumnarGraph for SkelGraph {
     fn src_map(&self) -> &impl Column<Dom = usize, Cod = usize> {
         &self.src_map
     }
-    fn tgt_map(&self) -> &impl Column<Dom = usize, Cod =usize > {
+    fn tgt_map(&self) -> &impl Column<Dom = usize, Cod = usize > {
         &self.tgt_map
     }
 }
+
+impl ColumnarGraphMut for SkelGraph {
+    fn src_map_mut(&mut self) -> &mut impl Column<Dom = usize, Cod = usize> {
+        &mut self.src_map
+    }
+    fn tgt_map_mut(&mut self) -> &mut impl Column<Dom = usize, Cod = usize> {
+        &mut self.tgt_map
+    }
+}
+
 impl ColumnarGraphImplGraph for SkelGraph {}
 
 impl SkelGraph {
@@ -304,6 +353,17 @@ where V: Eq+Hash+Clone, E: Eq+Hash+Clone, S: BuildHasher {
     fn src_map(&self) -> &impl Column<Dom = E, Cod = V> { &self.src_map }
     fn tgt_map(&self) -> &impl Column<Dom = E, Cod = V> { &self.tgt_map }
 }
+
+impl<V,E,S> ColumnarGraphMut for HashGraph<V,E,S>
+where V: Eq+Hash+Clone, E: Eq+Hash+Clone, S: BuildHasher {
+    fn src_map_mut(&mut self) -> &mut impl Column<Dom = E, Cod = V> {
+        &mut self.src_map
+    }
+    fn tgt_map_mut(&mut self) -> &mut impl Column<Dom = E, Cod = V> {
+        &mut self.tgt_map
+    }
+}
+
 impl<V,E,S> ColumnarGraphImplGraph for HashGraph<V,E,S>
 where V: Eq+Hash+Clone, E: Eq+Hash+Clone, S: BuildHasher {}
 
@@ -469,7 +529,7 @@ pub struct ColumnarGraphMapping<ColV,ColE> {
 impl<ColV,ColE> ColumnarGraphMapping<ColV,ColE> {
     /// Constructs a new graph mapping from existing columns.
     pub fn new(vertex_map: ColV, edge_map: ColE) -> Self {
-        Self { vertex_map: vertex_map, edge_map: edge_map }
+        Self { vertex_map, edge_map }
     }
 }
 
@@ -510,7 +570,9 @@ mod tests {
         g.add_vertices(['y', 'z'].into_iter());
         assert!(g.add_edge("f", 'x', 'y'));
         assert!(g.add_edge("g", 'y', 'z'));
-        assert!(g.add_edge("fg", 'x', 'z'));
+        assert!(g.make_edge("fg"));
+        g.set_src(&"fg", 'x');
+        g.set_tgt(&"fg", 'z');
         assert_eq!(g.src(&"fg"), 'x');
         assert_eq!(g.tgt(&"fg"), 'z');
     }

--- a/catlog/src/stdlib/theories.rs
+++ b/catlog/src/stdlib/theories.rs
@@ -1,6 +1,5 @@
 //! Standard library of double theories.
 
-use std::sync::OnceLock;
 use ustr::ustr;
 
 use crate::one::fin_category::*;
@@ -13,48 +12,36 @@ type UstrDiscreteDblThy = DiscreteDblTheory<UstrFinCategory>;
 
 As a double category, this is the terminal double category.
  */
-pub fn th_category() -> &'static UstrDiscreteDblThy {
-    static TH_CATEGORY: OnceLock<UstrDiscreteDblThy> = OnceLock::new();
-
-    TH_CATEGORY.get_or_init(|| {
-        let mut cat: UstrFinCategory = Default::default();
-        cat.add_ob_generator(ustr("object"));
-        DiscreteDblTheory::from(cat)
-    })
+pub fn th_category() -> UstrDiscreteDblThy {
+    let mut cat: UstrFinCategory = Default::default();
+    cat.add_ob_generator(ustr("object"));
+    DiscreteDblTheory::from(cat)
 }
 
 /** The theory of database schemas with attributes.
 
 As a double category, this is the "walking proarrow".
  */
-pub fn th_schema() -> &'static UstrDiscreteDblThy {
-    static TH_SCHEMA: OnceLock<UstrDiscreteDblThy> = OnceLock::new();
-
-    TH_SCHEMA.get_or_init(|| {
-        let mut cat: UstrFinCategory = Default::default();
-        let (x, y, p) = (ustr("entity"), ustr("attr_type"), ustr("attr"));
-        cat.add_ob_generator(x);
-        cat.add_ob_generator(y);
-        cat.add_hom_generator(p, x, y);
-        DiscreteDblTheory::from(cat)
-    })
+pub fn th_schema() -> UstrDiscreteDblThy {
+    let mut cat: UstrFinCategory = Default::default();
+    let (x, y, p) = (ustr("entity"), ustr("attr_type"), ustr("attr"));
+    cat.add_ob_generator(x);
+    cat.add_ob_generator(y);
+    cat.add_hom_generator(p, x, y);
+    DiscreteDblTheory::from(cat)
 }
 
 /** The theory of signed categories.
 
 A signed category is a category sliced over the group of signs.
  */
-pub fn th_signed_category() -> &'static UstrDiscreteDblThy {
-    static TH_SIGNED_CATEGORY: OnceLock<UstrDiscreteDblThy> = OnceLock::new();
-
-    TH_SIGNED_CATEGORY.get_or_init(|| {
-        let mut sgn: UstrFinCategory = Default::default();
-        let (x, n) = (ustr("object"), ustr("negative"));
-        sgn.add_ob_generator(x);
-        sgn.add_hom_generator(n, x, x);
-        sgn.set_composite(n, n, FinHom::Id(x));
-        DiscreteDblTheory::from(sgn)
-    })
+pub fn th_signed_category() -> UstrDiscreteDblThy {
+    let mut sgn: UstrFinCategory = Default::default();
+    let (x, n) = (ustr("object"), ustr("negative"));
+    sgn.add_ob_generator(x);
+    sgn.add_hom_generator(n, x, x);
+    sgn.set_composite(n, n, FinHom::Id(x));
+    DiscreteDblTheory::from(sgn)
 }
 
 #[cfg(test)]

--- a/catlog/src/zero/column.rs
+++ b/catlog/src/zero/column.rs
@@ -45,7 +45,21 @@ pub trait Mapping {
     */
     fn unset(&mut self, x: &Self::Dom) -> Option<Self::Cod>;
 
-    /// Is the mapping defined at a value?
+    /** Updates the mapping at a point, setting or unsetting it.
+
+    The old value is returned, if one was set.
+     */
+    fn update(
+        &mut self, x: Self::Dom,
+        maybe_y: Option<Self::Cod>
+    ) -> Option<Self::Cod> {
+        match maybe_y {
+            Some(y) => self.set(x, y),
+            None => self.unset(&x),
+        }
+    }
+
+    /// Is the mapping defined at a point?
     fn is_set(&self, x: &Self::Dom) -> bool {
         self.apply(x).is_some()
     }
@@ -171,7 +185,7 @@ impl<T: Eq> Mapping for VecColumn<T> {
     }
 
     fn is_set(&self, i: &usize) -> bool {
-        return *i < self.0.len();
+        return *i < self.0.len() && self.0[*i].is_some()
     }
 }
 
@@ -471,8 +485,9 @@ mod tests {
         let mut col = VecColumn::new(vec!["foo", "bar", "baz"]);
         assert!(col.is_set(&2));
         assert_eq!(col.apply(&2), Some(&"baz"));
-        assert!(!col.is_set(&3));
         assert_eq!(col.apply(&3), None);
+        assert_eq!(col.update(2, None), Some("baz"));
+        assert!(!col.is_set(&2));
 
         col.set(4, "baz");
         col.set(3, "bar");

--- a/frontend/catlog-wasm/Cargo.toml
+++ b/frontend/catlog-wasm/Cargo.toml
@@ -18,6 +18,7 @@ js-sys = "0.3.69"
 serde = { version = "1", features = ["derive"] }
 tsify-next = { version = "0.5", features = ["js"] }
 ustr = "1"
+uuid = { version = "1.10", features = ["v7", "serde", "js"] }
 wasm-bindgen = "0.2.92"
 
 [dev-dependencies]

--- a/frontend/catlog-wasm/src/lib.rs
+++ b/frontend/catlog-wasm/src/lib.rs
@@ -1,5 +1,26 @@
 pub mod theory;
 pub mod theories;
+pub mod model;
+
+use wasm_bindgen::prelude::*;
+
+
+/** Produce type defs for dependencies supporting `serde` but not `tsify`.
+
+Somewhat amazingly, the type system in TypeScript can express the constraint
+that an array be nonempty, with certain usage caveats:
+
+https://stackoverflow.com/q/56006111
+
+For now, though, we will not attempt to enforce this in the TypeScript layer.
+ */
+#[wasm_bindgen(typescript_custom_section)]
+const TS_APPEND_CONTENT: &'static str = r#"
+export type Uuid = string;
+export type Ustr = string;
+
+export type NonEmpty<T> = Array<T>;
+"#;
 
 
 pub fn set_panic_hook() {

--- a/frontend/catlog-wasm/src/model.rs
+++ b/frontend/catlog-wasm/src/model.rs
@@ -1,0 +1,48 @@
+//! Wasm bindings for models of double theories.
+
+use uuid::Uuid;
+
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+use tsify_next::{declare, Tsify};
+
+use super::theory::{ObType, MorType};
+
+
+/// Identifier of object in model of double theory.
+#[declare]
+pub type ObId = Uuid;
+
+/// Identifier of morphism in model of double theory.
+#[declare]
+pub type MorId = Uuid;
+
+/// Declaration of object in model of double theory.
+#[derive(Eq, PartialEq, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi, missing_as_null)]
+pub struct ObDecl {
+    /// Globally unique identifier of object.
+    pub id: ObId,
+
+    /// Object type in double theory.
+    #[serde(rename="obType")]
+    pub ob_type: ObType,
+}
+
+/// Declaration of morphism in model of double theory.
+#[derive(Eq, PartialEq, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi, missing_as_null)]
+pub struct MorDecl {
+    /// Globally unique identifier of morphism.
+    pub id: MorId,
+
+    /// Morphism type in double theory.
+    #[serde(rename="morType")]
+    pub mor_type: MorType,
+
+    /// Domain of morphism, if defined.
+    pub dom: Option<ObId>,
+
+    /// Codomain of morphism, if defined.
+    pub cod: Option<ObId>,
+}

--- a/frontend/catlog-wasm/src/model.rs
+++ b/frontend/catlog-wasm/src/model.rs
@@ -6,7 +6,9 @@ use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 use tsify_next::{declare, Tsify};
 
-use super::theory::{ObType, MorType};
+use catlog::one::fin_category::UstrFinCategory;
+use catlog::dbl::model::{self as dbl_model};
+use super::theory::*;
 
 
 /// Identifier of object in model of double theory.
@@ -18,7 +20,7 @@ pub type ObId = Uuid;
 pub type MorId = Uuid;
 
 /// Declaration of object in model of double theory.
-#[derive(Eq, PartialEq, Serialize, Deserialize, Tsify)]
+#[derive(Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi, missing_as_null)]
 pub struct ObDecl {
     /// Globally unique identifier of object.
@@ -30,7 +32,7 @@ pub struct ObDecl {
 }
 
 /// Declaration of morphism in model of double theory.
-#[derive(Eq, PartialEq, Serialize, Deserialize, Tsify)]
+#[derive(Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi, missing_as_null)]
 pub struct MorDecl {
     /// Globally unique identifier of morphism.
@@ -45,4 +47,66 @@ pub struct MorDecl {
 
     /// Codomain of morphism, if defined.
     pub cod: Option<ObId>,
+}
+
+
+type UuidDiscreteDblModel = dbl_model::DiscreteDblModel<Uuid, Uuid, UstrFinCategory>;
+
+/// Wasm bindings for a model of a discrete double theory.
+#[wasm_bindgen]
+pub struct DiscreteDblModel(UuidDiscreteDblModel);
+
+#[wasm_bindgen]
+impl DiscreteDblModel {
+    /// Creates an empty model of the given theory.
+    #[wasm_bindgen(constructor)]
+    pub fn new(theory: &DiscreteDblTheory) -> Self {
+        Self { 0: UuidDiscreteDblModel::new(theory.theory.clone()) }
+    }
+
+    /// Adds an object to the model.
+    #[wasm_bindgen(js_name = "addOb")]
+    pub fn add_ob(&mut self, decl: ObDecl) {
+        self.0.add_ob(decl.id, decl.ob_type.0);
+    }
+
+    /// Adds a morphism to the model.
+    #[wasm_bindgen(js_name = "addMor")]
+    pub fn add_mor(&mut self, decl: MorDecl) {
+        self.0.add_mor(decl.id, decl.mor_type.0);
+        self.0.update_dom(decl.id, decl.dom);
+        self.0.update_cod(decl.id, decl.cod);
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use catlog::one::fin_category::FinHom;
+    use catlog::dbl::model::DblModel;
+    use crate::theories::*;
+    use super::*;
+
+    #[test]
+    fn model_schema() {
+        let mut model = DiscreteDblModel::new(&th_schema());
+        let x = Uuid::now_v7();
+        let y = Uuid::now_v7();
+        model.add_ob(ObDecl{
+            id: x,
+            ob_type: ObType("entity".into()),
+        });
+        model.add_ob(ObDecl{
+            id: y,
+            ob_type: ObType("attr_type".into()),
+        });
+        model.add_mor(MorDecl{
+            id: Uuid::now_v7(),
+            mor_type: MorType(FinHom::Generator("attr".into())),
+            dom: Some(x),
+            cod: Some(y),
+        });
+        assert_eq!(model.0.objects().count(), 2);
+        assert_eq!(model.0.morphisms().count(), 1);
+    }
 }

--- a/frontend/catlog-wasm/src/theories.rs
+++ b/frontend/catlog-wasm/src/theories.rs
@@ -1,5 +1,6 @@
 //! Wasm bindings for double theories from the standard library.
 
+use std::sync::Arc;
 use wasm_bindgen::prelude::*;
 
 use catlog::stdlib::theories;
@@ -9,17 +10,17 @@ use super::theory::DiscreteDblTheory;
 /// The theory of categories.
 #[wasm_bindgen(js_name = thCategory)]
 pub fn th_category() -> DiscreteDblTheory {
-    DiscreteDblTheory::new(theories::th_category())
+    DiscreteDblTheory::new(Arc::new(theories::th_category()))
 }
 
 /// The theory of database schemas with attributes.
 #[wasm_bindgen(js_name = thSchema)]
 pub fn th_schema() -> DiscreteDblTheory {
-    DiscreteDblTheory::new(theories::th_schema())
+    DiscreteDblTheory::new(Arc::new(theories::th_schema()))
 }
 
 /// The theory of signed categories.
 #[wasm_bindgen(js_name = thSignedCategory)]
 pub fn th_signed_category() -> DiscreteDblTheory {
-    DiscreteDblTheory::new(theories::th_signed_category())
+    DiscreteDblTheory::new(Arc::new(theories::th_signed_category()))
 }

--- a/frontend/catlog-wasm/src/theory.rs
+++ b/frontend/catlog-wasm/src/theory.rs
@@ -2,6 +2,7 @@
 
 use std::hash::Hash;
 use std::collections::HashMap;
+use std::sync::Arc;
 use ustr::Ustr;
 
 use serde::{Deserialize, Serialize};
@@ -40,14 +41,14 @@ of hash maps with arbitrary keys in JavaScript.
 */
 #[wasm_bindgen]
 pub struct DiscreteDblTheory {
-    theory: &'static UstrDiscreteDblThy,
+    pub(crate) theory: Arc<UstrDiscreteDblThy>,
     ob_type_index: HashMap<ObType, usize>,
     mor_type_index: HashMap<MorType, usize>,
 }
 
 #[wasm_bindgen]
 impl DiscreteDblTheory {
-    pub(crate) fn new(theory: &'static UstrDiscreteDblThy) -> DiscreteDblTheory {
+    pub(crate) fn new(theory: Arc<UstrDiscreteDblThy>) -> DiscreteDblTheory {
         DiscreteDblTheory {
             theory: theory, ob_type_index: Default::default(),
             mor_type_index: Default::default(),

--- a/frontend/catlog-wasm/src/theory.rs
+++ b/frontend/catlog-wasm/src/theory.rs
@@ -1,33 +1,18 @@
-//! Wasm bindings for discrete double theories.
+//! Wasm bindings for double theories.
 
 use std::hash::Hash;
 use std::collections::HashMap;
+use ustr::Ustr;
 
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 use tsify_next::Tsify;
 
-use ustr::Ustr;
 use catlog::one::fin_category::*;
 use catlog::dbl::theory::{self as dbl_theory, DblTheory};
 
 type UstrDiscreteDblThy = dbl_theory::DiscreteDblTheory<UstrFinCategory>;
 
-
-/** Produce type defs for dependencies supporting `serde` but not `tsify`.
-
-Somewhat amazingly, the type system in TypeScript can express the constraint
-that an array be nonempty, with certain usage caveats:
-
-https://stackoverflow.com/q/56006111
-
-For now, though, we will not attempt to enforce this in the TypeScript layer.
- */
-#[wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = r#"
-export type Ustr = string;
-export type NonEmpty<T> = Array<T>;
-"#;
 
 // XXX: It seems like tsify should find the following on its own.
 #[wasm_bindgen]
@@ -40,12 +25,12 @@ extern "C" {
 /// Object type in discrete double theory.
 #[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
-pub struct ObType(Ustr);
+pub struct ObType(pub Ustr);
 
 /// Morphism type in discrete double theory.
 #[derive(Eq, Hash, PartialEq, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
-pub struct MorType(FinHom<Ustr, Ustr>);
+pub struct MorType(pub FinHom<Ustr, Ustr>);
 
 /** Wasm bindings for a discrete double theory.
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -70,21 +70,21 @@
       }
     },
     "node_modules/@automerge/automerge": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@automerge/automerge/-/automerge-2.2.4.tgz",
-      "integrity": "sha512-Crdv8m1vKCjNyv99TkeQes6MkFHLSEQSCvIEbiYRLiVs//xULHekTu2rypu01fN0Y4N/yrR1JoPozEffUqXqlw==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@automerge/automerge/-/automerge-2.2.5.tgz",
+      "integrity": "sha512-ckew+wwjSJwjRwMnf8vqzhThykp0gyUNqKv2b7dLoLb0mfQyPEFaemrsUiHh9WdX73jrH5eXsqqPJK4/yqpviQ==",
       "license": "MIT",
       "dependencies": {
         "uuid": "^9.0.0"
       }
     },
     "node_modules/@automerge/automerge-repo": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@automerge/automerge-repo/-/automerge-repo-1.2.0.tgz",
-      "integrity": "sha512-43MTly+CB1lh+Q/iASRLICkPta2INlvTCk9RssNJ9ECNlxL15xq6HVWPPkMKhgfN0yIT8mQXQFuhcBntaYpJ7w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@automerge/automerge-repo/-/automerge-repo-1.2.1.tgz",
+      "integrity": "sha512-uEBr4bM01aSWkEt2tDKQxfW0Pahz2zbTTn4sRJfeKJlAg2SLr4QepFJ+3Tp4CNEkkU485olfnKYf6gt7uilMZQ==",
       "license": "MIT",
       "dependencies": {
-        "@automerge/automerge": "2.2.3",
+        "@automerge/automerge": "^2.2.5",
         "bs58check": "^3.0.1",
         "cbor-x": "^1.3.0",
         "debug": "^4.3.4",
@@ -97,12 +97,12 @@
       }
     },
     "node_modules/@automerge/automerge-repo-network-websocket": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@automerge/automerge-repo-network-websocket/-/automerge-repo-network-websocket-1.2.0.tgz",
-      "integrity": "sha512-sNsaN7qyZxpyp2wrYt44WsxmSPgShRXmauWN5b+WwaDt8iIZhkGNPJxmbUSveOIKtnSGjpXtZI7ReWMUooDeRQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@automerge/automerge-repo-network-websocket/-/automerge-repo-network-websocket-1.2.1.tgz",
+      "integrity": "sha512-n4sI6l51iBf0edWtX+vhk+sc8wJL72IVZl682SvzRHakA5CzyNZiC8sVzc142zRT3RDN12jCWGpwA2Voq6EXsQ==",
       "license": "MIT",
       "dependencies": {
-        "@automerge/automerge-repo": "1.2.0",
+        "@automerge/automerge-repo": "1.2.1",
         "cbor-x": "^1.3.0",
         "debug": "^4.3.4",
         "eventemitter3": "^5.0.1",
@@ -111,21 +111,12 @@
       }
     },
     "node_modules/@automerge/automerge-repo-storage-indexeddb": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@automerge/automerge-repo-storage-indexeddb/-/automerge-repo-storage-indexeddb-1.2.0.tgz",
-      "integrity": "sha512-PYuteT89HRXDVgLEmpXBmx9dpaRDbaeLP+Tyvd+HErHZ6yfEH+uhREDfEgeXrWWADExF491K2LWF/PT+lLYdSw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@automerge/automerge-repo-storage-indexeddb/-/automerge-repo-storage-indexeddb-1.2.1.tgz",
+      "integrity": "sha512-u+9eZZJK7DAr541buF4ut1ipkuiKRoaAtoFYo/ilq7zOLO7JX+GQOFx/8eKKRDlGt/AHTcDaFktkcaX0vKahQQ==",
       "license": "MIT",
       "dependencies": {
-        "@automerge/automerge-repo": "1.2.0"
-      }
-    },
-    "node_modules/@automerge/automerge-repo/node_modules/@automerge/automerge": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@automerge/automerge/-/automerge-2.2.3.tgz",
-      "integrity": "sha512-CAyTKNpqhscqaylFxJJLq2RgrHyep6BYY8szQNt3EsWDfwkxaaz5kjsb2iiMjo/dS5tswbMxP3Omdk//9He13Q==",
-      "license": "MIT",
-      "dependencies": {
-        "uuid": "^9.0.0"
+        "@automerge/automerge-repo": "1.2.1"
       }
     },
     "node_modules/@automerge/automerge-wasm": {
@@ -216,9 +207,9 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.24.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.9.tgz",
-      "integrity": "sha512-G8v3jRg+z8IwY1jHFxvCNhOPYPterE4XljNgdGTYfSTtzzwjIswIzIaSPSLs3R7yFuqnqNeay5rjICfqVr+/6A==",
+      "version": "7.24.10",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.10.tgz",
+      "integrity": "sha512-o9HBZL1G2129luEUlG1hB4N/nlYNWHnpwlND9eOMclRqqu1YDy2sSYVCFUZwl8I1Gxh+QSRrP2vD7EpUmFVXxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -619,12 +610,24 @@
       }
     },
     "node_modules/@corvu/resizable": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@corvu/resizable/-/resizable-0.2.2.tgz",
-      "integrity": "sha512-VQ8PRCGP48oVgkvCyfGMwtH5g9CBxhTIEoJ9aGw2yf2P1bpGuE8CH3i6guhWrxVnZl5Fv8F/CWHIznd6h9Nb9g==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@corvu/resizable/-/resizable-0.2.3.tgz",
+      "integrity": "sha512-UwpObxqKlx1mc3G496Daz9NjK25Gx1V5fB8zIGazbq5tJs7aU8RjPW4png5OoNpMyxV7GQWjQtVc59zaAEVAJg==",
       "license": "MIT",
       "dependencies": {
-        "@corvu/utils": "~0.3.1"
+        "@corvu/utils": "~0.4.0"
+      },
+      "peerDependencies": {
+        "solid-js": "^1.8"
+      }
+    },
+    "node_modules/@corvu/resizable/node_modules/@corvu/utils": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@corvu/utils/-/utils-0.4.0.tgz",
+      "integrity": "sha512-LTjH/gSf4t/slzGoQdFYWrAykHp3A7JZYH+KjM5KCppVjDEY7pLjZkMTHU/vPF7gvjiXDYgA+6q68eiHRiJ8wA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.7"
       },
       "peerDependencies": {
         "solid-js": "^1.8"
@@ -1046,28 +1049,28 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.4.tgz",
-      "integrity": "sha512-a4IowK4QkXl4SCWTGUR0INAfEOX3wtsYw3rKK5InQEHMGObkR8Xk44qYQD9P4r6HHw0iIfK6GUKECmY8sTkqRA==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.5.tgz",
+      "integrity": "sha512-8GrTWmoFhm5BsMZOTHeGD2/0FLKLQQHvO/ZmQga4tKempYRLz8aqJGqXVuQgisnMObq2YZ2SgkwctN1LOOxcqA==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.4"
+        "@floating-ui/utils": "^0.2.5"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.7.tgz",
-      "integrity": "sha512-wmVfPG5o2xnKDU4jx/m4w5qva9FWHcnZ8BvzEe90D/RpwsJaTAVYPEPdQ8sbr/N8zZTAHlZUTQdqg8ZUbzHmng==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.8.tgz",
+      "integrity": "sha512-kx62rP19VZ767Q653wsP1XZCGIirkE09E0QUGNYTM/ttbbQHqcGPdSfWFxUyyNLc/W6aoJRBajOSXhP6GXjC0Q==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.4"
+        "@floating-ui/utils": "^0.2.5"
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.4.tgz",
-      "integrity": "sha512-dWO2pw8hhi+WrXq1YJy2yCuWoL20PddgGaqTgVe4cOS9Q6qklXCiA1tJEqX6BEwRNSCP84/afac9hd4MS+zEUA==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.5.tgz",
+      "integrity": "sha512-sTcG+QZ6fdEUObICavU+aB3Mp8HY4n14wYHdxK4fXjPmv3PXZZeY5RaguJmGyeH/CJQhX3fqKUtS4qc1LoHwhQ==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1162,9 +1165,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.18.1.tgz",
-      "integrity": "sha512-lncuC4aHicncmbORnx+dUaAgzee9cm/PbIqgWz1PpXuwc+sa1Ct83tnqUDy/GFKleLiN7ZIeytM6KJ4cAn1SxA==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.19.0.tgz",
+      "integrity": "sha512-JlPfZ/C7yn5S5p0yKk7uhHTTnFlvTgLetl2VxqE518QgyM7C9bSfFTYvB/Q/ftkq0RIPY4ySxTz+/wKJ/dXC0w==",
       "cpu": [
         "arm"
       ],
@@ -1176,9 +1179,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.18.1.tgz",
-      "integrity": "sha512-F/tkdw0WSs4ojqz5Ovrw5r9odqzFjb5LIgHdHZG65dFI1lWTWRVy32KDJLKRISHgJvqUeUhdIvy43fX41znyDg==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.19.0.tgz",
+      "integrity": "sha512-RDxUSY8D1tWYfn00DDi5myxKgOk6RvWPxhmWexcICt/MEC6yEMr4HNCu1sXXYLw8iAsg0D44NuU+qNq7zVWCrw==",
       "cpu": [
         "arm64"
       ],
@@ -1190,9 +1193,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.18.1.tgz",
-      "integrity": "sha512-vk+ma8iC1ebje/ahpxpnrfVQJibTMyHdWpOGZ3JpQ7Mgn/3QNHmPq7YwjZbIE7km73dH5M1e6MRRsnEBW7v5CQ==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.19.0.tgz",
+      "integrity": "sha512-emvKHL4B15x6nlNTBMtIaC9tLPRpeA5jMvRLXVbl/W9Ie7HhkrE7KQjvgS9uxgatL1HmHWDXk5TTS4IaNJxbAA==",
       "cpu": [
         "arm64"
       ],
@@ -1204,9 +1207,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.18.1.tgz",
-      "integrity": "sha512-IgpzXKauRe1Tafcej9STjSSuG0Ghu/xGYH+qG6JwsAUxXrnkvNHcq/NL6nz1+jzvWAnQkuAJ4uIwGB48K9OCGA==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.19.0.tgz",
+      "integrity": "sha512-fO28cWA1dC57qCd+D0rfLC4VPbh6EOJXrreBmFLWPGI9dpMlER2YwSPZzSGfq11XgcEpPukPTfEVFtw2q2nYJg==",
       "cpu": [
         "x64"
       ],
@@ -1218,9 +1221,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.18.1.tgz",
-      "integrity": "sha512-P9bSiAUnSSM7EmyRK+e5wgpqai86QOSv8BwvkGjLwYuOpaeomiZWifEos517CwbG+aZl1T4clSE1YqqH2JRs+g==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.19.0.tgz",
+      "integrity": "sha512-2Rn36Ubxdv32NUcfm0wB1tgKqkQuft00PtM23VqLuCUR4N5jcNWDoV5iBC9jeGdgS38WK66ElncprqgMUOyomw==",
       "cpu": [
         "arm"
       ],
@@ -1232,9 +1235,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.18.1.tgz",
-      "integrity": "sha512-5RnjpACoxtS+aWOI1dURKno11d7krfpGDEn19jI8BuWmSBbUC4ytIADfROM1FZrFhQPSoP+KEa3NlEScznBTyQ==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.19.0.tgz",
+      "integrity": "sha512-gJuzIVdq/X1ZA2bHeCGCISe0VWqCoNT8BvkQ+BfsixXwTOndhtLUpOg0A1Fcx/+eA6ei6rMBzlOz4JzmiDw7JQ==",
       "cpu": [
         "arm"
       ],
@@ -1246,9 +1249,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.18.1.tgz",
-      "integrity": "sha512-8mwmGD668m8WaGbthrEYZ9CBmPug2QPGWxhJxh/vCgBjro5o96gL04WLlg5BA233OCWLqERy4YUzX3bJGXaJgQ==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.19.0.tgz",
+      "integrity": "sha512-0EkX2HYPkSADo9cfeGFoQ7R0/wTKb7q6DdwI4Yn/ULFE1wuRRCHybxpl2goQrx4c/yzK3I8OlgtBu4xvted0ug==",
       "cpu": [
         "arm64"
       ],
@@ -1260,9 +1263,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.18.1.tgz",
-      "integrity": "sha512-dJX9u4r4bqInMGOAQoGYdwDP8lQiisWb9et+T84l2WXk41yEej8v2iGKodmdKimT8cTAYt0jFb+UEBxnPkbXEQ==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.19.0.tgz",
+      "integrity": "sha512-GlIQRj9px52ISomIOEUq/IojLZqzkvRpdP3cLgIE1wUWaiU5Takwlzpz002q0Nxxr1y2ZgxC2obWxjr13lvxNQ==",
       "cpu": [
         "arm64"
       ],
@@ -1274,9 +1277,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.18.1.tgz",
-      "integrity": "sha512-V72cXdTl4EI0x6FNmho4D502sy7ed+LuVW6Ym8aI6DRQ9hQZdp5sj0a2usYOlqvFBNKQnLQGwmYnujo2HvjCxQ==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.19.0.tgz",
+      "integrity": "sha512-N6cFJzssruDLUOKfEKeovCKiHcdwVYOT1Hs6dovDQ61+Y9n3Ek4zXvtghPPelt6U0AH4aDGnDLb83uiJMkWYzQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1288,9 +1291,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.18.1.tgz",
-      "integrity": "sha512-f+pJih7sxoKmbjghrM2RkWo2WHUW8UbfxIQiWo5yeCaCM0TveMEuAzKJte4QskBp1TIinpnRcxkquY+4WuY/tg==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.19.0.tgz",
+      "integrity": "sha512-2DnD3mkS2uuam/alF+I7M84koGwvn3ZVD7uG+LEWpyzo/bq8+kKnus2EVCkcvh6PlNB8QPNFOz6fWd5N8o1CYg==",
       "cpu": [
         "riscv64"
       ],
@@ -1302,9 +1305,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.18.1.tgz",
-      "integrity": "sha512-qb1hMMT3Fr/Qz1OKovCuUM11MUNLUuHeBC2DPPAWUYYUAOFWaxInaTwTQmc7Fl5La7DShTEpmYwgdt2hG+4TEg==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.19.0.tgz",
+      "integrity": "sha512-D6pkaF7OpE7lzlTOFCB2m3Ngzu2ykw40Nka9WmKGUOTS3xcIieHe82slQlNq69sVB04ch73thKYIWz/Ian8DUA==",
       "cpu": [
         "s390x"
       ],
@@ -1316,9 +1319,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.1.tgz",
-      "integrity": "sha512-7O5u/p6oKUFYjRbZkL2FLbwsyoJAjyeXHCU3O4ndvzg2OFO2GinFPSJFGbiwFDaCFc+k7gs9CF243PwdPQFh5g==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.19.0.tgz",
+      "integrity": "sha512-HBndjQLP8OsdJNSxpNIN0einbDmRFg9+UQeZV1eiYupIRuZsDEoeGU43NQsS34Pp166DtwQOnpcbV/zQxM+rWA==",
       "cpu": [
         "x64"
       ],
@@ -1330,9 +1333,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.18.1.tgz",
-      "integrity": "sha512-pDLkYITdYrH/9Cv/Vlj8HppDuLMDUBmgsM0+N+xLtFd18aXgM9Nyqupb/Uw+HeidhfYg2lD6CXvz6CjoVOaKjQ==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.19.0.tgz",
+      "integrity": "sha512-HxfbvfCKJe/RMYJJn0a12eiOI9OOtAUF4G6ozrFUK95BNyoJaSiBjIOHjZskTUffUrB84IPKkFG9H9nEvJGW6A==",
       "cpu": [
         "x64"
       ],
@@ -1344,9 +1347,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.18.1.tgz",
-      "integrity": "sha512-W2ZNI323O/8pJdBGil1oCauuCzmVd9lDmWBBqxYZcOqWD6aWqJtVBQ1dFrF4dYpZPks6F+xCZHfzG5hYlSHZ6g==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.19.0.tgz",
+      "integrity": "sha512-HxDMKIhmcguGTiP5TsLNolwBUK3nGGUEoV/BO9ldUBoMLBssvh4J0X8pf11i1fTV7WShWItB1bKAKjX4RQeYmg==",
       "cpu": [
         "arm64"
       ],
@@ -1358,9 +1361,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.18.1.tgz",
-      "integrity": "sha512-ELfEX1/+eGZYMaCIbK4jqLxO1gyTSOIlZr6pbC4SRYFaSIDVKOnZNMdoZ+ON0mrFDp4+H5MhwNC1H/AhE3zQLg==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.19.0.tgz",
+      "integrity": "sha512-xItlIAZZaiG/u0wooGzRsx11rokP4qyc/79LkAOdznGRAbOFc+SfEdfUOszG1odsHNgwippUJavag/+W/Etc6Q==",
       "cpu": [
         "ia32"
       ],
@@ -1372,9 +1375,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.18.1.tgz",
-      "integrity": "sha512-yjk2MAkQmoaPYCSu35RLJ62+dz358nE83VfTePJRp8CG7aMg25mEJYpXFiD+NcevhX8LxD5OP5tktPXnXN7GDw==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.19.0.tgz",
+      "integrity": "sha512-xNo5fV5ycvCCKqiZcpB65VMR11NJB+StnxHz20jdqRAktfdfzhgjTiJ2doTDQE/7dqGaV5I7ZGqKpgph6lCIag==",
       "cpu": [
         "x64"
       ],
@@ -1469,9 +1472,9 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.6.13.tgz",
-      "integrity": "sha512-eailUYex6fkfaQTev4Oa3mwn0/e3mQU4H8y1WPuImYQESOQDtVrowwUGDSc19evpBbHpKtwM+hw8nLlhIsF+Tw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.7.0.tgz",
+      "integrity": "sha512-d4vMzH6ICllDwlPuhset2h8gu/USHdbyfJim+2hQEdxC0UONtfpmu38XBgNqRjStrji1Q5M10jfeUZL3cu1i8g==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1487,16 +1490,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.6.13",
-        "@swc/core-darwin-x64": "1.6.13",
-        "@swc/core-linux-arm-gnueabihf": "1.6.13",
-        "@swc/core-linux-arm64-gnu": "1.6.13",
-        "@swc/core-linux-arm64-musl": "1.6.13",
-        "@swc/core-linux-x64-gnu": "1.6.13",
-        "@swc/core-linux-x64-musl": "1.6.13",
-        "@swc/core-win32-arm64-msvc": "1.6.13",
-        "@swc/core-win32-ia32-msvc": "1.6.13",
-        "@swc/core-win32-x64-msvc": "1.6.13"
+        "@swc/core-darwin-arm64": "1.7.0",
+        "@swc/core-darwin-x64": "1.7.0",
+        "@swc/core-linux-arm-gnueabihf": "1.7.0",
+        "@swc/core-linux-arm64-gnu": "1.7.0",
+        "@swc/core-linux-arm64-musl": "1.7.0",
+        "@swc/core-linux-x64-gnu": "1.7.0",
+        "@swc/core-linux-x64-musl": "1.7.0",
+        "@swc/core-win32-arm64-msvc": "1.7.0",
+        "@swc/core-win32-ia32-msvc": "1.7.0",
+        "@swc/core-win32-x64-msvc": "1.7.0"
       },
       "peerDependencies": {
         "@swc/helpers": "*"
@@ -1508,9 +1511,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.6.13.tgz",
-      "integrity": "sha512-SOF4buAis72K22BGJ3N8y88mLNfxLNprTuJUpzikyMGrvkuBFNcxYtMhmomO0XHsgLDzOJ+hWzcgjRNzjMsUcQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.7.0.tgz",
+      "integrity": "sha512-2ylhM7f0HwUwLrFYZAe/dse8PCbPsYcJS3Dt7Q8NT3PUn7vy6QOMxNcOPPuDrnmaXqQQO3oxdmRapguTxaat9g==",
       "cpu": [
         "arm64"
       ],
@@ -1525,9 +1528,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.6.13.tgz",
-      "integrity": "sha512-AW8akFSC+tmPE6YQQvK9S2A1B8pjnXEINg+gGgw0KRUUXunvu1/OEOeC5L2Co1wAwhD7bhnaefi06Qi9AiwOag==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.7.0.tgz",
+      "integrity": "sha512-SgVnN4gT1Rb9YfTkp4FCUITqSs7Yj0uB2SUciu5CV3HuGvS5YXCUzh+KrwpLFtx8NIgivISKcNnb41mJi98X8Q==",
       "cpu": [
         "x64"
       ],
@@ -1542,9 +1545,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.6.13.tgz",
-      "integrity": "sha512-f4gxxvDXVUm2HLYXRd311mSrmbpQF2MZ4Ja6XCQz1hWAxXdhRl1gpnZ+LH/xIfGSwQChrtLLVrkxdYUCVuIjFg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.7.0.tgz",
+      "integrity": "sha512-+Z9Dayart1iKJQEJJ9N/KS4z5EdXJE3WPFikY0jonKTo4Dd8RuyVz5yLvqcIMeVdz/SwximATaL6iJXw7hZS9A==",
       "cpu": [
         "arm"
       ],
@@ -1559,9 +1562,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.6.13.tgz",
-      "integrity": "sha512-Nf/eoW2CbG8s+9JoLtjl9FByBXyQ5cjdBsA4efO7Zw4p+YSuXDgc8HRPC+E2+ns0praDpKNZtLvDtmF2lL+2Gg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.7.0.tgz",
+      "integrity": "sha512-UnLrCiZ1EI4shznJn0xP6DLgsXUSwtfsdgHhGYCrvbgVBBve3S9iFgVFEB3SPl7Q/TdowNbrN4zHU0oChfiNfw==",
       "cpu": [
         "arm64"
       ],
@@ -1576,9 +1579,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.6.13.tgz",
-      "integrity": "sha512-2OysYSYtdw79prJYuKIiux/Gj0iaGEbpS2QZWCIY4X9sGoETJ5iMg+lY+YCrIxdkkNYd7OhIbXdYFyGs/w5LDg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.7.0.tgz",
+      "integrity": "sha512-H724UANA+ptsfwKRr9mnaDa9cb5fw0oFysiGKTgb3DMYcgk3Od0jMTnXVPFSVpo7FlmyxeC9K8ueUPBOoOK6XA==",
       "cpu": [
         "arm64"
       ],
@@ -1593,9 +1596,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.6.13.tgz",
-      "integrity": "sha512-PkR4CZYJNk5hcd2+tMWBpnisnmYsUzazI1O5X7VkIGFcGePTqJ/bWlfUIVVExWxvAI33PQFzLbzmN5scyIUyGQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.7.0.tgz",
+      "integrity": "sha512-SY3HA0K0Dpqt1HIfMLGpwL4hd4UaL2xHP5oZXPlRQPhUDZrbb4PbI3ZJnh66c63eL4ZR8EJ+HRFI0Alx5p69Zw==",
       "cpu": [
         "x64"
       ],
@@ -1610,9 +1613,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.6.13.tgz",
-      "integrity": "sha512-OdsY7wryTxCKwGQcwW9jwWg3cxaHBkTTHi91+5nm7hFPpmZMz1HivJrWAMwVE7iXFw+M4l6ugB/wCvpYrUAAjA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.7.0.tgz",
+      "integrity": "sha512-cEJ2ebtV1v/5Ilb55E05J6F5SrHKQWzUttIhR5Mkayyo+yvPslcpByuFC3D+J7X1ebziTOBpWuMpUdjLfh3SMQ==",
       "cpu": [
         "x64"
       ],
@@ -1627,9 +1630,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.6.13.tgz",
-      "integrity": "sha512-ap6uNmYjwk9M/+bFEuWRNl3hq4VqgQ/Lk+ID/F5WGqczNr0L7vEf+pOsRAn0F6EV+o/nyb3ePt8rLhE/wjHpPg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.7.0.tgz",
+      "integrity": "sha512-ecQOOmzEssz+m0pR4xDYCGuvn3E/l0nQ3tk5jp1NA1lsAy4bMV0YbYCHjptYvWL/UjhIerIp3IlCJ8x5DodSog==",
       "cpu": [
         "arm64"
       ],
@@ -1644,9 +1647,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.6.13.tgz",
-      "integrity": "sha512-IJ8KH4yIUHTnS/U1jwQmtbfQals7zWPG0a9hbEfIr4zI0yKzjd83lmtS09lm2Q24QBWOCFGEEbuZxR4tIlvfzA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.7.0.tgz",
+      "integrity": "sha512-gz81seZkRn3zMnVOc7L5k6F4vQC82gIxmHiL+GedK+A37XI/X26AASU3zxvORnqQbwQYXQ+AEVckxBmFlz3v2g==",
       "cpu": [
         "ia32"
       ],
@@ -1661,9 +1664,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.6.13.tgz",
-      "integrity": "sha512-f6/sx6LMuEnbuxtiSL/EkR0Y6qUHFw1XVrh6rwzKXptTipUdOY+nXpKoh+1UsBm/r7H0/5DtOdrn3q5ZHbFZjQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.7.0.tgz",
+      "integrity": "sha512-b5Fd1xEOw9uqBpj2lqsaR4Iq9UhiL84hNDcEsi6DQA7Y1l85waQAslTbS0E4/pJ1PISAs0jW0zIGLco1eaWBOg==",
       "cpu": [
         "x64"
       ],
@@ -1685,9 +1688,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.9.tgz",
-      "integrity": "sha512-qKnCno++jzcJ4lM4NTfYifm1EFSCeIfKiAHAfkENZAV5Kl9PjJIyd2yeeVv6c/2CckuLyv2NmRC5pv6pm2WQBg==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.12.tgz",
+      "integrity": "sha512-wBJA+SdtkbFhHjTMYH+dEH1y4VpfGdAc2Kw/LK09i9bXd/K6j6PkDcFCEzb6iVfZMkPRrl/q0e3toqTAJdkIVA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1771,9 +1774,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.14.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
-      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+      "version": "20.14.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
+      "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1974,9 +1977,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001642",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001642.tgz",
-      "integrity": "sha512-3XQ0DoRgLijXJErLSl+bLnJ+Et4KqV1PY6JJBGAFlsNsz31zeAIncyeZfLCabHK/jtSh+671RM9YMldxjUPZtA==",
+      "version": "1.0.30001643",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001643.tgz",
+      "integrity": "sha512-ERgWGNleEilSrHM6iUz/zJNSQTP8Mr21wDWpdgvRwcTXGAq6jMtOUPP4dqFPTdKqZ2wKTdtB+uucZ3MRpAUSmg==",
       "dev": true,
       "funding": [
         {
@@ -2134,9 +2137,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.827",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.827.tgz",
-      "integrity": "sha512-VY+J0e4SFcNfQy19MEoMdaIcZLmDCprqvBtkii1WTCTQHpRvf5N8+3kTYCgL/PcntvwQvmMJWTuDPsq+IlhWKQ==",
+      "version": "1.4.832",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.832.tgz",
+      "integrity": "sha512-cTen3SB0H2SGU7x467NRe1eVcQgcuS6jckKfWJHia2eo0cHIGOqHoAxevIYZD4eRHcWjkvFzo93bi3vJ9W+1lA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2590,9 +2593,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
       "dev": true,
       "license": "MIT"
     },
@@ -2686,9 +2689,9 @@
       }
     },
     "node_modules/prosemirror-model": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.22.1.tgz",
-      "integrity": "sha512-gMrxal+F3higDFxCkBK5iQXckRVYvIu/3dopERJ6b20xfwZ9cbYvQvuldqaN+v/XytNPGyURYUpUU23kBRxWCQ==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.22.2.tgz",
+      "integrity": "sha512-I4lS7HHIW47D0Xv/gWmi4iUWcQIDYaJKd8Hk4+lcSps+553FlQrhmxtItpEvTr75iAruhzVShVp6WUwsT6Boww==",
       "license": "MIT",
       "dependencies": {
         "orderedmap": "^2.0.0"
@@ -2735,9 +2738,9 @@
       }
     },
     "node_modules/prosemirror-view": {
-      "version": "1.33.8",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.33.8.tgz",
-      "integrity": "sha512-4PhMr/ufz2cdvFgpUAnZfs+0xij3RsFysreeG9V/utpwX7AJtYCDVyuRxzWoMJIEf4C7wVihuBNMPpFLPCiLQw==",
+      "version": "1.33.9",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.33.9.tgz",
+      "integrity": "sha512-xV1A0Vz9cIcEnwmMhKKFAOkfIp8XmJRnaZoPqNXrPS7EK5n11Ov8V76KhR0RsfQd/SIzmWY+bg+M44A2Lx/Nnw==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-model": "^1.20.0",
@@ -2763,9 +2766,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.18.1.tgz",
-      "integrity": "sha512-Elx2UT8lzxxOXMpy5HWQGZqkrQOtrVDDa/bm9l10+U4rQnVzbL/LgZ4NOM1MPIDyHk69W4InuYDF5dzRh4Kw1A==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.19.0.tgz",
+      "integrity": "sha512-5r7EYSQIowHsK4eTZ0Y81qpZuJz+MUuYeqmmYmRMl1nwhdmbiYqt5jwzf6u7wyOzJgYqtCRMtVRKOtHANBz7rA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2779,22 +2782,22 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.18.1",
-        "@rollup/rollup-android-arm64": "4.18.1",
-        "@rollup/rollup-darwin-arm64": "4.18.1",
-        "@rollup/rollup-darwin-x64": "4.18.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.18.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.18.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.18.1",
-        "@rollup/rollup-linux-arm64-musl": "4.18.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.18.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.18.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.18.1",
-        "@rollup/rollup-linux-x64-gnu": "4.18.1",
-        "@rollup/rollup-linux-x64-musl": "4.18.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.18.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.18.1",
-        "@rollup/rollup-win32-x64-msvc": "4.18.1",
+        "@rollup/rollup-android-arm-eabi": "4.19.0",
+        "@rollup/rollup-android-arm64": "4.19.0",
+        "@rollup/rollup-darwin-arm64": "4.19.0",
+        "@rollup/rollup-darwin-x64": "4.19.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.19.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.19.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.19.0",
+        "@rollup/rollup-linux-arm64-musl": "4.19.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.19.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.19.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.19.0",
+        "@rollup/rollup-linux-x64-gnu": "4.19.0",
+        "@rollup/rollup-linux-x64-musl": "4.19.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.19.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.19.0",
+        "@rollup/rollup-win32-x64-msvc": "4.19.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -2999,9 +3002,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
-      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -3085,9 +3088,9 @@
       "license": "ISC"
     },
     "node_modules/vite": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.3.tgz",
-      "integrity": "sha512-NPQdeCU0Dv2z5fu+ULotpuq5yfCS1BzKUIPhNbP3YBfAMGJXbt2nS+sbTFu+qchaqWTD+H3JK++nRwr6XIcp6A==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.4.tgz",
+      "integrity": "sha512-Cw+7zL3ZG9/NZBB8C+8QbQZmR54GwqIz+WMI4b3JgdYJvX+ny9AjJXqkGQlDXSXRP9rP0B4tbciRMOVEKulVOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3166,18 +3169,32 @@
       }
     },
     "node_modules/vite-plugin-top-level-await": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-top-level-await/-/vite-plugin-top-level-await-1.4.1.tgz",
-      "integrity": "sha512-hogbZ6yT7+AqBaV6lK9JRNvJDn4/IJvHLu6ET06arNfo0t2IsyCaon7el9Xa8OumH+ESuq//SDf8xscZFE0rWw==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-top-level-await/-/vite-plugin-top-level-await-1.4.2.tgz",
+      "integrity": "sha512-Lz9ZGlDEqLpIJ/NU3toXSUrjmovlJf9qV/LNNa5RB2NYbN3SptfnZEz91//uqahhZtFzL5lKREPwv3YJmlnybg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-virtual": "^3.0.2",
-        "@swc/core": "^1.3.100",
-        "uuid": "^9.0.1"
+        "@swc/core": "^1.7.0",
+        "uuid": "^10.0.0"
       },
       "peerDependencies": {
         "vite": ">=2.8"
+      }
+    },
+    "node_modules/vite-plugin-top-level-await/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vite-plugin-wasm": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,6 @@
         "@solid-primitives/pointer": "^0.2.19",
         "@viz-js/viz": "^3.7.0",
         "catlog-wasm": "file:catlog-wasm/pkg",
-        "newtype-ts": "^0.3.5",
         "prosemirror-commands": "^1.5.2",
         "prosemirror-keymap": "^1.2.2",
         "prosemirror-model": "^1.21.3",
@@ -2235,13 +2234,6 @@
         }
       }
     },
-    "node_modules/fp-ts": {
-      "version": "2.16.8",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.8.tgz",
-      "integrity": "sha512-nmDtNqmMZkOxu0M5hkrS9YA15/KPkYkILb6Axg9XBAoUoYEtzg+LFmVWqZrl9FNttsW0qIUpx9RCA9INbv+Bxw==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -2532,16 +2524,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/monocle-ts": {
-      "version": "2.3.13",
-      "resolved": "https://registry.npmjs.org/monocle-ts/-/monocle-ts-2.3.13.tgz",
-      "integrity": "sha512-D5Ygd3oulEoAm3KuGO0eeJIrhFf1jlQIoEVV2DYsZUMz42j4tGxgct97Aq68+F8w4w4geEnwFa8HayTS/7lpKQ==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "fp-ts": "^2.5.0"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -2565,16 +2547,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/newtype-ts": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/newtype-ts/-/newtype-ts-0.3.5.tgz",
-      "integrity": "sha512-v83UEQMlVR75yf1OUdoSFssjitxzjZlqBAjiGQ4WJaML8Jdc68LJ+BaSAXUmKY4bNzp7hygkKLYTsDi14PxI2g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "fp-ts": "^2.0.0",
-        "monocle-ts": "^2.0.0"
       }
     },
     "node_modules/node-gyp-build-optional-packages": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,6 @@
     "@solid-primitives/pointer": "^0.2.19",
     "@viz-js/viz": "^3.7.0",
     "catlog-wasm": "file:catlog-wasm/pkg",
-    "newtype-ts": "^0.3.5",
     "prosemirror-commands": "^1.5.2",
     "prosemirror-keymap": "^1.2.2",
     "prosemirror-model": "^1.21.3",

--- a/frontend/src/model/model_context.ts
+++ b/frontend/src/model/model_context.ts
@@ -1,12 +1,12 @@
 import { Accessor, createContext } from "solid-js";
 
+import { ObId } from "catlog-wasm";
 import { IndexedMap } from "../util/indexing";
 import { TheoryMeta } from "../theory";
-import { ObjectId } from "./types";
 
 export const TheoryContext = createContext<Accessor<TheoryMeta | undefined>>();
 
 // Bidirectional mapping between object IDs and names.
-export type ObjectIndex = IndexedMap<ObjectId,string>;
+export type ObjectIndex = IndexedMap<ObId,string>;
 
 export const ObjectIndexContext = createContext<Accessor<ObjectIndex>>();

--- a/frontend/src/model/model_graph.ts
+++ b/frontend/src/model/model_graph.ts
@@ -1,7 +1,7 @@
 import type * as Viz from "@viz-js/viz";
 
 import { TheoryMeta, TypeMeta } from "../theory";
-import { isoObjectId, isoMorphismId, ModelNotebook } from "./types";
+import { ModelNotebook } from "./types";
 
 import styles from "../theory/styles.module.css";
 
@@ -31,11 +31,11 @@ export function modelToGraphviz(
 
         if (judgment.tag === "object") {
             const { id, name } = judgment;
-            const meta = theory.getObTypeMeta(judgment.type);
+            const meta = theory.getObTypeMeta(judgment.obType);
             nodes.push({
-                name: isoObjectId.unwrap(id),
+                name: id,
                 attributes: {
-                    id: isoObjectId.unwrap(id),
+                    id,
                     label: name,
                     class: cssClass(meta),
                     fontname: fontname(meta),
@@ -44,12 +44,12 @@ export function modelToGraphviz(
         } else if (judgment.tag === "morphism") {
             const { id, name, dom, cod } = judgment;
             if (!dom || !cod) { continue; }
-            const meta = theory.getMorTypeMeta(judgment.type);
+            const meta = theory.getMorTypeMeta(judgment.morType);
             edges.push({
-                head: isoObjectId.unwrap(cod),
-                tail: isoObjectId.unwrap(dom),
+                head: cod,
+                tail: dom,
                 attributes: {
-                    id: isoMorphismId.unwrap(id),
+                    id,
                     label: name,
                     class: cssClass(meta),
                     fontname: fontname(meta),

--- a/frontend/src/model/model_notebook_editor.tsx
+++ b/frontend/src/model/model_notebook_editor.tsx
@@ -5,8 +5,9 @@ import { MultiProvider } from "@solid-primitives/context";
 import { IndexedMap, indexMap } from "../util/indexing";
 import { useDoc } from "../util/automerge_solid";
 
+import { ObId } from "catlog-wasm";
 import { isoTheoryId, TheoryId, TheoryMeta } from "../theory";
-import { ModelJudgment, MorphismDecl, newMorphismDecl, newObjectDecl, ModelNotebook, ObjectDecl, ObjectId } from "./types";
+import { ModelJudgment, MorphismDecl, newMorphismDecl, newObjectDecl, ModelNotebook, ObjectDecl } from "./types";
 import { CellActions, CellConstructor, newFormalCell, newRichTextCell, NotebookEditor } from "../notebook";
 import { InlineInput } from "../components";
 import { ObjectIndexContext, TheoryContext } from "./model_context";
@@ -80,8 +81,8 @@ export function ModelNotebookEditor(props: {
         setTheory(id && props.theories.get(id));
     });
 
-    const objectIndex = createMemo<IndexedMap<ObjectId,string>>(() => {
-        const map = new Map<ObjectId,string>();
+    const objectIndex = createMemo<IndexedMap<ObId,string>>(() => {
+        const map = new Map<ObId,string>();
         for (const cell of model().notebook.cells) {
             if (cell.tag == "formal" && cell.content.tag == "object") {
                 map.set(cell.content.id, cell.content.name);

--- a/frontend/src/model/model_notebook_editor.tsx
+++ b/frontend/src/model/model_notebook_editor.tsx
@@ -6,7 +6,7 @@ import { IndexedMap, indexMap } from "../util/indexing";
 import { useDoc } from "../util/automerge_solid";
 
 import { ObId } from "catlog-wasm";
-import { isoTheoryId, TheoryId, TheoryMeta } from "../theory";
+import { TheoryId, TheoryMeta } from "../theory";
 import { ModelJudgment, MorphismDecl, newMorphismDecl, newObjectDecl, ModelNotebook, ObjectDecl } from "./types";
 import { CellActions, CellConstructor, newFormalCell, newRichTextCell, NotebookEditor } from "../notebook";
 import { InlineInput } from "../components";
@@ -78,7 +78,7 @@ export function ModelNotebookEditor(props: {
 
     createEffect(() => {
         const id = model().theory;
-        setTheory(id && props.theories.get(id));
+        setTheory(id !== undefined ? props.theories.get(id) : undefined);
     });
 
     const objectIndex = createMemo<IndexedMap<ObId,string>>(() => {
@@ -105,11 +105,11 @@ export function ModelNotebookEditor(props: {
                 <select required
                     disabled={model().notebook.cells.some(
                         cell => cell.tag === "formal")}
-                    value={(id => id ? isoTheoryId.unwrap(id) : "")(model().theory)}
+                    value={model().theory ?? ""}
                     onInput={(evt) => {
                         let id = evt.target.value;
                         changeModel((model) => {
-                            model.theory = id ? isoTheoryId.wrap(id) : undefined;
+                            model.theory = id ? id : undefined;
                         });
                     }}
                 >
@@ -118,7 +118,7 @@ export function ModelNotebookEditor(props: {
                     </option>
                     <For each={Array.from(props.theories.values())}>
                     {(theory) =>
-                        <option value={isoTheoryId.unwrap(theory.id)}>
+                        <option value={theory.id}>
                             {theory.name}
                         </option>}
                     </For>

--- a/frontend/src/model/morphism_cell_editor.tsx
+++ b/frontend/src/model/morphism_cell_editor.tsx
@@ -4,7 +4,7 @@ import { MorphismDecl } from "./types";
 import { CellActions } from "../notebook";
 import { InlineInput } from "../components";
 import { ObjectIndexContext, TheoryContext } from "./model_context";
-import { ObjectIdInput} from "./object_cell_editor";
+import { ObjectIdInput } from "./object_cell_editor";
 
 
 import "./morphism_cell_editor.css";
@@ -30,7 +30,7 @@ export function MorphismCellEditor(props: {
     const theory = useContext(TheoryContext);
     const objectIndex = useContext(ObjectIndexContext);
 
-    const typeMeta = () => theory?.()?.getMorTypeMeta(props.morphism.type);
+    const typeMeta = () => theory?.()?.getMorTypeMeta(props.morphism.morType);
     const nameClasses = () =>
         ["morphism-decl-name", ...typeMeta()?.textClasses ?? []];
     const arrowClasses = () => {
@@ -44,7 +44,7 @@ export function MorphismCellEditor(props: {
             setObjectId={(id) => {
                 props.modifyMorphism((mor) => (mor.dom = id));
             }}
-            objectType={theory?.()?.theory.src(props.morphism.type)}
+            objectType={theory?.()?.theory.src(props.morphism.morType)}
             objectIndex={objectIndex && objectIndex()}
             deleteForward={() => nameRef.focus()}
             exitBackward={() => nameRef.focus()}
@@ -77,7 +77,7 @@ export function MorphismCellEditor(props: {
             setObjectId={(id) => {
                 props.modifyMorphism((mor) => (mor.cod = id));
             }}
-            objectType={theory?.()?.theory.tgt(props.morphism.type)}
+            objectType={theory?.()?.theory.tgt(props.morphism.morType)}
             objectIndex={objectIndex && objectIndex()}
             deleteBackward={() => nameRef.focus()}
             exitBackward={() => domRef.focus()}

--- a/frontend/src/model/object_cell_editor.tsx
+++ b/frontend/src/model/object_cell_editor.tsx
@@ -1,8 +1,8 @@
 import { createEffect, createSignal, splitProps, useContext } from "solid-js";
 
-import { ObType } from "catlog-wasm";
+import { ObId, ObType } from "catlog-wasm";
 import { IndexedMap } from "../util/indexing";
-import { ObjectDecl, ObjectId } from "./types";
+import { ObjectDecl } from "./types";
 import { CellActions } from "../notebook";
 import { InlineInput, InlineInputOptions } from "../components";
 import { TheoryMeta } from "../theory";
@@ -28,7 +28,7 @@ export function ObjectCellEditor(props: {
 
     const theory = useContext(TheoryContext);
     const cssClasses = (): string[] =>
-        ["object-decl", ...extraClasses(theory?.(), props.object.type)];
+        ["object-decl", ...extraClasses(theory?.(), props.object.obType)];
 
     return <div class={cssClasses().join(" ")}>
         <InlineInput ref={nameRef} placeholder="Unnamed"
@@ -48,10 +48,10 @@ export function ObjectCellEditor(props: {
 }
 
 export function ObjectIdInput(allProps: {
-    objectId: ObjectId | null;
-    setObjectId: (id: ObjectId | null) => void;
+    objectId: ObId | null;
+    setObjectId: (id: ObId | null) => void;
     objectType?: ObType;
-    objectIndex?: IndexedMap<ObjectId,string>;
+    objectIndex?: IndexedMap<ObId,string>;
 } & InlineInputOptions) {
     const [props, inputProps] = splitProps(allProps, [
         "objectId", "setObjectId", "objectIndex", "objectType",

--- a/frontend/src/model/types.ts
+++ b/frontend/src/model/types.ts
@@ -1,7 +1,6 @@
-import { Newtype, iso } from "newtype-ts";
 import { uuidv7 } from "uuidv7";
 
-import { MorType, ObType } from "catlog-wasm";
+import { MorDecl, MorType, ObDecl, ObType } from "catlog-wasm";
 import { TheoryId } from "../theory";
 import { Notebook } from "../notebook";
 
@@ -30,62 +29,34 @@ export type ModelDecl = ObjectDecl | MorphismDecl;
 
 /** Declaration of an object in a model.
  */
-export type ObjectDecl = {
+export type ObjectDecl = ObDecl & {
     tag: "object";
-
-    // Globally unique identifier of declaration.
-    id: ObjectId;
 
     // Human-readable name of object.
     name: string;
-
-    // Identifier of object type in double theory.
-    type: ObType;
 };
 
 export const newObjectDecl = (type: ObType): ObjectDecl => ({
     tag: "object",
-    id: isoObjectId.wrap(uuidv7()),
+    id: uuidv7(),
     name: "",
-    type: type,
+    obType: type,
 });
-
-export interface ObjectId
-extends Newtype<{ readonly ObjectId: unique symbol }, string> {}
-
-export const isoObjectId = iso<ObjectId>();
 
 /** Declaration of a morphim in a model.
  */
-export type MorphismDecl = {
+export type MorphismDecl = MorDecl & {
     tag: "morphism";
 
-    // Globally unique identifier of declaration.
-    id: MorphismId;
-
-    // Human-readable name of object.
+    // Human-readable name of morphism.
     name: string;
-
-    // Identifier of morphism type in double theory.
-    type: MorType;
-
-    // Domain of morphism.
-    dom: ObjectId | null;
-
-    // Codmain of morphism.
-    cod: ObjectId | null;
 };
 
 export const newMorphismDecl = (type: MorType): MorphismDecl => ({
     tag: "morphism",
-    id: isoMorphismId.wrap(uuidv7()),
+    id: uuidv7(),
     name: "",
-    type: type,
+    morType: type,
     dom: null,
     cod: null,
 });
-
-export interface MorphismId
-extends Newtype<{ readonly MorphismId: unique symbol }, string> {}
-
-export const isoMorphismId = iso<MorphismId>();

--- a/frontend/src/notebook/types.ts
+++ b/frontend/src/notebook/types.ts
@@ -1,4 +1,3 @@
-import { Newtype, iso } from "newtype-ts";
 import { uuidv7 } from "uuidv7";
 
 
@@ -20,7 +19,7 @@ export type RichTextCell = {
 
 export const newRichTextCell = (): RichTextCell => ({
     tag: "rich-text",
-    id: isoCellId.wrap(uuidv7()),
+    id: uuidv7(),
     content: "",
 });
 
@@ -32,11 +31,8 @@ export type FormalCell<T> = {
 
 export const newFormalCell = <T>(content: T): FormalCell<T> => ({
     tag: "formal",
-    id: isoCellId.wrap(uuidv7()),
+    id: uuidv7(),
     content: content,
 });
 
-export interface CellId
-extends Newtype<{ readonly CellId: unique symbol }, string> {}
-
-const isoCellId = iso<CellId>();
+export type CellId = string;

--- a/frontend/src/theory/types.ts
+++ b/frontend/src/theory/types.ts
@@ -1,4 +1,3 @@
-import { Newtype, iso } from "newtype-ts";
 import { KbdKey } from "@solid-primitives/keyboard";
 
 import { DiscreteDblTheory, ObType, MorType } from "catlog-wasm";
@@ -38,10 +37,9 @@ export class TheoryMeta {
         this.types = [];
         props.types?.forEach(this.bindType, this);
 
-        const {name, description} = props;
+        const {id, name, description} = props;
         Object.assign(this, {
-            id: isoTheoryId.wrap(props.id),
-            name, description,
+            id, name, description,
             onlyFree: props.onlyFree ?? false,
         });
     }
@@ -67,10 +65,7 @@ export class TheoryMeta {
     }
 }
 
-export interface TheoryId
-extends Newtype<{ readonly TheoryId: unique symbol }, string> {}
-
-export const isoTheoryId = iso<TheoryId>();
+export type TheoryId = string;
 
 
 /** A type in a double theory with frontend metadata.


### PR DESCRIPTION
Sequel to #33 and further progress toward #34. This PR:

- Uses Rust structs to induce the TypeScript defs for object and morphism declarations
- Enables models in the core to be constructed from data produced by the frontend