### PR TITLE
Use `Suspense` rather than `Show` when loading Graphviz

### DIFF
--- a/frontend/src/visualization/graph_svg.tsx
+++ b/frontend/src/visualization/graph_svg.tsx
@@ -8,22 +8,22 @@ import "./graph_svg.css";
 /** Draw a graph that has a layout using SVG.
  */
 export function GraphSVG<Id>(props: {
-    graph: GraphLayout.Graph<Id>;
+    graph?: GraphLayout.Graph<Id>;
 }) {
     const markerSet = () => {
         const markers = new Set<ArrowMarker>();
-        for (const edge of props.graph.edges) {
+        for (const edge of props.graph?.edges ?? []) {
             markers.add(styleMarkers[edge.style ?? "to"]);
         }
         return markers;
     };
 
     return (
-        <svg class="graph" width={props.graph.width} height={props.graph.height}>
+        <svg class="graph" width={props.graph?.width} height={props.graph?.height}>
             <defs>
                 <For each={Array.from(markerSet())}>{(marker) => markerComponents[marker]}</For>
             </defs>
-            <For each={props.graph.nodes}>
+            <For each={props.graph?.nodes ?? []}>
                 {(node) => {
                     const {
                         pos: { x, y },
@@ -51,7 +51,7 @@ export function GraphSVG<Id>(props: {
                     );
                 }}
             </For>
-            <For each={props.graph.edges}>
+            <For each={props.graph?.edges ?? []}>
                 {(edge) => {
                     const { label, sourcePos, targetPos, labelPos, path } = edge;
                     const marker = styleMarkers[edge.style ?? "to"];

--- a/frontend/src/visualization/graphviz_svg.tsx
+++ b/frontend/src/visualization/graphviz_svg.tsx
@@ -1,5 +1,5 @@
 import type * as Viz from "@viz-js/viz";
-import { type JSX, Show, createResource } from "solid-js";
+import { type JSX, Suspense, createResource } from "solid-js";
 
 import { GraphSVG } from "./graph_svg";
 import { loadViz, parseGraphvizJSON, vizRenderJSON0 } from "./graphviz";
@@ -24,20 +24,19 @@ export function GraphvizSVG(props: {
 
     return (
         <div class="graphviz-container">
-            <Show when={vizResource.loading && props.fallback}>{props.fallback}</Show>
-            <Show when={vizResource()}>
-                <GraphvizOutputSVG graph={render() as GraphvizJSON.Graph} />
-            </Show>
+            <Suspense fallback={props.fallback}>
+                <GraphvizOutputSVG graph={render()} />
+            </Suspense>
         </div>
     );
 }
 
 function GraphvizOutputSVG(props: {
-    graph: GraphvizJSON.Graph;
+    graph?: GraphvizJSON.Graph;
 }) {
     return (
         <div class="graphviz">
-            <GraphSVG graph={parseGraphvizJSON(props.graph)} />
+            <GraphSVG graph={props.graph && parseGraphvizJSON(props.graph)} />
         </div>
     );
 }


### PR DESCRIPTION
This is the recommended approach to partially render the DOM while waiting for resources to become available.