### PR TITLE
Moved release profile settings to top-level Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,7 @@ members = [
     "packages/catlog",
     "packages/catlog-wasm",
 ]
+
+[profile.release]
+# Tell `rustc` to optimize for small code size.
+opt-level = "s"

--- a/packages/catlog-wasm/Cargo.toml
+++ b/packages/catlog-wasm/Cargo.toml
@@ -25,6 +25,3 @@ wasm-bindgen = "0.2.92"
 [dev-dependencies]
 wasm-bindgen-test = "0.3.34"
 
-[profile.release]
-# Tell `rustc` to optimize for small code size.
-opt-level = "s"


### PR DESCRIPTION
The purpose of profiles in Cargo.toml is to configure options for optimizations and debugging in various situations [1]. Profile settings are taken from the top-level Cargo.toml. This makes some sense to me: you want to make sure that all crates are compiled with the same optimization settings for a given profile. If you had different profile settings in different crates, then you might have to rebuild a given crate multiple times with different options.

Specifically, `catlog` would be built without `-opt-level = s` when built for release, but then when `catlog-wasm` built for release, it would rebuild `catlog` with `-opt-level = s`. And even worse, it would rebuild all of catlog's dependencies with `-opt-level = s`.

I can see situations where this would actually be desirable. However, it seems to me like what we *really* want is a "browser" profile setting that applies `-opt-level = "s"`; a release build of `catlog` that is not for the browser shouldn't necessarily have `-opt-level = "s"`. We'll revisit this if we start to use catlog in a non-browser setting and performance is important.

This PR closes #73.