### PR TITLE
Wasm bindings for discrete tabulator theories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "all-the-same"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe9b89a827fde9dfc1f5f9d97e01ad37dde493b2d13560f07f218f11617e0a4"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "archery"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +78,7 @@ dependencies = [
 name = "catlog-wasm"
 version = "0.1.0"
 dependencies = [
+ "all-the-same",
  "catlog",
  "console_error_panic_hook",
  "getrandom",

--- a/packages/catlog-wasm/Cargo.toml
+++ b/packages/catlog-wasm/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
+all-the-same = "1.1.0"
 catlog = { path = "../catlog", features = ["serde-wasm"] }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 getrandom = { version = "0.2", features = ["js"] }

--- a/packages/catlog-wasm/src/model.rs
+++ b/packages/catlog-wasm/src/model.rs
@@ -64,20 +64,24 @@ pub struct DiscreteDblModel(UuidDiscreteDblModel);
 impl DiscreteDblModel {
     /// Creates an empty model of the given theory.
     #[wasm_bindgen(constructor)]
-    pub fn new(theory: &DiscreteDblTheory) -> Self {
+    pub fn new(theory: &DblTheory) -> Self {
         Self(UuidDiscreteDblModel::new(theory.theory.clone()))
     }
 
     /// Adds an object to the model.
     #[wasm_bindgen(js_name = "addOb")]
     pub fn add_ob(&mut self, decl: ObDecl) {
-        self.0.add_ob(decl.id, decl.ob_type.0);
+        // FIXME: Don't just unwrap.
+        let ob_type = decl.ob_type.try_into().unwrap();
+        self.0.add_ob(decl.id, ob_type);
     }
 
     /// Adds a morphism to the model.
     #[wasm_bindgen(js_name = "addMor")]
     pub fn add_mor(&mut self, decl: MorDecl) {
-        self.0.make_mor(decl.id, decl.mor_type.0);
+        // FIXME: Don't just unwrap.
+        let mor_type = decl.mor_type.try_into().unwrap();
+        self.0.make_mor(decl.id, mor_type);
         self.0.update_dom(decl.id, decl.dom);
         self.0.update_cod(decl.id, decl.cod);
     }
@@ -93,7 +97,6 @@ mod tests {
     use super::*;
     use crate::theories::*;
     use catlog::dbl::model::DblModel;
-    use catlog::one::fin_category::FinHom;
 
     #[test]
     fn model_schema() {
@@ -102,15 +105,15 @@ mod tests {
         let y = Uuid::now_v7();
         model.add_ob(ObDecl {
             id: x,
-            ob_type: ObType("entity".into()),
+            ob_type: ObType::Basic("entity".into()),
         });
         model.add_ob(ObDecl {
             id: y,
-            ob_type: ObType("attr_type".into()),
+            ob_type: ObType::Basic("attr_type".into()),
         });
         model.add_mor(MorDecl {
             id: Uuid::now_v7(),
-            mor_type: MorType(FinHom::Generator("attr".into())),
+            mor_type: MorType::Basic("attr".into()),
             dom: Some(x),
             cod: Some(y),
         });

--- a/packages/catlog-wasm/src/model.rs
+++ b/packages/catlog-wasm/src/model.rs
@@ -65,7 +65,10 @@ impl DiscreteDblModel {
     /// Creates an empty model of the given theory.
     #[wasm_bindgen(constructor)]
     pub fn new(theory: &DblTheory) -> Self {
-        Self(UuidDiscreteDblModel::new(theory.theory.clone()))
+        let th = match &theory.theory {
+            DblTheoryWrapper::Discrete(th) => th.clone(),
+        };
+        Self(UuidDiscreteDblModel::new(th))
     }
 
     /// Adds an object to the model.

--- a/packages/catlog-wasm/src/model.rs
+++ b/packages/catlog-wasm/src/model.rs
@@ -67,6 +67,9 @@ impl DiscreteDblModel {
     pub fn new(theory: &DblTheory) -> Self {
         let th = match &theory.theory {
             DblTheoryWrapper::Discrete(th) => th.clone(),
+            DblTheoryWrapper::DiscreteTab(_) => {
+                panic!("Models of discrete tabulator theories not implemented")
+            }
         };
         Self(UuidDiscreteDblModel::new(th))
     }

--- a/packages/catlog-wasm/src/model.rs
+++ b/packages/catlog-wasm/src/model.rs
@@ -11,6 +11,9 @@ use catlog::dbl::model::{self as dbl_model, InvalidDiscreteDblModel};
 use catlog::one::fin_category::UstrFinCategory;
 use catlog::validate::{self, Validate};
 
+#[cfg(test)]
+use catlog::dbl::model::DblModel as BaseDblModel;
+
 /// Identifier of object in model of double theory.
 #[declare]
 pub type ObId = Uuid;
@@ -56,45 +59,76 @@ pub struct DiscreteDblModelErrors(Vec<InvalidDiscreteDblModel<Uuid>>);
 
 type UuidDiscreteDblModel = dbl_model::DiscreteDblModel<Uuid, UstrFinCategory>;
 
-/// Wasm bindings for a model of a discrete double theory.
+/// Wrapper for models of double theories of various kinds.
+#[allow(clippy::large_enum_variant)]
+enum DblModelWrapper {
+    Discrete(UuidDiscreteDblModel),
+    DiscreteTab(()), // Not yet implemented.
+}
+
+/// Wasm bindings for a model of a double theory.
 #[wasm_bindgen]
-pub struct DiscreteDblModel(UuidDiscreteDblModel);
+pub struct DblModel(DblModelWrapper);
 
 #[wasm_bindgen]
-impl DiscreteDblModel {
+impl DblModel {
     /// Creates an empty model of the given theory.
     #[wasm_bindgen(constructor)]
     pub fn new(theory: &DblTheory) -> Self {
-        let th = match &theory.theory {
-            DblTheoryWrapper::Discrete(th) => th.clone(),
-            DblTheoryWrapper::DiscreteTab(_) => {
-                panic!("Models of discrete tabulator theories not implemented")
+        let wrapper = match &theory.theory {
+            DblTheoryWrapper::Discrete(th) => {
+                DblModelWrapper::Discrete(UuidDiscreteDblModel::new(th.clone()))
             }
+            DblTheoryWrapper::DiscreteTab(_) => DblModelWrapper::DiscreteTab(()),
         };
-        Self(UuidDiscreteDblModel::new(th))
+        Self(wrapper)
     }
 
     /// Adds an object to the model.
     #[wasm_bindgen(js_name = "addOb")]
     pub fn add_ob(&mut self, decl: ObDecl) {
-        // FIXME: Don't just unwrap.
-        let ob_type = decl.ob_type.try_into().unwrap();
-        self.0.add_ob(decl.id, ob_type);
+        if let DblModelWrapper::Discrete(model) = &mut self.0 {
+            // FIXME: Don't just unwrap.
+            let ob_type = decl.ob_type.try_into().unwrap();
+            model.add_ob(decl.id, ob_type);
+        }
     }
 
     /// Adds a morphism to the model.
     #[wasm_bindgen(js_name = "addMor")]
     pub fn add_mor(&mut self, decl: MorDecl) {
-        // FIXME: Don't just unwrap.
-        let mor_type = decl.mor_type.try_into().unwrap();
-        self.0.make_mor(decl.id, mor_type);
-        self.0.update_dom(decl.id, decl.dom);
-        self.0.update_cod(decl.id, decl.cod);
+        if let DblModelWrapper::Discrete(model) = &mut self.0 {
+            // FIXME: Don't just unwrap.
+            let mor_type = decl.mor_type.try_into().unwrap();
+            model.make_mor(decl.id, mor_type);
+            model.update_dom(decl.id, decl.dom);
+            model.update_cod(decl.id, decl.cod);
+        }
     }
 
+    /// Validates that the model is well defined.
     #[wasm_bindgen]
     pub fn validate(&self) -> DiscreteDblModelErrors {
-        DiscreteDblModelErrors(validate::unwrap_errors(self.0.validate()))
+        DiscreteDblModelErrors(match &self.0 {
+            DblModelWrapper::Discrete(model) => validate::unwrap_errors(model.validate()),
+            _ => Vec::new(),
+        })
+    }
+
+    #[cfg(test)]
+    fn ob_count(&self) -> usize {
+        match &self.0 {
+            DblModelWrapper::Discrete(model) => model.objects().count(),
+            _ => 0,
+        }
+    }
+
+    #[cfg(test)]
+    fn mor_count(&self) -> usize {
+        match &self.0 {
+            DblModelWrapper::Discrete(model) => model.morphisms().count(),
+            _ => 0,
+        }
     }
 }
 
@@ -102,11 +136,10 @@ impl DiscreteDblModel {
 mod tests {
     use super::*;
     use crate::theories::*;
-    use catlog::dbl::model::DblModel;
 
     #[test]
     fn model_schema() {
-        let mut model = DiscreteDblModel::new(&th_schema());
+        let mut model = DblModel::new(&th_schema());
         let x = Uuid::now_v7();
         let y = Uuid::now_v7();
         model.add_ob(ObDecl {
@@ -123,8 +156,8 @@ mod tests {
             dom: Some(x),
             cod: Some(y),
         });
-        assert_eq!(model.0.objects().count(), 2);
-        assert_eq!(model.0.morphisms().count(), 1);
+        assert_eq!(model.ob_count(), 2);
+        assert_eq!(model.mor_count(), 1);
         assert!(model.validate().0.is_empty());
     }
 }

--- a/packages/catlog-wasm/src/theories.rs
+++ b/packages/catlog-wasm/src/theories.rs
@@ -23,6 +23,12 @@ pub fn th_signed_category() -> DblTheory {
     DblTheory::from_discrete(theories::th_signed_category())
 }
 
+/// The theory of categories with links.
+#[wasm_bindgen(js_name = thCategoryLinks)]
+pub fn th_category_links() -> DblTheory {
+    DblTheory::from_discrete_tabulator(theories::th_category_links())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -35,7 +41,16 @@ mod tests {
         let entity = ObType::Basic(ustr("entity"));
         let attr_type = ObType::Basic(ustr("attr_type"));
         let attr = MorType::Basic(ustr("attr"));
-        assert_eq!(th.src(attr.clone()).unwrap(), entity);
-        assert_eq!(th.tgt(attr).unwrap(), attr_type);
+        assert_eq!(th.src(attr.clone()), Some(entity));
+        assert_eq!(th.tgt(attr), Some(attr_type));
+    }
+
+    #[test]
+    fn discrete_tab_theory() {
+        let th = th_category_links();
+        let x = ObType::Basic(ustr("object"));
+        let link = MorType::Basic(ustr("link"));
+        assert_eq!(th.src(link.clone()), Some(x));
+        assert!(matches!(th.tgt(link), Some(ObType::Tabulator(_))));
     }
 }

--- a/packages/catlog-wasm/src/theories.rs
+++ b/packages/catlog-wasm/src/theories.rs
@@ -1,25 +1,24 @@
 //! Wasm bindings for double theories from the standard library.
 
-use std::sync::Arc;
 use wasm_bindgen::prelude::*;
 
-use super::theory::DiscreteDblTheory;
+use super::theory::DblTheory;
 use catlog::stdlib::theories;
 
 /// The theory of categories.
 #[wasm_bindgen(js_name = thCategory)]
-pub fn th_category() -> DiscreteDblTheory {
-    DiscreteDblTheory::new(Arc::new(theories::th_category()))
+pub fn th_category() -> DblTheory {
+    DblTheory::new(theories::th_category())
 }
 
 /// The theory of database schemas with attributes.
 #[wasm_bindgen(js_name = thSchema)]
-pub fn th_schema() -> DiscreteDblTheory {
-    DiscreteDblTheory::new(Arc::new(theories::th_schema()))
+pub fn th_schema() -> DblTheory {
+    DblTheory::new(theories::th_schema())
 }
 
 /// The theory of signed categories.
 #[wasm_bindgen(js_name = thSignedCategory)]
-pub fn th_signed_category() -> DiscreteDblTheory {
-    DiscreteDblTheory::new(Arc::new(theories::th_signed_category()))
+pub fn th_signed_category() -> DblTheory {
+    DblTheory::new(theories::th_signed_category())
 }

--- a/packages/catlog-wasm/src/theories.rs
+++ b/packages/catlog-wasm/src/theories.rs
@@ -1,4 +1,4 @@
-//! Wasm bindings for double theories from the standard library.
+//! Wasm bindings for double theories from the standard library in `catlog`.
 
 use wasm_bindgen::prelude::*;
 
@@ -8,17 +8,34 @@ use catlog::stdlib::theories;
 /// The theory of categories.
 #[wasm_bindgen(js_name = thCategory)]
 pub fn th_category() -> DblTheory {
-    DblTheory::new(theories::th_category())
+    DblTheory::from_discrete(theories::th_category())
 }
 
 /// The theory of database schemas with attributes.
 #[wasm_bindgen(js_name = thSchema)]
 pub fn th_schema() -> DblTheory {
-    DblTheory::new(theories::th_schema())
+    DblTheory::from_discrete(theories::th_schema())
 }
 
 /// The theory of signed categories.
 #[wasm_bindgen(js_name = thSignedCategory)]
 pub fn th_signed_category() -> DblTheory {
-    DblTheory::new(theories::th_signed_category())
+    DblTheory::from_discrete(theories::th_signed_category())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::theory::*;
+    use ustr::ustr;
+
+    #[test]
+    fn discrete_dbl_theory() {
+        let th = th_schema();
+        let entity = ObType::Basic(ustr("entity"));
+        let attr_type = ObType::Basic(ustr("attr_type"));
+        let attr = MorType::Basic(ustr("attr"));
+        assert_eq!(th.src(attr.clone()).unwrap(), entity);
+        assert_eq!(th.tgt(attr).unwrap(), attr_type);
+    }
 }

--- a/packages/catlog-wasm/src/theory.rs
+++ b/packages/catlog-wasm/src/theory.rs
@@ -12,8 +12,6 @@ use wasm_bindgen::prelude::*;
 use catlog::dbl::theory::{self as dbl_theory, DblTheory};
 use catlog::one::fin_category::*;
 
-type UstrDiscreteDblThy = dbl_theory::DiscreteDblTheory<UstrFinCategory>;
-
 // XXX: It seems like tsify should find the following on its own.
 #[wasm_bindgen]
 extern "C" {
@@ -39,14 +37,14 @@ of hash maps with arbitrary keys in JavaScript.
 */
 #[wasm_bindgen]
 pub struct DiscreteDblTheory {
-    pub(crate) theory: Arc<UstrDiscreteDblThy>,
+    pub(crate) theory: Arc<dbl_theory::UstrDiscreteDblThy>,
     ob_type_index: HashMap<ObType, usize>,
     mor_type_index: HashMap<MorType, usize>,
 }
 
 #[wasm_bindgen]
 impl DiscreteDblTheory {
-    pub(crate) fn new(theory: Arc<UstrDiscreteDblThy>) -> DiscreteDblTheory {
+    pub(crate) fn new(theory: Arc<dbl_theory::UstrDiscreteDblThy>) -> DiscreteDblTheory {
         DiscreteDblTheory {
             theory,
             ob_type_index: Default::default(),

--- a/packages/catlog/src/dbl/theory.rs
+++ b/packages/catlog/src/dbl/theory.rs
@@ -71,15 +71,17 @@ composed:
   - Section 10: Finite-product double theories
 */
 
-use std::hash::{BuildHasher, Hash, RandomState};
+use std::hash::{BuildHasher, BuildHasherDefault, Hash, RandomState};
 
 use derivative::Derivative;
 use derive_more::From;
 use nonempty::nonempty;
 use ref_cast::RefCast;
+use ustr::{IdentityHasher, Ustr};
 
 use super::pasting::DblPasting;
 use crate::one::category::*;
+use crate::one::fin_category::UstrFinCategory;
 use crate::one::path::Path;
 use crate::zero::*;
 
@@ -210,6 +212,9 @@ indeed **discrete**, which can equivalently be defined as
 #[derive(From, RefCast)]
 #[repr(transparent)]
 pub struct DiscreteDblTheory<Cat: FgCategory>(Cat);
+
+/// Discrete double theory with names of the type `Ustr`.
+pub type UstrDiscreteDblThy = DiscreteDblTheory<UstrFinCategory>;
 
 impl<C: FgCategory> DblTheory for DiscreteDblTheory<C>
 where
@@ -346,6 +351,9 @@ pub struct DiscreteTabTheory<V, E, S = RandomState> {
     tgt: HashColumn<E, TabObType<V, E>, S>,
     compose_map: HashColumn<(E, E), TabMorType<V, E>>,
 }
+
+/// Discrete tabulator theory with names of type `Ustr`.
+pub type UstrDiscreteTabThy = DiscreteTabTheory<Ustr, Ustr, BuildHasherDefault<IdentityHasher>>;
 
 impl<V, E, S> DiscreteTabTheory<V, E, S>
 where

--- a/packages/catlog/src/dbl/theory.rs
+++ b/packages/catlog/src/dbl/theory.rs
@@ -214,7 +214,7 @@ indeed **discrete**, which can equivalently be defined as
 pub struct DiscreteDblTheory<Cat: FgCategory>(Cat);
 
 /// Discrete double theory with names of the type `Ustr`.
-pub type UstrDiscreteDblThy = DiscreteDblTheory<UstrFinCategory>;
+pub type UstrDiscreteDblTheory = DiscreteDblTheory<UstrFinCategory>;
 
 impl<C: FgCategory> DblTheory for DiscreteDblTheory<C>
 where
@@ -353,7 +353,7 @@ pub struct DiscreteTabTheory<V, E, S = RandomState> {
 }
 
 /// Discrete tabulator theory with names of type `Ustr`.
-pub type UstrDiscreteTabThy = DiscreteTabTheory<Ustr, Ustr, BuildHasherDefault<IdentityHasher>>;
+pub type UstrDiscreteTabTheory = DiscreteTabTheory<Ustr, Ustr, BuildHasherDefault<IdentityHasher>>;
 
 impl<V, E, S> DiscreteTabTheory<V, E, S>
 where

--- a/packages/catlog/src/dbl/theory.rs
+++ b/packages/catlog/src/dbl/theory.rs
@@ -292,7 +292,7 @@ pub enum TabObType<V, E> {
     /// Basic or generating object type.
     Basic(V),
 
-    /// Object type for the tabulator of a morphism type.
+    /// Tabulator of a morphism type.
     Tabulator(Box<TabMorType<V, E>>),
 }
 

--- a/packages/catlog/src/one/fin_category.rs
+++ b/packages/catlog/src/one/fin_category.rs
@@ -7,11 +7,6 @@ use nonempty::NonEmpty;
 use thiserror::Error;
 use ustr::{IdentityHasher, Ustr};
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-#[cfg(feature = "serde-wasm")]
-use tsify_next::Tsify;
-
 use super::category::*;
 use super::graph::*;
 use super::path::*;
@@ -19,11 +14,7 @@ use crate::validate::{self, Validate};
 use crate::zero::{Column, HashColumn, Mapping};
 
 /// Morphism in a finite category.
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(tag = "tag", content = "content"))]
-#[cfg_attr(feature = "serde-wasm", derive(Tsify))]
-#[cfg_attr(feature = "serde-wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum FinHom<V, E> {
     /// Identity morphism on an object.
     Id(V),

--- a/packages/catlog/src/stdlib/theories.rs
+++ b/packages/catlog/src/stdlib/theories.rs
@@ -1,13 +1,9 @@
 //! Standard library of double theories.
 
-use std::hash::BuildHasherDefault;
-use ustr::{ustr, IdentityHasher, Ustr};
+use ustr::ustr;
 
-use crate::dbl::theory::{DblTheory, DiscreteDblTheory, DiscreteTabTheory, TabObType};
-use crate::one::fin_category::*;
-
-type UstrDiscreteDblThy = DiscreteDblTheory<UstrFinCategory>;
-type UstrDiscreteTabThy = DiscreteTabTheory<Ustr, Ustr, BuildHasherDefault<IdentityHasher>>;
+use crate::dbl::theory::*;
+use crate::one::fin_category::{FinHom, UstrFinCategory};
 
 /** The theory of categories, aka the trivial double theory.
 

--- a/packages/catlog/src/stdlib/theories.rs
+++ b/packages/catlog/src/stdlib/theories.rs
@@ -9,7 +9,7 @@ use crate::one::fin_category::{FinHom, UstrFinCategory};
 
 As a double category, this is the terminal double category.
  */
-pub fn th_category() -> UstrDiscreteDblThy {
+pub fn th_category() -> UstrDiscreteDblTheory {
     let mut cat: UstrFinCategory = Default::default();
     cat.add_ob_generator(ustr("object"));
     DiscreteDblTheory::from(cat)
@@ -19,7 +19,7 @@ pub fn th_category() -> UstrDiscreteDblThy {
 
 As a double category, this is the "walking proarrow".
  */
-pub fn th_schema() -> UstrDiscreteDblThy {
+pub fn th_schema() -> UstrDiscreteDblTheory {
     let mut cat: UstrFinCategory = Default::default();
     let (x, y, p) = (ustr("entity"), ustr("attr_type"), ustr("attr"));
     cat.add_ob_generator(x);
@@ -32,7 +32,7 @@ pub fn th_schema() -> UstrDiscreteDblThy {
 
 A signed category is a category sliced over the group of signs.
  */
-pub fn th_signed_category() -> UstrDiscreteDblThy {
+pub fn th_signed_category() -> UstrDiscreteDblTheory {
     let mut sgn: UstrFinCategory = Default::default();
     let (x, n) = (ustr("object"), ustr("negative"));
     sgn.add_ob_generator(x);
@@ -46,8 +46,8 @@ pub fn th_signed_category() -> UstrDiscreteDblThy {
 A category with links is a category `C` together with a profunctor from `C` to
 `Arr(C)`, the arrow category of C.
  */
-pub fn th_category_links() -> UstrDiscreteTabThy {
-    let mut th: UstrDiscreteTabThy = Default::default();
+pub fn th_category_links() -> UstrDiscreteTabTheory {
+    let mut th: UstrDiscreteTabTheory = Default::default();
     let x = ustr("object");
     th.add_ob_type(x);
     th.add_mor_type(

--- a/packages/frontend/src/model/model_notebook_editor.tsx
+++ b/packages/frontend/src/model/model_notebook_editor.tsx
@@ -15,7 +15,7 @@ import {
 import { useDoc } from "../util/automerge_solid";
 import { type IndexedMap, indexArray, indexMap } from "../util/indexing";
 
-import { DiscreteDblModel, type InvalidDiscreteDblModel, type ObId, type Uuid } from "catlog-wasm";
+import { DblModel, type InvalidDiscreteDblModel, type ObId, type Uuid } from "catlog-wasm";
 import { InlineInput } from "../components";
 import {
     type CellActions,
@@ -127,7 +127,7 @@ export function ModelNotebookEditor(props: {
         let errs: InvalidDiscreteDblModel<Uuid>[] = [];
         const th = theory();
         if (th) {
-            const coreModel = new DiscreteDblModel(th.theory);
+            const coreModel = new DblModel(th.theory);
             for (const judgment of model()) {
                 if (judgment.tag === "object") {
                     coreModel.addOb(judgment);

--- a/packages/frontend/src/theory/theories.ts
+++ b/packages/frontend/src/theory/theories.ts
@@ -22,7 +22,7 @@ const thSimpleOlog = () =>
         types: [
             {
                 tag: "ob_type",
-                obType: "object",
+                obType: { tag: "Basic", content: "object" },
                 name: "Type",
                 description: "Type or class of things",
                 shortcut: ["O"],
@@ -31,7 +31,10 @@ const thSimpleOlog = () =>
             },
             {
                 tag: "mor_type",
-                morType: { tag: "Id", content: "object" },
+                morType: {
+                    tag: "Hom",
+                    content: { tag: "Basic", content: "object" },
+                },
                 name: "Aspect",
                 description: "Aspect or property of a thing",
                 shortcut: ["M"],
@@ -48,7 +51,7 @@ const thSimpleSchema = () =>
         types: [
             {
                 tag: "ob_type",
-                obType: "entity",
+                obType: { tag: "Basic", content: "entity" },
                 name: "Entity",
                 description: "Type of entity or thing",
                 shortcut: ["O"],
@@ -58,7 +61,10 @@ const thSimpleSchema = () =>
             },
             {
                 tag: "mor_type",
-                morType: { tag: "Id", content: "entity" },
+                morType: {
+                    tag: "Hom",
+                    content: { tag: "Basic", content: "entity" },
+                },
                 name: "Mapping",
                 description: "Many-to-one relation between entities",
                 shortcut: ["M"],
@@ -66,7 +72,7 @@ const thSimpleSchema = () =>
             },
             {
                 tag: "mor_type",
-                morType: { tag: "Generator", content: "attr" },
+                morType: { tag: "Basic", content: "attr" },
                 name: "Attribute",
                 description: "Data attribute of an entity",
                 shortcut: ["A"],
@@ -74,14 +80,17 @@ const thSimpleSchema = () =>
             },
             {
                 tag: "ob_type",
-                obType: "attr_type",
+                obType: { tag: "Basic", content: "attr_type" },
                 name: "Attribute type",
                 description: "Data type for an attribute",
                 textClasses: [styles.code],
             },
             {
                 tag: "mor_type",
-                morType: { tag: "Id", content: "attr_type" },
+                morType: {
+                    tag: "Hom",
+                    content: { tag: "Basic", content: "attr_type" },
+                },
                 name: "Operation",
                 description: "Operation on data types for attributes",
                 textClasses: [styles.code],
@@ -98,20 +107,23 @@ const thRegNet = () =>
         types: [
             {
                 tag: "ob_type",
-                obType: "object",
+                obType: { tag: "Basic", content: "object" },
                 name: "Species",
                 description: "Biochemical species in the network",
             },
             {
                 tag: "mor_type",
-                morType: { tag: "Id", content: "object" },
+                morType: {
+                    tag: "Hom",
+                    content: { tag: "Basic", content: "object" },
+                },
                 name: "Promotion",
                 description: "Positive interaction: activates or promotes",
                 arrowStyle: "to",
             },
             {
                 tag: "mor_type",
-                morType: { tag: "Generator", content: "negative" },
+                morType: { tag: "Basic", content: "negative" },
                 name: "Inhibition",
                 description: "Negative interaction: represses or inhibits",
                 arrowStyle: "flat",

--- a/packages/frontend/src/theory/types.ts
+++ b/packages/frontend/src/theory/types.ts
@@ -1,6 +1,6 @@
 import type { KbdKey } from "@solid-primitives/keyboard";
 
-import type { DiscreteDblTheory, MorType, ObType } from "catlog-wasm";
+import type { DblTheory, MorType, ObType } from "catlog-wasm";
 import type { ArrowStyle } from "../visualization/types";
 
 /** A double theory with frontend metadata.
@@ -16,7 +16,7 @@ export class TheoryMeta {
     readonly description?: string;
 
     // The underlying double theory.
-    readonly theory: DiscreteDblTheory;
+    readonly theory: DblTheory;
 
     // Types in theory bound with metadata, to be displayed in this order.
     readonly types: TypeMeta[];
@@ -28,7 +28,7 @@ export class TheoryMeta {
         id: string;
         name: string;
         description?: string;
-        theory: () => DiscreteDblTheory;
+        theory: () => DblTheory;
         types?: TypeMeta[];
         onlyFree?: boolean;
     }) {


### PR DESCRIPTION
Sequel to #76. Closes #77.

To make this work, the PR introduces a new approach for interop between the core and frontend: the frontend has a single data structure for object/morphism types, which are (partially) convertible to/from more specific types in the core.