### PR TITLE
References in docs for `catlog`

### DIFF
--- a/packages/catlog/src/dbl/computad.rs
+++ b/packages/catlog/src/dbl/computad.rs
@@ -852,7 +852,8 @@ mod tests {
 
     #[test]
     fn hash_dbl_computad() {
-        // The signature for monads (Lambert & Patterson 2024, Theory 3.8).
+        // The signature for monads ([Lambert & Patterson
+        // 2024](crate::refs::CartDblTheories), Theory 3.8).
         let mut sig_monad: HashDblComputad<char, char, char, char> = Default::default();
         assert!(sig_monad.add_vertex('x'));
         assert!(sig_monad.add_edge('t', 'x', 'x'));

--- a/packages/catlog/src/dbl/computad.rs
+++ b/packages/catlog/src/dbl/computad.rs
@@ -8,18 +8,12 @@ data that generates a free double category.
 Though the term "double computad" is not standard, it is the obvious analogue
 for double categories of a [2-computad](https://ncatlab.org/nlab/show/computad),
 the generating data for a free 2-category or bicategory. Double computads have
-also been called "double signatures" (Delpeuch 2020, Definition 2.1). They are
-the special case of "double derivation schemes" in which the categories of
-objects and arrows, and of objects and proarrows, are both free categories
-(Fiore et al 2008, Definition 3.3).
-
-# References
-
-- Fiore, Paoli, Pronk, 2008: Model structures on the category of small double
-  categories ([arXiv](https://arxiv.org/abs/0711.0473))
-- Delpeuch, 2020: The word problem for double categories
-  ([arXiv](https://arxiv.org/abs/1907.09927))
-*/
+also been called "double signatures" ([Delpeuch
+2020](crate::refs::WordProblemDblCats), Definition 2.1). They are the special
+case of "double derivation schemes" in which the categories of objects and
+arrows, and of objects and proarrows, are both free categories ([Fiore et al
+2008](crate::refs::ModelStructureDblCat), Definition 3.3).
+ */
 
 use derivative::Derivative;
 use derive_more::From;

--- a/packages/catlog/src/dbl/diagram.rs
+++ b/packages/catlog/src/dbl/diagram.rs
@@ -235,8 +235,8 @@ mod tests {
 
     #[test]
     fn skel_dbl_diagram() {
-        // Formula for general restriction in an equipment (see, for example,
-        // Lambert & Patterson 2024, Equation 4.7).
+        // Formula for general restriction in an equipment ([Lambert & Patterson
+        // 2024](crate::refs::CartDblTheories), Equation 4.7).
         let mut cptd: HashDblComputad<&str, &str, &str, &str> = Default::default();
         cptd.add_vertices(["w", "x", "y", "z"]);
         cptd.add_edge("f", "x", "w");

--- a/packages/catlog/src/dbl/model_morphism.rs
+++ b/packages/catlog/src/dbl/model_morphism.rs
@@ -10,8 +10,12 @@ and between morphisms that are:
 
 In mathematical terms, a model morphism is a natural transformation between lax
 double functors. The natural transformation can be strict, pseudo, lax, or
-oplax. For details, see (Lambert & Patterson 2024, Section 7: Lax
-transformations).
+oplax.
+
+# References
+
+- [Lambert & Patterson 2024](crate::refs::CartDblTheories),
+  Section 7: Lax transformations
  */
 
 use std::hash::Hash;

--- a/packages/catlog/src/dbl/pasting.rs
+++ b/packages/catlog/src/dbl/pasting.rs
@@ -12,17 +12,13 @@ provides little guidance about implementation. We follow the philosophy if not
 the technical details of Makkai in regarding "the notion of *computad*... \[as\]
 nothing but the precise notion of *higher-dimensional categorical diagram*" and
 singling out the pasting diagrams as those diagrams that admit a unique
-top-dimensional composite (Makkai 2005; 2007). Thus, we define a "double pasting
+top-dimensional composite ([Makkai 2005](crate::refs::MakkaiComputads);
+[2007](crate::refs::MakkaiComputadsPasting)). Thus, we define a "double pasting
 diagram" to be a [double diagram](super::diagram) with additional data
 constraining it to have a unique composite cell. This construction seems to be
 original and is unfortunately not yet accompanied by a pasting theorem
 establishing its correctness.
-
-# References
-
-- Makkai, 2005: The word problem for computads
-- Makkai, 2007: Computads and 2-dimensional pasting diagrams
-*/
+ */
 
 use nonempty::NonEmpty;
 

--- a/packages/catlog/src/dbl/theory.rs
+++ b/packages/catlog/src/dbl/theory.rs
@@ -62,13 +62,9 @@ composed:
 
 # References
 
-- Lambert & Patterson, 2024: Cartesian double theories: A double-categorical
-  framework for categorical doctrines
-  ([DOI](https://doi.org/10.1016/j.aim.2024.109630),
-   [arXiv](https://arxiv.org/abs/2310.05384))
-- Patterson, 2024: Products in double categories, revisited
-  ([arXiv](https://arxiv.org/abs/2401.08990))
-  - Section 10: Finite-product double theories
+- [Lambert & Patterson, 2024](crate::refs::CartDblTheories)
+- [Patterson, 2024](crate::refs::DblProducts),
+  Section 10: Finite-product double theories
 */
 
 use std::hash::{BuildHasher, BuildHasherDefault, Hash, RandomState};

--- a/packages/catlog/src/lib.rs
+++ b/packages/catlog/src/lib.rs
@@ -24,6 +24,9 @@ packages.
 #![allow(confusable_idents)]
 #![warn(missing_docs)]
 
+#[cfg(doc)]
+pub mod refs;
+
 pub mod validate;
 
 pub mod dbl;

--- a/packages/catlog/src/refs.rs
+++ b/packages/catlog/src/refs.rs
@@ -1,0 +1,32 @@
+/*! References to the literature (docs only).
+
+This module contains references cited in the docs for this crate. It is only
+built when the crate is compiled with the `doc` feature and is not intended for
+any purpose besides documentation.
+ */
+
+// NOTE: Preferably this data would be recorded in a structured way, e.g., as
+// constant structs of some type `Reference`. This works fine in Rust but it
+// doesn't produce usable docs because rustdoc doesn't display constants except
+// in certain special cases.
+//
+// - https://github.com/rust-lang/rust/pull/98814
+// - https://github.com/rust-lang/rust/issues/98929
+
+/** Reference: Cartesian double theories.
+
+Lambert & Patterson, 2024. Cartesian double theories: A double-categorical
+framework for categorical doctrines.
+
+- [DOI:10.1016/j.aim.2024.109630](https://doi.org/10.1016/j.aim.2024.109630)
+- [arXiv:2310.05384](https://arxiv.org/abs/2310.05384)
+ */
+pub const CartDblTheories: () = ();
+
+/** Reference: Products in double categories, revisited.
+
+Patterson, 2024: Products in double categories, revisited.
+
+- [arXiv:2401.08990](https://arxiv.org/abs/2401.08990)
+ */
+pub const DblProducts: () = ();

--- a/packages/catlog/src/refs.rs
+++ b/packages/catlog/src/refs.rs
@@ -30,3 +30,38 @@ Patterson, 2024: Products in double categories, revisited.
 - [arXiv:2401.08990](https://arxiv.org/abs/2401.08990)
  */
 pub const DblProducts: () = ();
+
+/** Reference: Model structures for double categories.
+
+Fiore, Paoli, Pronk, 2008: Model structures on the category of small double
+categories.
+
+- [DOI:10.2140/agt.2008.8.1855](https://doi.org/10.2140/agt.2008.8.1855)
+- [arXiv:0711.0473](https://arxiv.org/abs/0711.0473)
+ */
+pub const ModelStructureDblCat: () = ();
+
+/** Reference: Word problem for double categories.
+
+Delpeuch, 2020: The word problem for double categories.
+
+- [TAC-35-1](http://www.tac.mta.ca/tac/volumes/35/1/35-01abs.html)
+- [arXiv:1907.09927](https://arxiv.org/abs/1907.09927)
+ */
+pub const WordProblemDblCats: () = ();
+
+/** Reference: Word problem for computads.
+
+Makkai, 2005: The word problem for computads.
+
+<https://www.math.mcgill.ca/makkai/WordProblem/>
+ */
+pub const MakkaiComputads: () = ();
+
+/** Reference: Computads and 2-dimensional pasting diagrams.
+
+Makkai, 2007: Computads and 2-dimensional pasting diagrams.
+
+<https://www.math.mcgill.ca/makkai/2dcomputads/>
+ */
+pub const MakkaiComputadsPasting: () = ();


### PR DESCRIPTION
This approach might seem slightly crazy but the `refs` module is only compiled when the `doc` feature is enabled, so it will not, for example, increase the size of the Wasm bundle.