### PR TITLE
Disable PR comment on release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -155,14 +155,14 @@ jobs:
 
       - name: Generate URL Preview
         id: url_preview
-        if: ${{ env.BRANCH_NAME != 'main' }}
+        if: ${{ env.BRANCH_NAME != 'main' }} && (github.event_name == 'push' || github.event_name == 'pull_request')
         run: |
           NETLIFY_PREVIEW_URL=$(jq -r '.deploy_url' deploy_output.json)
           echo "NETLIFY_PREVIEW_URL=$NETLIFY_PREVIEW_URL" >> "$GITHUB_OUTPUT"
 
       - name: Comment URL Preview on PR
         uses: mshick/add-pr-comment@v2
-        if: ${{ env.BRANCH_NAME != 'main' }}
+        if: ${{ env.BRANCH_NAME != 'main' }} && (github.event_name == 'push' || github.event_name == 'pull_request')
         with:
           message: |
             Preview url: ${{ steps.url_preview.outputs.NETLIFY_PREVIEW_URL }}


### PR DESCRIPTION
# Default TODO list

- [x] Are all notable changes added to the changelog in `dev-docs/`?
- [x] Are there any manual checks that you did while preparing this release that could be automated and become part of the CI?
- [x] Are any relevant issues to the PR mentioned so that they will be automatically closed when the PR merges?
