### PR TITLE
Lazy load double theories in the frontend

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -15,8 +15,6 @@ import { Match, Switch, createResource } from "solid-js";
 const serverHost = import.meta.env.VITE_BACKEND_HOST;
 
 function App() {
-    const theories = stdTheories();
-
     if (!serverHost) {
         throw "Must set environment variable BACKEND_HOST";
     }
@@ -89,7 +87,7 @@ function App() {
                         refId={h().refId}
                         client={client}
                         init={init}
-                        theories={theories}
+                        theories={stdTheories}
                     />
                 )}
             </Match>

--- a/packages/frontend/src/model/model_context.ts
+++ b/packages/frontend/src/model/model_context.ts
@@ -1,12 +1,12 @@
 import { type Accessor, createContext } from "solid-js";
 
 import type { InvalidDiscreteDblModel, Uuid } from "catlog-wasm";
-import type { TheoryMeta } from "../theory";
+import type { Theory } from "../theory";
 import type { IndexedMap } from "../util/indexing";
 
 /** The theory that the model is a model of.
  */
-export const TheoryContext = createContext<Accessor<TheoryMeta | undefined>>();
+export const TheoryContext = createContext<Accessor<Theory | undefined>>();
 
 /** Indexed mapping from object IDs to human-readable names.
  */

--- a/packages/frontend/src/model/model_editor.tsx
+++ b/packages/frontend/src/model/model_editor.tsx
@@ -2,7 +2,7 @@ import type { DocHandle } from "@automerge/automerge-repo";
 import Resizable from "@corvu/resizable";
 import { For, createSignal } from "solid-js";
 
-import type { TheoryId, TheoryMeta } from "../theory";
+import type { TheoryId, Theory } from "../theory";
 import { ModelNotebookEditor, type ModelNotebookRef } from "./model_notebook_editor";
 import type { ModelNotebook } from "./types";
 
@@ -18,7 +18,7 @@ export function ModelEditor(props: {
     init: ModelNotebook;
     client: RPCClient;
     refId: string;
-    theories: Map<TheoryId, TheoryMeta>;
+    theories: Map<TheoryId, Theory>;
 }) {
     const [editorRef, setEditorRef] = createSignal<ModelNotebookRef>();
 

--- a/packages/frontend/src/model/model_editor.tsx
+++ b/packages/frontend/src/model/model_editor.tsx
@@ -2,7 +2,7 @@ import type { DocHandle } from "@automerge/automerge-repo";
 import Resizable from "@corvu/resizable";
 import { For, createSignal } from "solid-js";
 
-import type { TheoryId, Theory } from "../theory";
+import type { TheoryLibrary } from "../stdlib";
 import { ModelNotebookEditor, type ModelNotebookRef } from "./model_notebook_editor";
 import type { ModelNotebook } from "./types";
 
@@ -18,7 +18,7 @@ export function ModelEditor(props: {
     init: ModelNotebook;
     client: RPCClient;
     refId: string;
-    theories: Map<TheoryId, Theory>;
+    theories: TheoryLibrary;
 }) {
     const [editorRef, setEditorRef] = createSignal<ModelNotebookRef>();
 

--- a/packages/frontend/src/model/model_notebook_editor.tsx
+++ b/packages/frontend/src/model/model_notebook_editor.tsx
@@ -24,7 +24,8 @@ import {
     newFormalCell,
     newRichTextCell,
 } from "../notebook";
-import type { TheoryId, Theory } from "../theory";
+import type { TheoryLibrary } from "../stdlib";
+import type { Theory } from "../theory";
 import {
     ModelErrorsContext,
     MorphismIndexContext,
@@ -95,7 +96,7 @@ export type ModelNotebookRef = {
 export function ModelNotebookEditor(props: {
     handle: DocHandle<ModelNotebook>;
     init: ModelNotebook;
-    theories: Map<TheoryId, Theory>;
+    theories: TheoryLibrary;
     ref?: (ref: ModelNotebookRef) => void;
 }) {
     const [theory, setTheory] = createSignal<Theory | undefined>();
@@ -186,8 +187,8 @@ export function ModelNotebookEditor(props: {
                         <option value="" disabled selected hidden>
                             Choose a logic
                         </option>
-                        <For each={Array.from(props.theories.values())}>
-                            {(theory) => <option value={theory.id}>{theory.name}</option>}
+                        <For each={Array.from(props.theories.metadata())}>
+                            {(meta) => <option value={meta.id}>{meta.name}</option>}
                         </For>
                     </select>
                 </div>

--- a/packages/frontend/src/model/model_notebook_editor.tsx
+++ b/packages/frontend/src/model/model_notebook_editor.tsx
@@ -24,7 +24,7 @@ import {
     newFormalCell,
     newRichTextCell,
 } from "../notebook";
-import type { TheoryId, TheoryMeta } from "../theory";
+import type { TheoryId, Theory } from "../theory";
 import {
     ModelErrorsContext,
     MorphismIndexContext,
@@ -84,7 +84,7 @@ export type ModelNotebookRef = {
     model: Accessor<Array<ModelJudgment>>;
 
     // Get the double theory that the model is of, if it is defined.
-    theory: Accessor<TheoryMeta | undefined>;
+    theory: Accessor<Theory | undefined>;
 
     // Get the `catlog` model object, if it is valid.
     validatedModel: Accessor<DblModel | null>;
@@ -95,10 +95,10 @@ export type ModelNotebookRef = {
 export function ModelNotebookEditor(props: {
     handle: DocHandle<ModelNotebook>;
     init: ModelNotebook;
-    theories: Map<TheoryId, TheoryMeta>;
+    theories: Map<TheoryId, Theory>;
     ref?: (ref: ModelNotebookRef) => void;
 }) {
-    const [theory, setTheory] = createSignal<TheoryMeta | undefined>();
+    const [theory, setTheory] = createSignal<Theory | undefined>();
 
     const [modelNb, changeModelNb] = useDoc(() => props.handle, props.init);
 
@@ -228,7 +228,7 @@ function judgmentType(judgment: ModelJudgment): string | undefined {
 
 type ModelCellConstructor = CellConstructor<ModelJudgment>;
 
-function modelCellConstructors(theory?: TheoryMeta): ModelCellConstructor[] {
+function modelCellConstructors(theory?: Theory): ModelCellConstructor[] {
     // On Mac, the Alt/Option key remaps keys, whereas on other platforms
     // Control tends to be already bound in other shortcuts.
     const modifier = navigator.userAgent.includes("Mac") ? "Control" : "Alt";

--- a/packages/frontend/src/model/object_input.tsx
+++ b/packages/frontend/src/model/object_input.tsx
@@ -3,7 +3,7 @@ import { Dynamic } from "solid-js/web";
 import { P, match } from "ts-pattern";
 
 import type { Ob, ObType } from "catlog-wasm";
-import type { TheoryMeta } from "../theory";
+import type { Theory } from "../theory";
 import { IdInput, type IdInputOptions } from "./id_input";
 import { MorphismIndexContext, ObjectIndexContext, TheoryContext } from "./model_context";
 
@@ -73,7 +73,7 @@ function BasicObInput(
     );
 }
 
-export function obClasses(theory: TheoryMeta | undefined, typ?: ObType): string[] {
+export function obClasses(theory: Theory | undefined, typ?: ObType): string[] {
     const typeMeta = typ ? theory?.getObTypeMeta(typ) : undefined;
     return [...(typeMeta?.cssClasses ?? []), ...(typeMeta?.textClasses ?? [])];
 }

--- a/packages/frontend/src/stdlib/index.ts
+++ b/packages/frontend/src/stdlib/index.ts
@@ -7,4 +7,5 @@ at present this is the complete set of logics available in the application.
 @module
  */
 
+export * from "./types";
 export { stdTheories } from "./theories";

--- a/packages/frontend/src/stdlib/theories.tsx
+++ b/packages/frontend/src/stdlib/theories.tsx
@@ -1,6 +1,6 @@
 import * as catlog from "catlog-wasm";
 
-import { TheoryMeta } from "../theory";
+import { Theory } from "../theory";
 import { uniqueIndexArray } from "../util/indexing";
 import { ModelGraphviz, StockFlowDiagram, SubmodelsGraphviz } from "./views";
 
@@ -19,7 +19,7 @@ export const stdTheories = () =>
 
 const thSimpleOlog = () => {
     const thCategory = new catlog.ThCategory();
-    return new TheoryMeta({
+    return new Theory({
         id: "simple-olog",
         name: "Olog",
         description: "Ontology log, a simple conceptual model",
@@ -57,7 +57,7 @@ const thSimpleOlog = () => {
 
 const thSimpleSchema = () => {
     const thSchema = new catlog.ThSchema();
-    return new TheoryMeta({
+    return new Theory({
         id: "schema",
         name: "Schema",
         description: "Schema for a categorical database",
@@ -122,7 +122,7 @@ const thSimpleSchema = () => {
 
 const thRegNet = () => {
     const thSignedCategory = new catlog.ThSignedCategory();
-    return new TheoryMeta({
+    return new Theory({
         id: "reg-net",
         name: "Regulatory network",
         theory: thSignedCategory.theory(),
@@ -174,7 +174,7 @@ const thCausalLoop = () => {
     const negativeLoops = (model: catlog.DblModel | null) =>
         model ? thSignedCategory.negativeLoops(model) : [];
 
-    return new TheoryMeta({
+    return new Theory({
         id: "causal-loop",
         name: "Causal loop diagram",
         theory: thSignedCategory.theory(),
@@ -258,7 +258,7 @@ const loopGraphvizConfig = {
 
 const thStockFlow = () => {
     const thCategoryLinks = new catlog.ThCategoryLinks();
-    return new TheoryMeta({
+    return new Theory({
         id: "stock-flow",
         name: "Stock and flow",
         theory: thCategoryLinks.theory(),

--- a/packages/frontend/src/stdlib/theories.tsx
+++ b/packages/frontend/src/stdlib/theories.tsx
@@ -1,249 +1,261 @@
 import * as catlog from "catlog-wasm";
 
 import { Theory } from "../theory";
-import { uniqueIndexArray } from "../util/indexing";
+import { TheoryLibrary } from "./types";
 import { ModelGraphviz, StockFlowDiagram, SubmodelsGraphviz } from "./views";
 
 import styles from "./styles.module.css";
 import svgStyles from "./svg_styles.module.css";
 
-/** Standard library of double theories supported by frontend.
+/** Standard library of double theories supported by the frontend. */
+export const stdTheories = new TheoryLibrary();
 
-TODO: the theories be lazily constructed apart from top-level metadata.
- */
-export const stdTheories = () =>
-    uniqueIndexArray(
-        [thSimpleOlog(), thSimpleSchema(), thRegNet(), thCausalLoop(), thStockFlow()],
-        (th) => th.id,
-    );
-
-const thSimpleOlog = () => {
-    const thCategory = new catlog.ThCategory();
-    return new Theory({
+stdTheories.add(
+    {
         id: "simple-olog",
         name: "Olog",
         description: "Ontology log, a simple conceptual model",
-        theory: thCategory.theory(),
-        types: [
-            {
-                tag: "ObType",
-                obType: { tag: "Basic", content: "Object" },
-                name: "Type",
-                description: "Type or class of things",
-                shortcut: ["O"],
-                cssClasses: [styles["corner-box"]],
-                svgClasses: [svgStyles.box],
-            },
-            {
-                tag: "MorType",
-                morType: {
-                    tag: "Hom",
-                    content: { tag: "Basic", content: "Object" },
+    },
+    (meta) => {
+        const thCategory = new catlog.ThCategory();
+        return new Theory({
+            ...meta,
+            theory: thCategory.theory(),
+            types: [
+                {
+                    tag: "ObType",
+                    obType: { tag: "Basic", content: "Object" },
+                    name: "Type",
+                    description: "Type or class of things",
+                    shortcut: ["O"],
+                    cssClasses: [styles["corner-box"]],
+                    svgClasses: [svgStyles.box],
                 },
-                name: "Aspect",
-                description: "Aspect or property of a thing",
-                shortcut: ["M"],
-            },
-        ],
-        modelViews: [
-            {
-                name: "Diagram",
-                description: "Visualize the olog as a diagram",
-                component: ModelGraphviz,
-            },
-        ],
-    });
-};
+                {
+                    tag: "MorType",
+                    morType: {
+                        tag: "Hom",
+                        content: { tag: "Basic", content: "Object" },
+                    },
+                    name: "Aspect",
+                    description: "Aspect or property of a thing",
+                    shortcut: ["M"],
+                },
+            ],
+            modelViews: [
+                {
+                    name: "Diagram",
+                    description: "Visualize the olog as a diagram",
+                    component: ModelGraphviz,
+                },
+            ],
+        });
+    },
+);
 
-const thSimpleSchema = () => {
-    const thSchema = new catlog.ThSchema();
-    return new Theory({
+stdTheories.add(
+    {
         id: "schema",
         name: "Schema",
         description: "Schema for a categorical database",
-        theory: thSchema.theory(),
-        types: [
-            {
-                tag: "ObType",
-                obType: { tag: "Basic", content: "Entity" },
-                name: "Entity",
-                description: "Type of entity or thing",
-                shortcut: ["O"],
-                cssClasses: [styles.box],
-                svgClasses: [svgStyles.box],
-                textClasses: [styles.code],
-            },
-            {
-                tag: "MorType",
-                morType: {
-                    tag: "Hom",
-                    content: { tag: "Basic", content: "Entity" },
+    },
+    (meta) => {
+        const thSchema = new catlog.ThSchema();
+        return new Theory({
+            ...meta,
+            theory: thSchema.theory(),
+            types: [
+                {
+                    tag: "ObType",
+                    obType: { tag: "Basic", content: "Entity" },
+                    name: "Entity",
+                    description: "Type of entity or thing",
+                    shortcut: ["O"],
+                    cssClasses: [styles.box],
+                    svgClasses: [svgStyles.box],
+                    textClasses: [styles.code],
                 },
-                name: "Mapping",
-                description: "Many-to-one relation between entities",
-                shortcut: ["M"],
-                textClasses: [styles.code],
-            },
-            {
-                tag: "MorType",
-                morType: { tag: "Basic", content: "Attr" },
-                name: "Attribute",
-                description: "Data attribute of an entity",
-                shortcut: ["A"],
-                textClasses: [styles.code],
-            },
-            {
-                tag: "ObType",
-                obType: { tag: "Basic", content: "AttrType" },
-                name: "Attribute type",
-                description: "Data type for an attribute",
-                textClasses: [styles.code],
-            },
-            {
-                tag: "MorType",
-                morType: {
-                    tag: "Hom",
-                    content: { tag: "Basic", content: "AttrType" },
+                {
+                    tag: "MorType",
+                    morType: {
+                        tag: "Hom",
+                        content: { tag: "Basic", content: "Entity" },
+                    },
+                    name: "Mapping",
+                    description: "Many-to-one relation between entities",
+                    shortcut: ["M"],
+                    textClasses: [styles.code],
                 },
-                name: "Operation",
-                description: "Operation on data types for attributes",
-                textClasses: [styles.code],
-            },
-        ],
-        modelViews: [
-            {
-                name: "Diagram",
-                description: "Visualize the schema as a diagram",
-                component: ModelGraphviz,
-            },
-        ],
-    });
-};
+                {
+                    tag: "MorType",
+                    morType: { tag: "Basic", content: "Attr" },
+                    name: "Attribute",
+                    description: "Data attribute of an entity",
+                    shortcut: ["A"],
+                    textClasses: [styles.code],
+                },
+                {
+                    tag: "ObType",
+                    obType: { tag: "Basic", content: "AttrType" },
+                    name: "Attribute type",
+                    description: "Data type for an attribute",
+                    textClasses: [styles.code],
+                },
+                {
+                    tag: "MorType",
+                    morType: {
+                        tag: "Hom",
+                        content: { tag: "Basic", content: "AttrType" },
+                    },
+                    name: "Operation",
+                    description: "Operation on data types for attributes",
+                    textClasses: [styles.code],
+                },
+            ],
+            modelViews: [
+                {
+                    name: "Diagram",
+                    description: "Visualize the schema as a diagram",
+                    component: ModelGraphviz,
+                },
+            ],
+        });
+    },
+);
 
-const thRegNet = () => {
-    const thSignedCategory = new catlog.ThSignedCategory();
-    return new Theory({
+stdTheories.add(
+    {
         id: "reg-net",
         name: "Regulatory network",
-        theory: thSignedCategory.theory(),
-        onlyFreeModels: true,
-        types: [
-            {
-                tag: "ObType",
-                obType: { tag: "Basic", content: "Object" },
-                name: "Species",
-                shortcut: ["S"],
-                description: "Biochemical species in the network",
-            },
-            {
-                tag: "MorType",
-                morType: {
-                    tag: "Hom",
-                    content: { tag: "Basic", content: "Object" },
+    },
+    (meta) => {
+        const thSignedCategory = new catlog.ThSignedCategory();
+        return new Theory({
+            ...meta,
+            theory: thSignedCategory.theory(),
+            onlyFreeModels: true,
+            types: [
+                {
+                    tag: "ObType",
+                    obType: { tag: "Basic", content: "Object" },
+                    name: "Species",
+                    shortcut: ["S"],
+                    description: "Biochemical species in the network",
                 },
-                name: "Promotion",
-                shortcut: ["P"],
-                description: "Positive interaction: activates or promotes",
-                preferUnnamed: true,
-            },
-            {
-                tag: "MorType",
-                morType: { tag: "Basic", content: "Negative" },
-                name: "Inhibition",
-                shortcut: ["I"],
-                description: "Negative interaction: represses or inhibits",
-                arrowStyle: "flat",
-                preferUnnamed: true,
-            },
-        ],
-        modelViews: [
-            {
-                name: "Network",
-                description: "Visualize the regulatory network",
-                component: ModelGraphviz,
-            },
-        ],
-    });
-};
+                {
+                    tag: "MorType",
+                    morType: {
+                        tag: "Hom",
+                        content: { tag: "Basic", content: "Object" },
+                    },
+                    name: "Promotion",
+                    shortcut: ["P"],
+                    description: "Positive interaction: activates or promotes",
+                    preferUnnamed: true,
+                },
+                {
+                    tag: "MorType",
+                    morType: { tag: "Basic", content: "Negative" },
+                    name: "Inhibition",
+                    shortcut: ["I"],
+                    description: "Negative interaction: represses or inhibits",
+                    arrowStyle: "flat",
+                    preferUnnamed: true,
+                },
+            ],
+            modelViews: [
+                {
+                    name: "Network",
+                    description: "Visualize the regulatory network",
+                    component: ModelGraphviz,
+                },
+            ],
+        });
+    },
+);
 
-const thCausalLoop = () => {
-    const thSignedCategory = new catlog.ThSignedCategory();
-
-    const positiveLoops = (model: catlog.DblModel | null) =>
-        model ? thSignedCategory.positiveLoops(model) : [];
-    const negativeLoops = (model: catlog.DblModel | null) =>
-        model ? thSignedCategory.negativeLoops(model) : [];
-
-    return new Theory({
+stdTheories.add(
+    {
         id: "causal-loop",
         name: "Causal loop diagram",
-        theory: thSignedCategory.theory(),
-        onlyFreeModels: true,
-        types: [
-            {
-                tag: "ObType",
-                obType: { tag: "Basic", content: "Object" },
-                name: "Variable",
-                shortcut: ["V"],
-                description: "Variable quantity",
-            },
-            {
-                tag: "MorType",
-                morType: {
-                    tag: "Hom",
-                    content: { tag: "Basic", content: "Object" },
+    },
+    (meta) => {
+        const thSignedCategory = new catlog.ThSignedCategory();
+        const positiveLoops = (model: catlog.DblModel | null) =>
+            model ? thSignedCategory.positiveLoops(model) : [];
+        const negativeLoops = (model: catlog.DblModel | null) =>
+            model ? thSignedCategory.negativeLoops(model) : [];
+
+        return new Theory({
+            ...meta,
+            theory: thSignedCategory.theory(),
+            onlyFreeModels: true,
+            types: [
+                {
+                    tag: "ObType",
+                    obType: { tag: "Basic", content: "Object" },
+                    name: "Variable",
+                    shortcut: ["V"],
+                    description: "Variable quantity",
                 },
-                name: "Positive link",
-                shortcut: ["P"],
-                description: "Variables change in the same direction",
-                arrowStyle: "plus",
-                preferUnnamed: true,
-            },
-            {
-                tag: "MorType",
-                morType: { tag: "Basic", content: "Negative" },
-                name: "Negative link",
-                shortcut: ["N"],
-                description: "Variables change in the opposite direction",
-                arrowStyle: "minus",
-                preferUnnamed: true,
-            },
-        ],
-        modelViews: [
-            {
-                name: "Diagram",
-                description: "Visualize the causal loop diagram",
-                component: ModelGraphviz,
-            },
-            {
-                name: "Balancing loops",
-                description: "Analyze the diagram for balancing loops",
-                component: (props) => (
-                    <SubmodelsGraphviz
-                        title="Balancing loops"
-                        model={props.model}
-                        submodels={negativeLoops(props.validatedModel)}
-                        theory={props.theory}
-                        {...loopGraphvizConfig}
-                    />
-                ),
-            },
-            {
-                name: "Reinforcing loops",
-                description: "Analyze the diagram for reinforcing loops",
-                component: (props) => (
-                    <SubmodelsGraphviz
-                        title="Reinforcing loops"
-                        model={props.model}
-                        submodels={positiveLoops(props.validatedModel)}
-                        theory={props.theory}
-                        {...loopGraphvizConfig}
-                    />
-                ),
-            },
-        ],
-    });
-};
+                {
+                    tag: "MorType",
+                    morType: {
+                        tag: "Hom",
+                        content: { tag: "Basic", content: "Object" },
+                    },
+                    name: "Positive link",
+                    shortcut: ["P"],
+                    description: "Variables change in the same direction",
+                    arrowStyle: "plus",
+                    preferUnnamed: true,
+                },
+                {
+                    tag: "MorType",
+                    morType: { tag: "Basic", content: "Negative" },
+                    name: "Negative link",
+                    shortcut: ["N"],
+                    description: "Variables change in the opposite direction",
+                    arrowStyle: "minus",
+                    preferUnnamed: true,
+                },
+            ],
+            modelViews: [
+                {
+                    name: "Diagram",
+                    description: "Visualize the causal loop diagram",
+                    component: ModelGraphviz,
+                },
+                {
+                    name: "Balancing loops",
+                    description: "Analyze the diagram for balancing loops",
+                    component: (props) => (
+                        <SubmodelsGraphviz
+                            title="Balancing loops"
+                            model={props.model}
+                            submodels={negativeLoops(props.validatedModel)}
+                            theory={props.theory}
+                            {...loopGraphvizConfig}
+                        />
+                    ),
+                },
+                {
+                    name: "Reinforcing loops",
+                    description: "Analyze the diagram for reinforcing loops",
+                    component: (props) => (
+                        <SubmodelsGraphviz
+                            title="Reinforcing loops"
+                            model={props.model}
+                            submodels={positiveLoops(props.validatedModel)}
+                            theory={props.theory}
+                            {...loopGraphvizConfig}
+                        />
+                    ),
+                },
+            ],
+        });
+    },
+);
 
 const loopGraphvizConfig = {
     options: {
@@ -256,49 +268,54 @@ const loopGraphvizConfig = {
     },
 };
 
-const thStockFlow = () => {
-    const thCategoryLinks = new catlog.ThCategoryLinks();
-    return new Theory({
+stdTheories.add(
+    {
         id: "stock-flow",
         name: "Stock and flow",
-        theory: thCategoryLinks.theory(),
-        onlyFreeModels: true,
-        types: [
-            {
-                tag: "ObType",
-                obType: { tag: "Basic", content: "Object" },
-                name: "Stock",
-                description: "Thing with an amount",
-                shortcut: ["S"],
-                cssClasses: [styles.box],
-                svgClasses: [svgStyles.box],
-            },
-            {
-                tag: "MorType",
-                morType: {
-                    tag: "Hom",
-                    content: { tag: "Basic", content: "Object" },
+    },
+    (meta) => {
+        const thCategoryLinks = new catlog.ThCategoryLinks();
+        return new Theory({
+            ...meta,
+            theory: thCategoryLinks.theory(),
+            onlyFreeModels: true,
+            types: [
+                {
+                    tag: "ObType",
+                    obType: { tag: "Basic", content: "Object" },
+                    name: "Stock",
+                    description: "Thing with an amount",
+                    shortcut: ["S"],
+                    cssClasses: [styles.box],
+                    svgClasses: [svgStyles.box],
                 },
-                name: "Flow",
-                description: "Flow from one stock to another",
-                shortcut: ["F"],
-                arrowStyle: "double",
-            },
-            {
-                tag: "MorType",
-                morType: { tag: "Basic", content: "Link" },
-                name: "Link",
-                description: "Influence of a stock on a flow",
-                preferUnnamed: true,
-                shortcut: ["L"],
-            },
-        ],
-        modelViews: [
-            {
-                name: "Diagram",
-                description: "Visualize the stock and flow diagram",
-                component: StockFlowDiagram,
-            },
-        ],
-    });
-};
+                {
+                    tag: "MorType",
+                    morType: {
+                        tag: "Hom",
+                        content: { tag: "Basic", content: "Object" },
+                    },
+                    name: "Flow",
+                    description: "Flow from one stock to another",
+                    shortcut: ["F"],
+                    arrowStyle: "double",
+                },
+                {
+                    tag: "MorType",
+                    morType: { tag: "Basic", content: "Link" },
+                    name: "Link",
+                    description: "Influence of a stock on a flow",
+                    preferUnnamed: true,
+                    shortcut: ["L"],
+                },
+            ],
+            modelViews: [
+                {
+                    name: "Diagram",
+                    description: "Visualize the stock and flow diagram",
+                    component: StockFlowDiagram,
+                },
+            ],
+        });
+    },
+);

--- a/packages/frontend/src/stdlib/types.ts
+++ b/packages/frontend/src/stdlib/types.ts
@@ -1,0 +1,63 @@
+import { Theory, type TheoryId } from "../theory";
+
+/** Frontend metadata for a double theory.
+
+Does not contain the data of the theory but contains enough information to
+identify the theory and display it to the user.
+ */
+export type TheoryMeta = {
+    /** Unique identifier of theory. */
+    id: TheoryId;
+
+    /** Human-readable name for models of theory. */
+    name: string;
+
+    /** Short description of models of theory. */
+    description?: string;
+};
+
+/** Library of double theories configured for the frontend.
+
+Theories are lazy loaded.
+ */
+export class TheoryLibrary {
+    private readonly metaMap: Map<TheoryId, TheoryMeta>;
+    private readonly theoryMap: Map<TheoryId, Theory | ((meta: TheoryMeta) => Theory)>;
+
+    constructor() {
+        this.metaMap = new Map();
+        this.theoryMap = new Map();
+    }
+
+    /** Add a theory to the library. */
+    add(meta: TheoryMeta, cons: (meta: TheoryMeta) => Theory) {
+        if (this.metaMap.has(meta.id)) {
+            throw Error(`Theory with ID ${meta.id} already defined`);
+        }
+        this.metaMap.set(meta.id, meta);
+        this.theoryMap.set(meta.id, cons);
+    }
+
+    /** Get a theory by ID.
+
+    A theory is instantiated and cached the first time it is retrieved.
+     */
+    get(id: TheoryId): Theory {
+        const meta = this.metaMap.get(id);
+        const theoryOrCons = this.theoryMap.get(id);
+        if (meta === undefined || theoryOrCons === undefined) {
+            throw Error(`No theory with ID ${id}`);
+        } else if (theoryOrCons instanceof Theory) {
+            return theoryOrCons;
+        } else {
+            const theory = theoryOrCons(meta);
+            this.theoryMap.set(id, theory);
+            return theory;
+        }
+    }
+
+    /** Iterator over metadata for available theories. */
+    metadata(): IterableIterator<TheoryMeta> {
+        return this.metaMap.values();
+    }
+}

--- a/packages/frontend/src/stdlib/views/model_graph.tsx
+++ b/packages/frontend/src/stdlib/views/model_graph.tsx
@@ -1,7 +1,7 @@
 import type * as Viz from "@viz-js/viz";
 
 import type { ModelJudgment } from "../../model";
-import type { TheoryMeta, TypeMeta } from "../../theory";
+import type { Theory, TypeMeta } from "../../theory";
 import { GraphvizSVG } from "../../visualization";
 
 import styles from "../styles.module.css";
@@ -10,7 +10,7 @@ import styles from "../styles.module.css";
  */
 export function ModelGraphviz(props: {
     model: Array<ModelJudgment>;
-    theory: TheoryMeta;
+    theory: Theory;
     attributes?: GraphvizAttributes;
     options?: Viz.RenderOptions;
 }) {
@@ -30,7 +30,7 @@ morphism whose domain or codomain is not a basic object will be ignored.
  */
 export function modelToGraphviz(
     model: Array<ModelJudgment>,
-    theory: TheoryMeta,
+    theory: Theory,
     attributes?: GraphvizAttributes,
 ): Viz.Graph {
     const nodes = [];

--- a/packages/frontend/src/stdlib/views/stock_flow_diagram.tsx
+++ b/packages/frontend/src/stdlib/views/stock_flow_diagram.tsx
@@ -3,7 +3,7 @@ import { type Component, For, createResource } from "solid-js";
 import { P, match } from "ts-pattern";
 
 import type { ModelJudgment } from "../../model";
-import type { TheoryMeta } from "../../theory";
+import type { Theory } from "../../theory";
 import { uniqueIndexArray } from "../../util/indexing";
 import {
     type ArrowMarker,
@@ -23,7 +23,7 @@ links from stocks to flows using our own layout heuristics.
  */
 export function StockFlowDiagram(props: {
     model: Array<ModelJudgment>;
-    theory: TheoryMeta;
+    theory: Theory;
     vizOptions?: Viz.RenderOptions;
 }) {
     const [vizResource] = createResource(loadViz);

--- a/packages/frontend/src/stdlib/views/submodel_graphs.tsx
+++ b/packages/frontend/src/stdlib/views/submodel_graphs.tsx
@@ -6,7 +6,7 @@ import { Show, createSignal } from "solid-js";
 import type { DblModel } from "catlog-wasm";
 import { IconButton } from "../../components";
 import type { ModelJudgment } from "../../model";
-import type { TheoryMeta } from "../../theory";
+import type { Theory } from "../../theory";
 import { type GraphvizAttributes, ModelGraphviz } from "./model_graph";
 
 import "./submodel_graphs.css";
@@ -16,7 +16,7 @@ import "./submodel_graphs.css";
 export function SubmodelsGraphviz(props: {
     model: Array<ModelJudgment>;
     submodels: Array<DblModel>;
-    theory: TheoryMeta;
+    theory: Theory;
     title?: string;
     attributes?: GraphvizAttributes;
     options?: Viz.RenderOptions;

--- a/packages/frontend/src/theory/types.ts
+++ b/packages/frontend/src/theory/types.ts
@@ -6,9 +6,9 @@ import { MorTypeIndex, ObTypeIndex } from "catlog-wasm";
 import type { ModelJudgment } from "../model";
 import type { ArrowStyle } from "../visualization/types";
 
-/** A double theory equipped with metadata for use in frontend.
+/** A double theory configured for use in the frontend.
  */
-export class TheoryMeta {
+export class Theory {
     /** Unique identifier of theory. */
     readonly id: TheoryId;
 
@@ -167,7 +167,7 @@ export type ModelViewProps = {
     The theory may well be assumed fixed for certain views but it is passed
     regardless.
      */
-    theory: TheoryMeta;
+    theory: Theory;
 
     /** The `catlog` model object, if it is valid. */
     validatedModel: DblModel | null;


### PR DESCRIPTION
The construction and configuration of the `catlog` theory is deferred until the first time the theory is accessed.

This change is invisible to the user but should help keep load times short as the list of theories grows (which it should substantially).