### PR TITLE
Indicate minimum Rust version in Cargo.toml

### DIFF
--- a/packages/catlog/Cargo.toml
+++ b/packages/catlog/Cargo.toml
@@ -4,6 +4,7 @@ description = "A toolbox for catgorical logic based on double theories"
 authors = ["Evan Patterson"]
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.76"
 
 [features]
 serde = ["dep:serde", "nonempty/serialize", "ustr/serde"]


### PR DESCRIPTION
It turns out we are using a standard library import not introduced until [Rust v1.76](https://blog.rust-lang.org/2024/02/08/Rust-1.76.0.html). See the discussion in #131 where this problem was reported.