### PR TITLE
Add missing readme step, correct server error

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ An early demo is available at <https://catcolab.org>.
 The staging deployment, synced to the `main` branch, is available at <https://next.catcolab.org>.
 Documentation for developers is browsable at <https://next.catcolab.org/dev/>.
 
-To build locally, clone the repository and run
+To build locally, given you have npm and Rust installed, clone the repository and run
 
 ```bash
 > npm install
+> export VITE_BACKEND_HOST=backend-next.catcolab.org
 > npm run build
 > npm run dev
 ```

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -16,7 +16,7 @@ const serverHost = import.meta.env.VITE_BACKEND_HOST;
 
 function App() {
     if (!serverHost) {
-        throw "Must set environment variable BACKEND_HOST";
+        throw "Must set environment variable VITE_BACKEND_HOST";
     }
 
     const http_url = `https://${serverHost}`;


### PR DESCRIPTION
The error when somebody forgets to configure `VITE_BACKEND_HOST` was misspelling the relevant environment variable. I also added this step to the readme.


# Default TODO list

- [x ] Are all notable changes added to the changelog in `dev-docs/`?
- [ x] Are there any manual checks that you did while preparing this release that could be automated and become part of the CI?
- [x ] Are any relevant issues to the PR mentioned so that they will be automatically closed when the PR merges?
