### PR TITLE
Add indicator to "choose logic" dropdown

### DIFF
--- a/packages/frontend/src/model/model_notebook_editor.tsx
+++ b/packages/frontend/src/model/model_notebook_editor.tsx
@@ -163,7 +163,7 @@ export function ModelNotebookEditor(props: {
                         }}
                     >
                         <option value="" disabled selected hidden>
-                            Choose a logic
+                            Choose a logic ▼
                         </option>
                         <For each={Array.from(props.theories.metadata())}>
                             {(meta) => <option value={meta.id}>{meta.name}</option>}

--- a/packages/frontend/src/model/model_notebook_editor.tsx
+++ b/packages/frontend/src/model/model_notebook_editor.tsx
@@ -163,7 +163,7 @@ export function ModelNotebookEditor(props: {
                         }}
                     >
                         <option value="" disabled selected hidden>
-                            Choose a logic ▼
+                            Choose a logic ▾
                         </option>
                         <For each={Array.from(props.theories.metadata())}>
                             {(meta) => <option value={meta.id}>{meta.name}</option>}


### PR DESCRIPTION
Description: Added an upside-down caret (▼) next to the "Choose a logic" label in the ModelNotebookEditor component to indicate a dropdown menu.

- [N/A] Are all notable changes added to the changelog in `dev-docs/`?
- [N/A] Are there any manual checks that you did while preparing this release that could be automated and become part of the CI?
- [x] Are any relevant issues to the PR mentioned so that they will be automatically closed when the PR merges?
