### PR TITLE
Disable netlify deploy for external PR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,6 +110,7 @@ jobs:
     name: Deploy to netlify
     runs-on: ubuntu-latest
     needs: [build_dev-docs, build_frontend, build_rust_docs]
+    if: github.event.pull_request.head.repo.full_name == 'ToposInstitute/CatColab'
     steps:
       - name: Repository Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
When an external contributor makes a pull request, we should not attempt to deploy to netlify because it will inevitably fail. Closes #146. 

# Default TODO list

- [x] Are all notable changes added to the changelog in `dev-docs/`?
- [x] Are there any manual checks that you did while preparing this release that could be automated and become part of the CI?
- [x] Are any relevant issues to the PR mentioned so that they will be automatically closed when the PR merges?
