### PR TITLE
Find feedback loops in regulatory networks

### DIFF
--- a/packages/frontend/src/stdlib/theories.tsx
+++ b/packages/frontend/src/stdlib/theories.tsx
@@ -173,6 +173,18 @@ stdTheories.add(
                     name: "Network",
                     description: "Visualize the regulatory network",
                 }),
+                configureSubmodelsAnalysis({
+                    id: "positive-loops",
+                    name: "Positive feedback",
+                    description: "Analyze the network for positive feedback loops",
+                    findSubmodels: (model) => thSignedCategory.positiveLoops(model),
+                }),
+                configureSubmodelsAnalysis({
+                    id: "negative-loops",
+                    name: "Negative feedback",
+                    description: "Analyze the network for negative feedback loops",
+                    findSubmodels: (model) => thSignedCategory.negativeLoops(model),
+                }),
             ],
         });
     },


### PR DESCRIPTION
This feature is already available in the isomorphic theory for causal loop diagrams, but we might as include it for reg nets too.