### PR TITLE
Prevent tree-shaking from breaking `echarts`

### DIFF
--- a/packages/frontend/src/visualization/echarts.ts
+++ b/packages/frontend/src/visualization/echarts.ts
@@ -3,6 +3,11 @@
 @module
  */
 
+// XXX: Prevent echarts from being tree-shaken:
+// https://apache.github.io/echarts-handbook/en/basics/import/
+import * as echarts from "echarts";
+echarts;
+
 import { EChartsAutoSize } from "echarts-solid";
 
 export default EChartsAutoSize;


### PR DESCRIPTION
ECharts currently works locally but is broken in the deploy.