### PR TITLE
Check monicity of free simple model morphisms, initialize hom search, monic search constraint

### DIFF
--- a/packages/catlog/src/dbl/model.rs
+++ b/packages/catlog/src/dbl/model.rs
@@ -211,6 +211,11 @@ where
         self.category.add_mor_generator(f, dom, cod)
     }
 
+    /// Adds an equation to the model, making it not free.
+    pub fn add_equation(&mut self, key: Id, eq: PathEq<Id, Id>) {
+        self.category.add_equation(key, eq);
+    }
+
     /// Adds a basic morphism to the model without setting its (co)domain.
     pub fn make_mor(&mut self, f: Id, typ: Cat::Mor) -> bool {
         self.mor_types.set(f.clone(), typ);
@@ -473,5 +478,11 @@ mod tests {
         assert!(model.validate().is_ok());
         model.add_mor(ustr("b"), entity, ustr("type"), FinMor::Id(ustr("Entity")));
         assert_eq!(model.validate().unwrap_err().len(), 1);
+
+        assert!(model.is_free());
+
+        let peq = PathEq::new(Path::single(ustr("a")), Path::single(ustr("b")));
+        model.add_equation(ustr("e"), peq);
+        assert!(!model.is_free());
     }
 }

--- a/packages/catlog/src/one/graph_algorithms.rs
+++ b/packages/catlog/src/one/graph_algorithms.rs
@@ -8,10 +8,9 @@ use super::path::*;
 
 /** Iterates over all simple paths between two vertices of a finite graph.
 
-A **simple path** is a path in which all edges are distinct.
+On our definition, a **simple path** is a path in which all edges are distinct.
 
 A **simple cycle** is a simple path in which the source and target coincide.
-
 This being a category theory library, we do consider the empty/identity path at
 a vertex to be a simple cycle.
 
@@ -54,11 +53,10 @@ where
                 let tgt = graph.tgt(&e);
                 if !visited.contains(&e) {
                     path.push(e.clone());
-                    visited.insert(e.clone());
+                    visited.insert(e);
                     stack.push(graph.out_edges(&tgt).collect());
                     if tgt == *to {
-                        let result: Option<Path<<G as Graph>::V, <G as Graph>::E>> =
-                            Path::collect(path.iter().cloned());
+                        let result = Path::collect(path.iter().cloned());
                         return Some(result.unwrap());
                     }
                 }
@@ -173,21 +171,19 @@ mod tests {
         let paths: Vec<_> = simple_paths(&g, &0, &2).collect();
         assert_eq!(paths, vec![Path::Seq(nonempty![0, 1])]);
 
-        let mut g: HashGraph<char, &str> = Default::default();
+        let mut g: HashGraph<_, _> = Default::default();
         assert!(g.add_vertex('x'));
-        assert!(g.add_edge("f", 'x', 'x'));
-        assert!(g.add_edge("g", 'x', 'x'));
-        let paths: Vec<_> = simple_paths(&g, &'x', &'x').collect();
-        assert_eq!(
-            paths,
-            vec![
-                Path::Id('x'),
-                Path::Seq(nonempty!["g"]),
-                Path::Seq(nonempty!["g", "f"]),
-                Path::Seq(nonempty!["f"]),
-                Path::Seq(nonempty!["f", "g"]),
-            ]
-        );
+        assert!(g.add_edge('f', 'x', 'x'));
+        assert!(g.add_edge('g', 'x', 'x'));
+        let paths: HashSet<_> = simple_paths(&g, &'x', &'x').collect();
+        let target = HashSet::from([
+            Path::Id('x'),
+            Path::Seq(nonempty!['f']),
+            Path::Seq(nonempty!['g']),
+            Path::Seq(nonempty!['f', 'g']),
+            Path::Seq(nonempty!['g', 'f']),
+        ]);
+        assert_eq!(paths, target);
     }
 
     #[test]

--- a/packages/catlog/src/one/path.rs
+++ b/packages/catlog/src/one/path.rs
@@ -7,6 +7,7 @@ data type for [path equations](`PathEq`).
 use either::Either;
 use nonempty::{nonempty, NonEmpty};
 use std::collections::HashSet;
+use std::hash::Hash;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -36,7 +37,7 @@ case analysis on the edge sequence anyway to determine whether, say,
 [`reduce`](std::iter::Iterator::reduce) is valid. Thus, it seems better to reify
 the two cases in the data structure itself.
 */
-#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(tag = "tag", content = "content"))]
 #[cfg_attr(feature = "serde-wasm", derive(Tsify))]
@@ -185,7 +186,7 @@ impl<V, E> Path<V, E> {
     /// Returns whether or not there are repeated edges in the path.
     pub fn is_simple(&self) -> bool
     where
-        E: Eq + std::hash::Hash,
+        E: Eq + Hash,
     {
         match self {
             Path::Id(_) => true,
@@ -425,12 +426,9 @@ mod tests {
     }
 
     #[test]
-    fn is_simple() {
-        let p1: Path<i32, i32> = Path::pair(0, 1);
-        let p2: Path<i32, i32> = Path::pair(0, 0);
-        let p3: Path<i32, i32> = Path::Id(0);
-        assert!(p1.is_simple());
-        assert!(!p2.is_simple());
-        assert!(p3.is_simple());
+    fn path_is_simple() {
+        assert!(SkelPath::pair(0, 1).is_simple());
+        assert!(!SkelPath::pair(0, 0).is_simple());
+        assert!(SkelPath::Id(0).is_simple());
     }
 }

--- a/packages/catlog/src/one/path.rs
+++ b/packages/catlog/src/one/path.rs
@@ -6,6 +6,7 @@ data type for [path equations](`PathEq`).
 
 use either::Either;
 use nonempty::{nonempty, NonEmpty};
+use std::collections::HashSet;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -35,7 +36,7 @@ case analysis on the edge sequence anyway to determine whether, say,
 [`reduce`](std::iter::Iterator::reduce) is valid. Thus, it seems better to reify
 the two cases in the data structure itself.
 */
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(tag = "tag", content = "content"))]
 #[cfg_attr(feature = "serde-wasm", derive(Tsify))]
@@ -177,6 +178,20 @@ impl<V, E> Path<V, E> {
                 // ...and their sources and target are compatible. Too strict?
                 std::iter::zip(edges.iter(), edges.iter().skip(1)).all(
                     |(e,f)| graph.tgt(e) == graph.src(f))
+            }
+        }
+    }
+
+    /// Returns whether or not there are repeated edges in the path.
+    pub fn is_simple(&self) -> bool
+    where
+        E: Eq + std::hash::Hash,
+    {
+        match self {
+            Path::Id(_) => true,
+            Path::Seq(edges) => {
+                let edges: HashSet<_> = edges.into_iter().collect();
+                edges.len() == self.len()
             }
         }
     }
@@ -407,5 +422,15 @@ mod tests {
         assert_eq!(eq.src(&g), 0);
         assert_eq!(eq.tgt(&g), 2);
         assert!(eq.validate_in(&g).is_ok());
+    }
+
+    #[test]
+    fn is_simple() {
+        let p1: Path<i32, i32> = Path::pair(0, 1);
+        let p2: Path<i32, i32> = Path::pair(0, 0);
+        let p3: Path<i32, i32> = Path::Id(0);
+        assert!(p1.is_simple());
+        assert!(!p2.is_simple());
+        assert!(p3.is_simple());
     }
 }

--- a/packages/catlog/src/stdlib/analyses/ode/stock_flow.rs
+++ b/packages/catlog/src/stdlib/analyses/ode/stock_flow.rs
@@ -231,7 +231,7 @@ mod test {
         model: &UstrDiscreteDblModel,
         expected: Expect,
     ) {
-        match analysis.compile_system(&model) {
+        match analysis.compile_system(model) {
             Ok(problem) => {
                 expected.assert_eq(&plot(&problem));
             }


### PR DESCRIPTION
This adds some related features which combine in a test which states (informally) `simple_paths(G, x, y)` is equal to `homomorphisms(walking_edge, G; initial=(walking_src -> x, walking_tgt -> y))` (in the case of all the object/morphism types being the same). This is done for an arbitrary model with lots of loops, but in general could be a nice thing to property-based-test in the future.

Now, a path is simple if it has no repeated generating morphisms (before it couldn't repeat objects except for beginning and end). A model morphism is simple if all generators are sent to simple paths.

This PR additionally adds a check for whether a morphism is monic (conditional on it being free and simple).

Initializing hom search merely adds some clauses to the `search` function which check, before looping through possible ob/mor assignments, if the ob/mor has already been preassigned. Future work will go into making this more efficient by playing with the order which the algorithm attempts assignments to improve performance.

