### PR TITLE
Rename backend-next to backend for prod server

### DIFF
--- a/infrastructure/hosts/catcolab/catcolab.nix
+++ b/infrastructure/hosts/catcolab/catcolab.nix
@@ -23,7 +23,7 @@ in {
     services.postgresql.enable = true;
     services.nginx.enable = true;
 
-    services.nginx.virtualHosts."backend-next.catcolab.org" = {
+    services.nginx.virtualHosts."backend.catcolab.org" = {
         forceSSL = true;
         enableACME = true;
         locations."/" = {

--- a/packages/frontend/.env.production
+++ b/packages/frontend/.env.production
@@ -1,2 +1,2 @@
 VITE_APP_TITLE="CatColab"
-VITE_BACKEND_HOST=https://backend-next.catcolab.org
+VITE_BACKEND_HOST=https://backend.catcolab.org


### PR DESCRIPTION
Renaming prod server from "backend-next.catcolab.org" to "backend.catcolab.org".