### PR TITLE
Temporary workaround for backend in dev environment

### DIFF
--- a/packages/frontend/.env.development
+++ b/packages/frontend/.env.development
@@ -1,2 +1,2 @@
 VITE_APP_TITLE="CatColab [dev]"
-VITE_BACKEND_HOST=https://backend-next.catcolab.org
+VITE_BACKEND_HOST=https://backend.catcolab.org


### PR DESCRIPTION
I started getting

![image](https://github.com/user-attachments/assets/77e5b0cd-1f56-4869-a874-1584e8748bfe)

and this change gets it working again. I am not sure if `backend-next.catcolab.org` is gone and whether `dev-docs/trees/dev-000A.tree` should also be updated, or if there is another fix I should do that keeps using `backend-next.catcolab.org`