### PR TITLE
Remove broken linear path in layout for links in stock-flow diagrams

### DIFF
--- a/packages/frontend/README.md
+++ b/packages/frontend/README.md
@@ -1,7 +1,8 @@
-## Usage
+## Contributing
 
-```bash
-$ npm install # or pnpm install or yarn install
-$ npm run build
-$ vite
-```
+Please run 
+
+``pnpm run format
+pnpm run lint``
+
+before submitting a PR.

--- a/packages/frontend/src/analysis/stock_flow_diagram.tsx
+++ b/packages/frontend/src/analysis/stock_flow_diagram.tsx
@@ -115,6 +115,7 @@ function StockFlowSVG(props: {
                     },
                 },
                 ({ srcId, tgtId }) => {
+                    console.log("nodeMap", nodeMap);
                     const srcNode = nodeMap.get(srcId);
                     const tgtEdge = edgeMap.get(tgtId);
                     if (!srcNode || !tgtEdge) {
@@ -122,10 +123,7 @@ function StockFlowSVG(props: {
                     }
                     pathElem.setAttribute("d", tgtEdge.path);
                     const midpoint = pathElem.getPointAtLength(pathElem.getTotalLength() / 2);
-                    const path =
-                        tgtEdge.source === srcId || tgtEdge.target === srcId
-                            ? quadraticCurve(srcNode.pos, midpoint, 1.0)
-                            : linearPath(srcNode.pos, midpoint);
+                    const path = quadraticCurve(srcNode.pos, midpoint, 1.0)
                     result.push(path.join(" "));
                 },
             );
@@ -151,13 +149,6 @@ function StockFlowSVG(props: {
         </svg>
     );
 }
-
-/** Linear path from one point to another.
- */
-function linearPath(src: GraphLayout.Point, tgt: GraphLayout.Point) {
-    return ["M", src.x, tgt.x, "L", tgt.x, tgt.y];
-}
-
 /** Quadratic Bezier curve from one point to another.
  */
 function quadraticCurve(src: GraphLayout.Point, tgt: GraphLayout.Point, ratio: number) {

--- a/packages/frontend/src/analysis/stock_flow_diagram.tsx
+++ b/packages/frontend/src/analysis/stock_flow_diagram.tsx
@@ -115,7 +115,6 @@ function StockFlowSVG(props: {
                     },
                 },
                 ({ srcId, tgtId }) => {
-                    console.log("nodeMap", nodeMap);
                     const srcNode = nodeMap.get(srcId);
                     const tgtEdge = edgeMap.get(tgtId);
                     if (!srcNode || !tgtEdge) {
@@ -123,7 +122,7 @@ function StockFlowSVG(props: {
                     }
                     pathElem.setAttribute("d", tgtEdge.path);
                     const midpoint = pathElem.getPointAtLength(pathElem.getTotalLength() / 2);
-                    const path = quadraticCurve(srcNode.pos, midpoint, 1.0)
+                    const path = quadraticCurve(srcNode.pos, midpoint, 1.0);
                     result.push(path.join(" "));
                 },
             );


### PR DESCRIPTION
Fixes #231 by simply removing the misbehaving linear-path function for building links that would have been semantically bugged even if the implementation were corrected. Here's an example of a messy link situation after the fix:

![Screenshot 2024-10-28 at 6 07 13 PM](https://github.com/user-attachments/assets/7398e01e-2815-4eb3-8391-bd1888378ce2)

