### PR TITLE
Validate diagrams in models of discrete double theories

### DIFF
--- a/packages/catlog/src/dbl/model_diagram.rs
+++ b/packages/catlog/src/dbl/model_diagram.rs
@@ -16,13 +16,13 @@ TODO: Document in devs docs and link here.
 use std::hash::Hash;
 
 use nonempty::NonEmpty;
-use thiserror::Error;
 
-use crate::one::*;
-use crate::validate::{self, Validate};
+use crate::one::FgCategory;
+use crate::validate;
 
 use super::model::DiscreteDblModel;
-use super::model_morphism::{DblModelMapping, DiscreteDblModelMapping};
+use super::model_morphism::DblModelMorphism;
+use super::model_morphism::{DblModelMapping, DiscreteDblModelMapping, InvalidDblModelMorphism};
 
 /** A diagram in a model of a double theory.
 
@@ -34,6 +34,11 @@ double theory. If that is in question, then the model should be validated
 pub struct DblModelDiagram<Map, Dom>(Map, Dom);
 
 impl<Map, Dom> DblModelDiagram<Map, Dom> {
+    /// Constructs a new diagram from the given mapping and domain model.
+    pub fn new(map: Map, dom: Dom) -> Self {
+        Self(map, dom)
+    }
+
     /// The mapping underlying the diagram.
     pub fn mapping(&self) -> &Map {
         &self.0
@@ -64,38 +69,6 @@ where
 pub type DiscreteDblModelDiagram<DomId, CodId, Cat> =
     DblModelDiagram<DiscreteDblModelMapping<DomId, CodId>, DiscreteDblModel<DomId, Cat>>;
 
-/** An invalid assignment in a double model diagram defined explicitly by data.
- *
- * Note that, by specifying a model morphism via its action on generators, we
- * obtain for free that identities are sent to identities and composites of
- * generators are sent to their composites in the codomain.
-*/
-#[derive(Debug, Error, PartialEq, Clone)]
-pub enum InvalidDblModelDiagram<Ob, Mor> {
-    /// Missing data
-    #[error("Object `{0}` is not mapped to anything in the codomain")]
-    MissingOb(Ob),
-
-    /// Missing data
-    #[error("Morphism `{0}` is not mapped to anything in the codomain")]
-    MissingMor(Mor),
-}
-
-impl<DomId, CodId, Cat> Validate for DiscreteDblModelDiagram<DomId, CodId, Cat>
-where
-    DomId: Eq + Clone + Hash,
-    CodId: Eq + Clone + Hash,
-    Cat: FgCategory,
-    Cat::Ob: Hash,
-    Cat::Mor: Hash,
-{
-    type ValidationError = InvalidDblModelDiagram<DomId, DomId>;
-
-    fn validate(&self) -> Result<(), NonEmpty<Self::ValidationError>> {
-        validate::wrap_errors(self.iter_invalid())
-    }
-}
-
 impl<DomId, CodId, Cat> DiscreteDblModelDiagram<DomId, CodId, Cat>
 where
     DomId: Eq + Clone + Hash,
@@ -104,29 +77,21 @@ where
     Cat::Ob: Hash,
     Cat::Mor: Hash,
 {
-    /// An iterator over invalid objects and morphisms in the diagram.
-    pub fn iter_invalid(&self) -> impl Iterator<Item = InvalidDblModelDiagram<DomId, DomId>> + '_ {
-        let DblModelDiagram(mapping, dom) = self;
+    /// Validates that the diagram is well-defined in the given model.
+    pub fn validate_in(
+        &self,
+        model: &DiscreteDblModel<CodId, Cat>,
+    ) -> Result<(), NonEmpty<InvalidDblModelMorphism<DomId, DomId>>> {
+        validate::wrap_errors(self.iter_invalid_in(model))
+    }
 
-        // Diagrams can always be indexed by free models.
-        assert!(dom.is_free(), "Domain model should be free");
-        let ob_errors = dom.object_generators().filter_map(|v| {
-            if mapping.apply_ob(&v).is_some() {
-                None
-            } else {
-                Some(InvalidDblModelDiagram::MissingOb(v))
-            }
-        });
-
-        let mor_errors = dom.morphism_generators().flat_map(|f| {
-            if mapping.apply_basic_mor(&f).is_some() {
-                vec![] // No errors
-            } else {
-                [InvalidDblModelDiagram::MissingMor(f)].to_vec()
-            }
-        });
-
-        ob_errors.chain(mor_errors)
+    /// Iterates over failures of the diagram to be valid in the given model.
+    pub fn iter_invalid_in<'a>(
+        &'a self,
+        model: &'a DiscreteDblModel<CodId, Cat>,
+    ) -> impl Iterator<Item = InvalidDblModelMorphism<DomId, DomId>> + '_ {
+        let morphism = DblModelMorphism::new(self.mapping(), self.domain(), model);
+        morphism.iter_invalid()
     }
 }
 
@@ -137,7 +102,7 @@ mod tests {
     use std::sync::Arc;
     use ustr::ustr;
 
-    use crate::one::fin_category::FinMor;
+    use crate::one::{fin_category::FinMor, Path};
     use crate::stdlib::*;
 
     #[test]
@@ -154,7 +119,7 @@ mod tests {
         f.assign_ob(ustr("type"), 'y');
         f.assign_basic_mor(ustr("attr"), Path::pair('p', 'q'));
 
-        let diagram = DblModelDiagram(f, model);
+        let diagram = DblModelDiagram::new(f, model);
         assert_eq!(diagram.ob(&entity), 'x');
         assert_eq!(diagram.mor(&Path::single(ustr("attr"))), Path::pair('p', 'q'));
     }
@@ -162,15 +127,13 @@ mod tests {
     #[test]
     fn validate_model_diagram() {
         let theory = Arc::new(th_signed_category());
-        let negloop = negative_loop(theory.clone());
+        let pos_loop = positive_loop(theory.clone());
+        let neg_loop = negative_loop(theory.clone());
 
         let mut f: DiscreteDblModelMapping<_, _> = Default::default();
         f.assign_ob(ustr("x"), ustr("x"));
-        f.assign_basic_mor(ustr(""), Path::Id(ustr("negative")));
-        let dmd = DblModelDiagram(f, negloop);
-        assert!(dmd.validate().is_err());
-        // A bad map from h to itself that is wrong for the ob (it is in the map
-        // but sent to something that doesn't exist) and for the hom generator
-        // (not in the map)
+        f.assign_basic_mor(ustr("positive"), Path::pair(ustr("negative"), ustr("negative")));
+        let diagram = DblModelDiagram::new(f, pos_loop);
+        assert!(diagram.validate_in(&neg_loop).is_ok());
     }
 }

--- a/packages/catlog/src/dbl/model_diagram.rs
+++ b/packages/catlog/src/dbl/model_diagram.rs
@@ -1,14 +1,16 @@
 /*! Diagrams in models of a double theory.
 
-A diagram in a [model](super::model) consists of a [morphism](super::model_morphism)
-of models together with its domain, which is a free mode.
+A **diagram** in a [model](super::model) is simply a
+[morphism](super::model_morphism) into that model. This includes the domain of
+that morphism, which is assumed to be a free model.
 
-Diagrams are currently used primarily to represent instances of models from
-a fibered perspective.
+Diagrams are currently used primarily to represent instances of models from a
+fibered perspective, generalizing how a diagram in a category can be used to
+represent a copresheaf over that category.
 
 # References
 
-- TODO dev-docs
+TODO: Document in devs docs and link here.
  */
 
 use std::hash::Hash;
@@ -16,42 +18,36 @@ use std::hash::Hash;
 use nonempty::NonEmpty;
 use thiserror::Error;
 
-use super::model::DiscreteDblModel;
-use super::model_morphism::{DblModelMapping, DiscreteDblModelMapping};
 use crate::one::*;
 use crate::validate::{self, Validate};
 
-/**  A diagram in a model of a double theory defined by a [mapping](DblModelMapping).
+use super::model::DiscreteDblModel;
+use super::model_morphism::{DblModelMapping, DiscreteDblModelMapping};
+
+/** A diagram in a model of a double theory.
 
 This struct owns its data, namely, the domain model and the model
-mapping. The domain is assumed to
-be a valid model of a double theory. If that is in question, the
-model should be validated *before* validating this object.
+[mapping](DblModelMapping). The domain is assumed to be a valid model of a
+double theory. If that is in question, then the model should be validated
+*before* validating this object.
 */
-pub struct DblModelDiagram<Map, Dom>(pub Map, pub Dom);
+pub struct DblModelDiagram<Map, Dom>(Map, Dom);
+
+impl<Map, Dom> DblModelDiagram<Map, Dom> {
+    /// The mapping underlying the diagram.
+    pub fn mapping(&self) -> &Map {
+        &self.0
+    }
+
+    /// The domain, or shape, of the diagram.
+    pub fn domain(&self) -> &Dom {
+        &self.1
+    }
+}
 
 /// A diagram in a model of a discrete double theory.
 pub type DiscreteDblModelDiagram<DomId, CodId, Cat> =
     DblModelDiagram<DiscreteDblModelMapping<DomId, CodId>, DiscreteDblModel<DomId, Cat>>;
-
-impl<DomId, CodId, Cat> DiscreteDblModelDiagram<DomId, CodId, Cat>
-where
-    DomId: Eq + Clone + Hash,
-    CodId: Eq + Clone + Hash,
-    Cat: FgCategory,
-    Cat::Ob: Hash,
-    Cat::Mor: Hash,
-{
-    /// The domain of the diagram.
-    pub fn domain(&self) -> &DiscreteDblModel<DomId, Cat> {
-        &self.1
-    }
-
-    /// The mapping of the diagram.
-    pub fn mapping(&self) -> &DiscreteDblModelMapping<DomId, CodId> {
-        &self.0
-    }
-}
 
 /** An invalid assignment in a double model diagram defined explicitly by data.
  *

--- a/packages/catlog/src/dbl/model_diagram.rs
+++ b/packages/catlog/src/dbl/model_diagram.rs
@@ -45,6 +45,21 @@ impl<Map, Dom> DblModelDiagram<Map, Dom> {
     }
 }
 
+impl<Map, Dom> DblModelDiagram<Map, Dom>
+where
+    Map: DblModelMapping,
+{
+    /// Gets an object indexed by the diagram.
+    pub fn ob(&self, i: &Map::DomOb) -> Map::CodOb {
+        self.0.apply_ob(i).expect("Diagram should be defined at object")
+    }
+
+    /// Gets a morphism indexed by the diagram.
+    pub fn mor(&self, h: &Map::DomMor) -> Map::CodMor {
+        self.0.apply_mor(h).expect("Diagram should be defined at morphism")
+    }
+}
+
 /// A diagram in a model of a discrete double theory.
 pub type DiscreteDblModelDiagram<DomId, CodId, Cat> =
     DblModelDiagram<DiscreteDblModelMapping<DomId, CodId>, DiscreteDblModel<DomId, Cat>>;
@@ -132,16 +147,16 @@ mod tests {
         let entity = ustr("entity");
         model.add_ob(entity, ustr("Entity"));
         model.add_ob(ustr("type"), ustr("AttrType"));
-        model.add_mor(ustr("a"), entity, ustr("type"), FinMor::Generator(ustr("Attr")));
+        model.add_mor(ustr("attr"), entity, ustr("type"), FinMor::Generator(ustr("Attr")));
 
         let mut f: DiscreteDblModelMapping<_, _> = Default::default();
         f.assign_ob(entity, 'x');
         f.assign_ob(ustr("type"), 'y');
-        f.assign_basic_mor(ustr("a"), Path::pair('p', 'q'));
+        f.assign_basic_mor(ustr("attr"), Path::pair('p', 'q'));
 
-        let diagram = DblModelDiagram(f.clone(), model.clone());
-        assert_eq!(diagram.domain(), &model);
-        assert_eq!(diagram.mapping(), &f);
+        let diagram = DblModelDiagram(f, model);
+        assert_eq!(diagram.ob(&entity), 'x');
+        assert_eq!(diagram.mor(&Path::single(ustr("attr"))), Path::pair('p', 'q'));
     }
 
     #[test]

--- a/packages/catlog/src/dbl/model_morphism.rs
+++ b/packages/catlog/src/dbl/model_morphism.rs
@@ -214,6 +214,13 @@ models should be validated *before* validating this object.
  */
 pub struct DblModelMorphism<'a, Map, Dom, Cod>(&'a Map, &'a Dom, &'a Cod);
 
+impl<'a, Map, Dom, Cod> DblModelMorphism<'a, Map, Dom, Cod> {
+    /// Constructs a new morphism between models.
+    pub fn new(map: &'a Map, dom: &'a Dom, cod: &'a Cod) -> Self {
+        Self(map, dom, cod)
+    }
+}
+
 /// A morphism between models of a discrete double theory.
 pub type DiscreteDblModelMorphism<'a, DomId, CodId, Cat> = DblModelMorphism<
     'a,

--- a/packages/catlog/src/dbl/model_morphism.rs
+++ b/packages/catlog/src/dbl/model_morphism.rs
@@ -23,7 +23,6 @@ use std::hash::Hash;
 use std::sync::Arc;
 
 use derivative::Derivative;
-
 use nonempty::NonEmpty;
 use thiserror::Error;
 
@@ -213,7 +212,7 @@ This struct borrows its data to perform validation. The domain and codomain are
 assumed to be valid models of double theories. If that is in question, the
 models should be validated *before* validating this object.
  */
-pub struct DblModelMorphism<'a, Map, Dom, Cod>(pub &'a Map, pub &'a Dom, pub &'a Cod);
+pub struct DblModelMorphism<'a, Map, Dom, Cod>(&'a Map, &'a Dom, &'a Cod);
 
 /// A morphism between models of a discrete double theory.
 pub type DiscreteDblModelMorphism<'a, DomId, CodId, Cat> = DblModelMorphism<


### PR DESCRIPTION
Follow-up to #248. Increases the functionality while reducing the code by delegating the validation of a diagram to validation of a morphism, which is already implemented.