### PR TITLE
Replace/remove a few type aliases for IDs

### DIFF
--- a/packages/frontend/src/model/document.ts
+++ b/packages/frontend/src/model/document.ts
@@ -6,7 +6,7 @@ import type { DblModel, ModelValidationResult, Uuid } from "catlog-wasm";
 import { type Api, type LiveDoc, getLiveDoc } from "../api";
 import { type Notebook, newNotebook } from "../notebook";
 import type { TheoryLibrary } from "../stdlib";
-import type { Theory, TheoryId } from "../theory";
+import type { Theory } from "../theory";
 import { type IndexedMap, indexMap } from "../util/indexing";
 import { type ModelJudgment, catlogModel } from "./types";
 
@@ -18,7 +18,7 @@ export type ModelDocument = {
     name: string;
 
     /** Identifier of double theory that the model is of. */
-    theory?: TheoryId;
+    theory?: string;
 
     /** Content of the model, formal and informal. */
     notebook: Notebook<ModelJudgment>;

--- a/packages/frontend/src/model/theory_selector.tsx
+++ b/packages/frontend/src/model/theory_selector.tsx
@@ -2,13 +2,12 @@ import Dialog from "@corvu/dialog";
 import { For, Show, createMemo, createSignal } from "solid-js";
 
 import type { TheoryLibrary, TheoryMeta } from "../stdlib";
-import type { TheoryId } from "../theory";
 
 import "./theory_selector.css";
 
 type TheorySelectorProps = {
     theory: TheoryMeta | undefined;
-    setTheory: (theory: TheoryId | undefined) => void;
+    setTheory: (theoryId: string | undefined) => void;
     theories: TheoryLibrary;
 };
 
@@ -73,7 +72,7 @@ export function TheorySelector(props: TheorySelectorProps) {
                                         id={meta.id}
                                         value={meta.id}
                                         onchange={(evt) => {
-                                            const id = evt.target.value as TheoryId;
+                                            const id = evt.target.value;
                                             props.setTheory(id ? id : undefined);
                                         }}
                                     />

--- a/packages/frontend/src/notebook/notebook_cell.tsx
+++ b/packages/frontend/src/notebook/notebook_cell.tsx
@@ -10,6 +10,7 @@ import { createAutofocus } from "@solid-primitives/autofocus";
 import type { EditorView } from "prosemirror-view";
 import { type JSX, Show, createEffect, createSignal, onCleanup } from "solid-js";
 
+import type { Uuid } from "catlog-wasm";
 import {
     type Completion,
     Completions,
@@ -18,7 +19,6 @@ import {
     RichTextEditor,
 } from "../components";
 import { focusInputWhen } from "../util/focus";
-import type { CellId } from "./types";
 
 import ArrowDown from "lucide-solid/icons/arrow-down";
 import ArrowUp from "lucide-solid/icons/arrow-up";
@@ -70,11 +70,11 @@ export type CellDragData = {
     [cellDragDataKey]: true;
 
     /** ID of the cell being dragged. */
-    cellId: CellId;
+    cellId: Uuid;
 };
 
 /** Create drag-and-drop data for a notebook cell. */
-const createCellDragData = (cellId: CellId) => ({
+const createCellDragData = (cellId: Uuid) => ({
     [cellDragDataKey]: true,
     cellId,
 });
@@ -90,7 +90,7 @@ This component contains UI elements common to any cell. The actual content of
 the cell is rendered by its children.
  */
 export function NotebookCell(props: {
-    cellId: CellId;
+    cellId: Uuid;
     actions: CellActions;
     children: JSX.Element;
     tag?: string;
@@ -197,7 +197,7 @@ export function NotebookCell(props: {
 /** Editor for rich text cells, a simple wrapper around `RichTextEditor`.
  */
 export function RichTextCellEditor(props: {
-    cellId: CellId;
+    cellId: Uuid;
     handle: DocHandle<unknown>;
     path: Prop[];
     isActive: boolean;

--- a/packages/frontend/src/notebook/types.ts
+++ b/packages/frontend/src/notebook/types.ts
@@ -1,5 +1,7 @@
 import { uuidv7 } from "uuidv7";
 
+import type { Uuid } from "catlog-wasm";
+
 /** Data type for a notebook.
 
 A notebook is nothing more than a list of cells. Any metadata associated with
@@ -17,9 +19,6 @@ custom type, which is typically formal in contrast to natural text.
  */
 export type Cell<T> = RichTextCell | FormalCell<T> | StemCell;
 
-/** UUID for a cell in a notebook. */
-export type CellId = string;
-
 /** Creates an empty notebook. */
 export const newNotebook = <T>(): Notebook<T> => ({
     cells: [],
@@ -28,7 +27,7 @@ export const newNotebook = <T>(): Notebook<T> => ({
 /** A cell containing rich text. */
 export type RichTextCell = {
     tag: "rich-text";
-    id: CellId;
+    id: Uuid;
     content: string;
 };
 
@@ -42,7 +41,7 @@ export const newRichTextCell = (): RichTextCell => ({
 /** A cell containing custom data, usually a formal object. */
 export type FormalCell<T> = {
     tag: "formal";
-    id: CellId;
+    id: Uuid;
     content: T;
 };
 
@@ -60,7 +59,7 @@ and replaced when a type for the new cell is selected.
  */
 export type StemCell = {
     tag: "stem";
-    id: CellId;
+    id: Uuid;
 };
 
 /** Creates a new stem cell. */

--- a/packages/frontend/src/stdlib/types.ts
+++ b/packages/frontend/src/stdlib/types.ts
@@ -1,4 +1,4 @@
-import { Theory, type TheoryId } from "../theory";
+import { Theory } from "../theory";
 
 /** Frontend metadata for a double theory.
 
@@ -7,7 +7,7 @@ identify the theory and display it to the user.
  */
 export type TheoryMeta = {
     /** Unique identifier of theory. */
-    id: TheoryId;
+    id: string;
 
     /** Human-readable name for models of theory. */
     name: string;
@@ -24,8 +24,11 @@ export type TheoryMeta = {
 Theories are lazy loaded.
  */
 export class TheoryLibrary {
-    private readonly metaMap: Map<TheoryId, TheoryMeta>;
-    private readonly theoryMap: Map<TheoryId, Theory | ((meta: TheoryMeta) => Theory)>;
+    /** Map from theory ID to metadata about the theory. */
+    private readonly metaMap: Map<string, TheoryMeta>;
+
+    /** Map from theory ID to the theory itself or the constructor for it. */
+    private readonly theoryMap: Map<string, Theory | ((meta: TheoryMeta) => Theory)>;
 
     constructor() {
         this.metaMap = new Map();
@@ -45,7 +48,7 @@ export class TheoryLibrary {
 
     A theory is instantiated and cached the first time it is retrieved.
      */
-    get(id: TheoryId): Theory {
+    get(id: string): Theory {
         const meta = this.metaMap.get(id);
         const theoryOrCons = this.theoryMap.get(id);
         if (meta === undefined || theoryOrCons === undefined) {

--- a/packages/frontend/src/theory/types.ts
+++ b/packages/frontend/src/theory/types.ts
@@ -13,7 +13,7 @@ how to display models of the theory and instances of models.
  */
 export class Theory {
     /** Unique identifier of theory. */
-    readonly id: TheoryId;
+    readonly id: string;
 
     /** Underlying double theory in the core. */
     readonly theory: DblTheory;
@@ -39,7 +39,11 @@ export class Theory {
 
     private readonly modelTypeMeta: TypeMetadata<ModelObTypeMeta, ModelMorTypeMeta>;
     private readonly instanceTypeMeta: TypeMetadata<InstanceObTypeMeta, InstanceMorTypeMeta>;
+
+    /** Map from theory ID to model analysis metadata. */
     private readonly modelAnalysisMap: Map<string, ModelAnalysisMeta>;
+
+    /** Map from theory ID to diagram analysis metadata. */
     private readonly diagramAnalysisMap: Map<string, DiagramAnalysisMeta>;
 
     constructor(props: {
@@ -135,9 +139,6 @@ export class Theory {
         return this.diagramAnalysisMap.get(id);
     }
 }
-
-/** Unique identifier of a theory configured for the frontend. */
-export type TheoryId = string;
 
 /** Helper class to index and lookup metadata for object and morphism types. */
 class TypeMetadata<ObMeta extends HasObTypeMeta, MorMeta extends HasMorTypeMeta> {


### PR DESCRIPTION
For consistency with the rest of the codebase, where we're not using such specific type aliases.