### PR TITLE
Theory-specific help

### DIFF
--- a/packages/frontend/src/help/index.mdx
+++ b/packages/frontend/src/help/index.mdx
@@ -1,5 +1,6 @@
 import { A } from "@solidjs/router";
 import { Warning } from "../components/alert";
+import { theoryDocumentationDisplay } from "./theory_documentation/theory_file_parser.tsx"
 
 # Help & resources
 
@@ -54,3 +55,6 @@ identification of motifs, and translation into other formats.</dd>
 Future of versions of CatColab will display the further concepts of
 **instances**, **morphisms**, and **migrations**, to be described when they
 become available.
+
+## Theories 
+<theoryDocumentationDisplay />

--- a/packages/frontend/src/help/theory_documentation/causal-loop.mdx
+++ b/packages/frontend/src/help/theory_documentation/causal-loop.mdx
@@ -1,0 +1,3 @@
+---
+title: Causal Loop
+---

--- a/packages/frontend/src/help/theory_documentation/theory_file_parser.tsx
+++ b/packages/frontend/src/help/theory_documentation/theory_file_parser.tsx
@@ -1,0 +1,46 @@
+import { readdirSync, statSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { For, type JSX } from "solid-js";
+import type { Plugin } from "vite";
+
+export const documentationFileParser = (): Plugin => {
+    return {
+        name: "documentation-file-parser",
+        async buildStart() {
+            processFiles();
+        },
+
+        configureServer(server) {
+            server.watcher.on("change", (filePath) => {
+                if (filePath.includes("./theory_documentation")) {
+                    processFiles();
+                }
+            });
+        },
+    };
+};
+
+export const theoryDocumentationPosts: { slug: string }[] = [];
+
+export const processFiles = () => {
+    const outputFile = resolve("./theory_documentation/theory_documentation_files.json");
+    const theoryDocumentationDir = resolve("/theory_documentation");
+    const files = readdirSync(theoryDocumentationDir);
+    const theoryDocumentationPosts = files
+        .filter(
+            (file) =>
+                statSync(join(theoryDocumentationDir, file)).isFile() && file.endsWith(".mdx"),
+        )
+        .map((file) => ({ slug: file.replace(".mdx", "") }));
+    writeFileSync(outputFile, JSON.stringify(theoryDocumentationPosts, null, 2), "utf-8");
+};
+
+export function theoryDocumentationDisplay(): JSX.Element {
+    return (
+        <For each={theoryDocumentationPosts}>
+            {(theory_post) => (
+                <a href={`/theory_documentation/${theory_post.slug}.mdx`}>{theory_post.slug}</a>
+            )}
+        </For>
+    );
+}

--- a/packages/frontend/src/model/theory_selector.tsx
+++ b/packages/frontend/src/model/theory_selector.tsx
@@ -45,6 +45,8 @@ export function TheorySelectorDialog(
     );
 }
 
+export const [selectedTheory, setSelectedTheory] = createSignal<string | undefined>(undefined);
+
 export function TheorySelector(props: TheorySelectorProps) {
     const groupedTheories = createMemo(() => {
         const grouped = new Map<string, TheoryMeta[]>();
@@ -74,6 +76,7 @@ export function TheorySelector(props: TheorySelectorProps) {
                                         onchange={(evt) => {
                                             const id = evt.target.value;
                                             props.setTheory(id ? id : undefined);
+                                            setSelectedTheory(id);
                                         }}
                                     />
                                     <label for={meta.id}>

--- a/packages/frontend/src/page/toolbar.tsx
+++ b/packages/frontend/src/page/toolbar.tsx
@@ -1,6 +1,7 @@
 import { A, useNavigate } from "@solidjs/router";
 import CircleHelp from "lucide-solid/icons/circle-help";
 import type { JSX } from "solid-js";
+import { selectedTheory, setSelectedTheory } from "../model/theory_selector";
 
 import { IconButton } from "../components";
 
@@ -33,13 +34,23 @@ const Brand = () => (
     </A>
 );
 
-/** Button that navigates to the root help page. */
+/** Button that navigates to the root help page or theory documentation page. */
 export function HelpButton() {
     const navigate = useNavigate();
-
-    return (
-        <IconButton onClick={() => navigate("/help")} tooltip="Get help about CatColab">
-            <CircleHelp />
-        </IconButton>
-    );
+    if (selectedTheory() == null) {
+        return (
+            <IconButton onClick={() => navigate("/help")} tooltip="Get help about CatColab">
+                <CircleHelp />
+            </IconButton>
+        );
+    } else {
+        return (
+            <IconButton
+                onClick={() => navigate(`"help/theory_documentation/${setSelectedTheory()}}.mdx"`)}
+                tooltip="Learn more about theory"
+            >
+                <CircleHelp />
+            </IconButton>
+        );
+    }
 }

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -9,6 +9,7 @@ import wasm from "vite-plugin-wasm";
 // *Also*, this plugin causes Vite 5 to complain about CJS.
 // https://github.com/nksaraf/vinxi/issues/289
 import pkg from "@vinxi/plugin-mdx";
+import { documentationFileParser } from "./src/help/theory_documentation/theory_file_parser";
 const { default: mdx } = pkg;
 
 export default defineConfig({
@@ -24,6 +25,7 @@ export default defineConfig({
         solid({
             extensions: [".mdx", ".md"],
         }),
+        documentationFileParser(),
     ],
     build: {
         chunkSizeWarningLimit: 2000,


### PR DESCRIPTION
Theory-specific help
- Help button directs to main help page when a theory hasn't been selected
- Otherwise it directs to a theory-specific help page

(PR is incomplete, routing isn't working)