### PR TITLE
Render empty model name as Untitled in backlinks

### DIFF
--- a/packages/frontend/src/diagram/diagram_editor.tsx
+++ b/packages/frontend/src/diagram/diagram_editor.tsx
@@ -102,7 +102,9 @@ export function DiagramPane(props: {
                 <div class="instance-of">
                     <div class="name">{liveModel().theory()?.instanceOfName}</div>
                     <div class="model">
-                        <A href={`/model/${liveModel().refId}`}>{liveModel().liveDoc.doc.name || "Untitled"}</A>
+                        <A href={`/model/${liveModel().refId}`}>
+                            {liveModel().liveDoc.doc.name || "Untitled"}
+                        </A>
                     </div>
                 </div>
             </div>

--- a/packages/frontend/src/diagram/diagram_editor.tsx
+++ b/packages/frontend/src/diagram/diagram_editor.tsx
@@ -102,7 +102,7 @@ export function DiagramPane(props: {
                 <div class="instance-of">
                     <div class="name">{liveModel().theory()?.instanceOfName}</div>
                     <div class="model">
-                        <A href={`/model/${liveModel().refId}`}>{liveModel().liveDoc.doc.name}</A>
+                        <A href={`/model/${liveModel().refId}`}>{liveModel().liveDoc.doc.name || "Untitled"}</A>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Closes https://github.com/ToposInstitute/CatColab/issues/272 in as simple a way as possible: an empty model name defaults to "Untitled". 

If we end up discovering this code needs to get used in multiple places, it could be its own `name_or_untitled` method. Unsure if that's necessary at this point.