### PR TITLE
Categories with scalars

### DIFF
--- a/packages/algjulia-service/src/decapodes.jl
+++ b/packages/algjulia-service/src/decapodes.jl
@@ -38,7 +38,6 @@ function to_pode(::Val{:Ob}, name::String)
         "dual 0-form" => :DualForm0
         "dual 1-form" => :DualForm1
         "dual 2-form" => :DualForm2
-        "constant" => :Constant
         x => throw(ImplError(x))
     end
 end

--- a/packages/catlog-wasm/src/theories.rs
+++ b/packages/catlog-wasm/src/theories.rs
@@ -1,6 +1,6 @@
 /*! Wasm bindings for double theories from the `catlog` standard library.
 
-Each struct in this modules provides a [`DblTheory`] plus possibly
+Each struct in this module provides a [`DblTheory`] plus possibly
 theory-specific analysis methods.
  */
 
@@ -118,6 +118,23 @@ impl ThNullableSignedCategory {
     }
 }
 
+/// The theory of categories with scalars.
+#[wasm_bindgen]
+pub struct ThCategoryWithScalars(Arc<theory::UstrDiscreteDblTheory>);
+
+#[wasm_bindgen]
+impl ThCategoryWithScalars {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self(Arc::new(theories::th_category_with_scalars()))
+    }
+
+    #[wasm_bindgen]
+    pub fn theory(&self) -> DblTheory {
+        DblTheory(self.0.clone().into())
+    }
+}
+
 /// The theory of categories with links.
 #[wasm_bindgen]
 pub struct ThCategoryLinks(Arc<theory::UstrDiscreteTabTheory>);
@@ -143,6 +160,7 @@ mod tests {
 
     #[test]
     fn discrete_dbl_theory() {
+        let _q = ThCategoryWithScalars::new().theory();
         let th = ThSchema::new().theory();
         let entity = ObType::Basic(ustr("Entity"));
         let attr_type = ObType::Basic(ustr("AttrType"));

--- a/packages/catlog-wasm/src/theories.rs
+++ b/packages/catlog-wasm/src/theories.rs
@@ -160,7 +160,6 @@ mod tests {
 
     #[test]
     fn discrete_dbl_theory() {
-        let _q = ThCategoryWithScalars::new().theory();
         let th = ThSchema::new().theory();
         let entity = ObType::Basic(ustr("Entity"));
         let attr_type = ObType::Basic(ustr("AttrType"));

--- a/packages/catlog/src/dbl/model_diagram.rs
+++ b/packages/catlog/src/dbl/model_diagram.rs
@@ -99,7 +99,7 @@ where
     pub fn iter_invalid_in<'a>(
         &'a self,
         model: &'a DiscreteDblModel<CodId, Cat>,
-    ) -> impl Iterator<Item = InvalidDiscreteDblModelDiagram<DomId>> + '_ {
+    ) -> impl Iterator<Item = InvalidDiscreteDblModelDiagram<DomId>> + 'a {
         let mut dom_errs = self.1.iter_invalid().peekable();
         if dom_errs.peek().is_some() {
             Either::Left(dom_errs.map(InvalidDblModelDiagram::Dom))

--- a/packages/catlog/src/stdlib/theories.rs
+++ b/packages/catlog/src/stdlib/theories.rs
@@ -62,10 +62,10 @@ pub fn th_nullable_signed_category() -> UstrDiscreteDblTheory {
 }
 
 /** The theory of categories with scalars.
- 
+
 A *category with scalars* is a category sliced over the monoid representing a walking
 idempotent. The morphisms over the identity are interpreted as scalars, which are closed
-under composition, as are the non-scalar morphisms. 
+under composition, as are the non-scalar morphisms.
 
 The main intended application is to categories
 enriched in `M`-sets for a monoid `M` such as the positive real numbers under multiplication,

--- a/packages/catlog/src/stdlib/theories.rs
+++ b/packages/catlog/src/stdlib/theories.rs
@@ -61,6 +61,25 @@ pub fn th_nullable_signed_category() -> UstrDiscreteDblTheory {
     DiscreteDblTheory::from(sgn)
 }
 
+/** The theory of categories with scalars.
+ 
+A *category with scalars* is a category sliced over the monoid representing a walking
+idempotent. The morphisms over the identity are interpreted as scalars, which are closed
+under composition, as are the non-scalar morphisms. 
+
+The main intended application is to categories
+enriched in `M`-sets for a monoid `M` such as the positive real numbers under multiplication,
+but to remain within simple theories the theory defined here is more general.
+ */
+pub fn th_category_with_scalars() -> UstrDiscreteDblTheory {
+    let mut idem: UstrFinCategory = Default::default();
+    let (x, s) = (ustr("Object"), ustr("Nonscalar"));
+    idem.add_ob_generator(x);
+    idem.add_mor_generator(s, x, x);
+    idem.set_composite(s, s, FinMor::Generator(s));
+    DiscreteDblTheory::from(idem)
+}
+
 /** The theory of categories with links.
 
 A *category with links* is a category `C` together with a profunctor from `C` to
@@ -92,6 +111,7 @@ mod tests {
         assert!(th_schema().validate().is_ok());
         assert!(th_signed_category().validate().is_ok());
         assert!(th_nullable_signed_category().validate().is_ok());
+        assert!(th_category_with_scalars().validate().is_ok());
         // TODO: Validate discrete tabulator theories.
         th_category_links();
     }

--- a/packages/frontend/src/stdlib/analyses/graph_visualization.css
+++ b/packages/frontend/src/stdlib/analyses/graph_visualization.css
@@ -1,3 +1,3 @@
 .graph-visualization {
-    overflow-x: scroll;
+    overflow-x: auto;
 }

--- a/packages/frontend/src/stdlib/arrow_styles.module.css
+++ b/packages/frontend/src/stdlib/arrow_styles.module.css
@@ -22,7 +22,8 @@
 .arrow.default,
 .arrow.plus,
 .arrow.minus,
-.arrow.indeterminate {
+.arrow.indeterminate,
+.arrow.scalar {
     &:before,
     &:after {
         content: "";
@@ -69,6 +70,16 @@
 .arrowContainer.indeterminate {
     &:after {
         content: "?";
+        transform: none;
+        position: absolute;
+        right: -7.5px;
+        bottom: 0px;
+    }
+}
+
+.arrowContainer.scalar {
+    &:after {
+        content: "∝";
         transform: none;
         position: absolute;
         right: -7.5px;

--- a/packages/frontend/src/stdlib/arrow_styles.module.css.d.ts
+++ b/packages/frontend/src/stdlib/arrow_styles.module.css.d.ts
@@ -9,5 +9,6 @@ declare const styles: {
     readonly indeterminate: string;
     readonly minus: string;
     readonly plus: string;
+    readonly scalar: string;
 };
 export = styles;

--- a/packages/frontend/src/stdlib/theories.tsx
+++ b/packages/frontend/src/stdlib/theories.tsx
@@ -401,9 +401,9 @@ stdTheories.add(
 
 stdTheories.add(
     {
-        id: "unary-DEC",
-        name: "Unary DEC operators",
-        description: "A category of DEC operators, including constants, on some space",
+        id: "unary-dec",
+        name: "Discrete exterior calculus (DEC)",
+        description: "DEC operators on a geometrical space",
         group: "Applied Mathematics",
     },
     (meta) => {
@@ -412,21 +412,20 @@ stdTheories.add(
         return new Theory({
             ...meta,
             theory: thCategoryWithScalars.theory(),
-            onlyFreeModels: true,
             modelTypes: [
                 {
                     tag: "ObType",
                     obType: { tag: "Basic", content: "Object" },
-                    name: "FormType",
+                    name: "Form type",
                     shortcut: ["F"],
                     description: "A type of differential form on the space",
                 },
                 {
                     tag: "MorType",
                     morType: { tag: "Basic", content: "Nonscalar" },
-                    name: "Nonscalar",
-                    shortcut: ["N"],
-                    description: "A nonscalar operator",
+                    name: "Operator",
+                    shortcut: ["D"],
+                    description: "A differential operator",
                 },
                 {
                     tag: "MorType",
@@ -437,9 +436,10 @@ stdTheories.add(
                     name: "Scalar",
                     arrowStyle: "scalar",
                     shortcut: ["S"],
-                    description: "Morphism multiplying by a scalar",
+                    description: "Multiplication by a scalar",
                 },
             ],
+            instanceOfName: "Equations in",
             instanceTypes: [
                 {
                     tag: "ObType",
@@ -451,9 +451,9 @@ stdTheories.add(
                 {
                     tag: "MorType",
                     morType: { tag: "Basic", content: "Nonscalar" },
-                    name: "Nonscalar",
-                    description: "A nonscalar operator acting on some form",
-                    shortcut: ["N"],
+                    name: "Apply operator",
+                    description: "An application of an operator to a form",
+                    shortcut: ["D"],
                 },
                 {
                     tag: "MorType",
@@ -461,8 +461,8 @@ stdTheories.add(
                         tag: "Hom",
                         content: { tag: "Basic", content: "Object" },
                     },
-                    name: "Scalar",
-                    description: "A scalar operator acting on some form",
+                    name: "Scalar multiply",
+                    description: "A scalar multiplication on a form",
                     shortcut: ["S"],
                 },
             ],
@@ -470,15 +470,16 @@ stdTheories.add(
                 configureModelGraph({
                     id: "graph",
                     name: "Graph",
-                    description: "Visualize the category with scalars as a graph",
+                    description: "Visualize the operations as a graph",
                 }),
             ],
             diagramAnalyses: [
                 configureDiagramGraph({
                     id: "graph",
                     name: "Graph",
-                    description: "Visualize the instance as a graph",
+                    description: "Visualize the equations as a diagram",
                 }),
+                configureDecapodes({}),
             ],
         });
     },
@@ -533,69 +534,6 @@ stdTheories.add(
                     name: "Diagram",
                     description: "Visualize the stock and flow diagram",
                 }),
-            ],
-        });
-    },
-);
-
-stdTheories.add(
-    {
-        id: "diagrammatic-equations",
-        name: "Equational theory",
-        description: "Systems of equations specified diagrammatically",
-        group: "Applied Mathematics",
-    },
-    (meta) => {
-        const thCategory = new catlog.ThCategory();
-        return new Theory({
-            ...meta,
-            theory: thCategory.theory(),
-            modelTypes: [
-                {
-                    tag: "ObType",
-                    obType: { tag: "Basic", content: "Object" },
-                    name: "Type",
-                    description: "Type of quantity",
-                    shortcut: ["Q"],
-                },
-                {
-                    tag: "MorType",
-                    morType: {
-                        tag: "Hom",
-                        content: { tag: "Basic", content: "Object" },
-                    },
-                    name: "Operation",
-                    description: "Arithmetical operation or differential operator",
-                    shortcut: ["A"],
-                },
-            ],
-            instanceOfName: "Equations in",
-            instanceTypes: [
-                {
-                    tag: "ObType",
-                    obType: { tag: "Basic", content: "Object" },
-                    name: "Quantity",
-                    description: "Variables and other numerical quantities",
-                    shortcut: ["Q"],
-                },
-                {
-                    tag: "MorType",
-                    morType: {
-                        tag: "Hom",
-                        content: { tag: "Basic", content: "Object" },
-                    },
-                    name: "Application",
-                    description: "Apply an operation to quantities",
-                    shortcut: ["A"],
-                },
-            ],
-            diagramAnalyses: [
-                configureDiagramGraph({
-                    id: "graph",
-                    name: "Diagram",
-                    description: "Visualize the equations as a diagram",
-                }),
-                configureDecapodes({}),
             ],
         });
     },

--- a/packages/frontend/src/stdlib/theories.tsx
+++ b/packages/frontend/src/stdlib/theories.tsx
@@ -402,9 +402,9 @@ stdTheories.add(
 stdTheories.add(
     {
         id: "unary-DEC",
-        name: "Unary DEC diagram",
+        name: "Unary DEC operators",
         description: "A category of DEC operators, including constants, on some space",
-        group: "TODO",
+        group: "Applied Mathematics",
     },
     (meta) => {
         const thCategoryWithScalars = new catlog.ThCategoryWithScalars();
@@ -435,6 +435,7 @@ stdTheories.add(
                         content: { tag: "Basic", content: "Object" },
                     },
                     name: "Scalar",
+                    arrowStyle: "scalar",
                     shortcut: ["S"],
                     description: "Morphism multiplying by a scalar",
                 },
@@ -480,7 +481,7 @@ stdTheories.add(
                 }),
             ],
         });
-    }
+    },
 );
 
 stdTheories.add(

--- a/packages/frontend/src/stdlib/theories.tsx
+++ b/packages/frontend/src/stdlib/theories.tsx
@@ -401,6 +401,90 @@ stdTheories.add(
 
 stdTheories.add(
     {
+        id: "unary-DEC",
+        name: "Unary DEC diagram",
+        description: "A category of DEC operators, including constants, on some space",
+        group: "TODO",
+    },
+    (meta) => {
+        const thCategoryWithScalars = new catlog.ThCategoryWithScalars();
+
+        return new Theory({
+            ...meta,
+            theory: thCategoryWithScalars.theory(),
+            onlyFreeModels: true,
+            modelTypes: [
+                {
+                    tag: "ObType",
+                    obType: { tag: "Basic", content: "Object" },
+                    name: "FormType",
+                    shortcut: ["F"],
+                    description: "A type of differential form on the space",
+                },
+                {
+                    tag: "MorType",
+                    morType: { tag: "Basic", content: "Nonscalar" },
+                    name: "Nonscalar",
+                    shortcut: ["N"],
+                    description: "A nonscalar operator",
+                },
+                {
+                    tag: "MorType",
+                    morType: {
+                        tag: "Hom",
+                        content: { tag: "Basic", content: "Object" },
+                    },
+                    name: "Scalar",
+                    shortcut: ["S"],
+                    description: "Morphism multiplying by a scalar",
+                },
+            ],
+            instanceTypes: [
+                {
+                    tag: "ObType",
+                    obType: { tag: "Basic", content: "Object" },
+                    name: "Form",
+                    description: "A form on the space",
+                    shortcut: ["F"],
+                },
+                {
+                    tag: "MorType",
+                    morType: { tag: "Basic", content: "Nonscalar" },
+                    name: "Nonscalar",
+                    description: "A nonscalar operator acting on some form",
+                    shortcut: ["N"],
+                },
+                {
+                    tag: "MorType",
+                    morType: {
+                        tag: "Hom",
+                        content: { tag: "Basic", content: "Object" },
+                    },
+                    name: "Scalar",
+                    description: "A scalar operator acting on some form",
+                    shortcut: ["S"],
+                },
+            ],
+            modelAnalyses: [
+                configureModelGraph({
+                    id: "graph",
+                    name: "Graph",
+                    description: "Visualize the category with scalars as a graph",
+                }),
+            ],
+            diagramAnalyses: [
+                configureDiagramGraph({
+                    id: "graph",
+                    name: "Graph",
+                    description: "Visualize the instance as a graph",
+                }),
+            ],
+        });
+    }
+);
+
+stdTheories.add(
+    {
         id: "primitive-stock-flow",
         name: "Stock and flow",
         description: "Model accumulation (stocks) and change (flows)",

--- a/packages/frontend/src/visualization/graph_svg.tsx
+++ b/packages/frontend/src/visualization/graph_svg.tsx
@@ -105,6 +105,10 @@ export function EdgeSVG<Id>(props: { edge: GraphLayout.Edge<Id> }) {
                     {defaultPath()}
                     {tgtLabel("?")}
                 </Match>
+                <Match when={props.edge.style === "scalar"}>
+                    {defaultPath()}
+                    {tgtLabel("∝")}
+                </Match>
             </Switch>
             <Show when={props.edge.label}>
                 <text
@@ -182,6 +186,7 @@ const styleToMarker: Record<ArrowStyle, ArrowMarker> = {
     plus: "triangle",
     minus: "triangle",
     indeterminate: "triangle",
+    scalar: "triangle",
 };
 
 /** SVG markers for arrow heads.

--- a/packages/frontend/src/visualization/types.ts
+++ b/packages/frontend/src/visualization/types.ts
@@ -4,7 +4,14 @@ import type { Setter } from "solid-js";
 
 Each arrow style has support to be rendered in HTML/CSS and SVG.
  */
-export type ArrowStyle = "default" | "double" | "flat" | "plus" | "minus" | "indeterminate";
+export type ArrowStyle =
+    | "default"
+    | "double"
+    | "flat"
+    | "plus"
+    | "minus"
+    | "indeterminate"
+    | "scalar";
 
 /** Prop for forwarding a ref to an `<svg>` element.
  */


### PR DESCRIPTION
Implements the theory for "categories with scalars", which are pairs of categories on the same objects in which one category acts on the other, that is, categories sliced over the monoid freely generated by an idempotent, or...Ah, yes, I just remembered that this almost promonads, except for the unitor relations. So that's worth thinking over, at least for me.

Scalar morphisms are decorated at the theory level with a little proportionality twiddle. Unfortunately it looks at a glance like we don't yet have decorated arrows implemented at the diagram level, which is where this would be most relevant. I'll see about taking a glance at that, though other things are liable to be more urgent.