### PR TITLE
Send Decapodes judgments after type inference and validation

### DIFF
--- a/packages/frontend/src/diagram/document.ts
+++ b/packages/frontend/src/diagram/document.ts
@@ -8,7 +8,7 @@ import { type LiveModelDocument, getLiveModel } from "../model";
 import { type Notebook, newNotebook } from "../notebook";
 import type { TheoryLibrary } from "../stdlib";
 import { type IdToNameMap, indexMap } from "../util/indexing";
-import { type DiagramJudgment, catlogDiagram } from "./types";
+import { type DiagramJudgment, toCatlogDiagram } from "./types";
 
 /** A document defining a diagram in a model. */
 export type DiagramDocument = {
@@ -112,7 +112,7 @@ function enlivenDiagramDocument(
                 return undefined;
             }
             const { model } = validatedModel;
-            const diagram = catlogDiagram(th.theory, formalJudgments());
+            const diagram = toCatlogDiagram(th.theory, formalJudgments());
             diagram.inferMissingFrom(model);
             const result = diagram.validateIn(model);
             return { diagram, result };

--- a/packages/frontend/src/diagram/types.ts
+++ b/packages/frontend/src/diagram/types.ts
@@ -9,7 +9,9 @@ import type {
     MorType,
     Ob,
     ObType,
+    Uuid,
 } from "catlog-wasm";
+import type { Name } from "../util/indexing";
 
 /** A judgment in the definition of a diagram in a model.
 
@@ -58,8 +60,8 @@ export const newDiagramMorphismDecl = (morType: MorType, over?: Mor): DiagramMor
     cod: null,
 });
 
-/** Construct a `catlog` diagram in a model from a sequence of judgments. */
-export function catlogDiagram(theory: DblTheory, judgments: Array<DiagramJudgment>) {
+/** Construct a diagram in `catlog` from a sequence of judgments. */
+export function toCatlogDiagram(theory: DblTheory, judgments: Array<DiagramJudgment>) {
     const diagram = new DblModelDiagram(theory);
     for (const judgment of judgments) {
         if (judgment.tag === "object") {
@@ -69,4 +71,26 @@ export function catlogDiagram(theory: DblTheory, judgments: Array<DiagramJudgmen
         }
     }
     return diagram;
+}
+
+/** Extract a sequence of judgments from a diagram in `catlog`. */
+export function fromCatlogDiagram(
+    diagram: DblModelDiagram,
+    obIdToName?: (id: Uuid) => Name | undefined,
+): Array<DiagramJudgment> {
+    const nameToString = (name?: Name) => (typeof name === "string" ? name : "");
+
+    const obDecls: DiagramObjectDecl[] = diagram.objectDeclarations().map((decl) => ({
+        tag: "object",
+        name: nameToString(obIdToName?.(decl.id)),
+        ...decl,
+    }));
+
+    const morDecls: DiagramMorphismDecl[] = diagram.morphismDeclarations().map((decl) => ({
+        tag: "morphism",
+        name: "", // Morphisms are currently unnamed in frontend.
+        ...decl,
+    }));
+
+    return [...obDecls, ...morDecls];
 }

--- a/packages/frontend/src/model/document.ts
+++ b/packages/frontend/src/model/document.ts
@@ -8,7 +8,7 @@ import { type Notebook, newNotebook } from "../notebook";
 import type { TheoryLibrary } from "../stdlib";
 import type { Theory } from "../theory";
 import { type IndexedMap, indexMap } from "../util/indexing";
-import { type ModelJudgment, catlogModel } from "./types";
+import { type ModelJudgment, toCatlogModel } from "./types";
 
 /** A document defining a model. */
 export type ModelDocument = {
@@ -110,7 +110,7 @@ function enlivenModelDocument(
                 // TODO: Currently only implemented for discrete theories.
                 return undefined;
             }
-            const model = catlogModel(th.theory, formalJudgments());
+            const model = toCatlogModel(th.theory, formalJudgments());
             const result = model.validate();
             return { model, result };
         },

--- a/packages/frontend/src/model/types.ts
+++ b/packages/frontend/src/model/types.ts
@@ -45,8 +45,8 @@ export const newMorphismDecl = (morType: MorType): MorphismDecl => ({
     cod: null,
 });
 
-/** Construct a `catlog` model from a sequence of model judgments. */
-export function catlogModel(theory: DblTheory, judgments: Array<ModelJudgment>): DblModel {
+/** Construct a model in `catlog` from a sequence of judgments. */
+export function toCatlogModel(theory: DblTheory, judgments: Array<ModelJudgment>): DblModel {
     const model = new DblModel(theory);
     for (const judgment of judgments) {
         if (judgment.tag === "object") {

--- a/packages/frontend/src/stdlib/analyses/decapodes.tsx
+++ b/packages/frontend/src/stdlib/analyses/decapodes.tsx
@@ -142,6 +142,11 @@ export function Decapodes(props: DiagramAnalysisProps<JupyterSettings>) {
                 <Match when={result.error}>
                     {(error) => <ErrorAlert title="Simulation error">{error().message}</ErrorAlert>}
                 </Match>
+                <Match when={props.liveDiagram.validatedDiagram()?.result.tag === "Err"}>
+                    <ErrorAlert title="Modeling error">
+                        {"Cannot run the simulation because the diagram is invalid"}
+                    </ErrorAlert>
+                </Match>
                 <Match when={result()}>{(data) => <PDEPlot2D data={data()} />}</Match>
             </Switch>
         </div>


### PR DESCRIPTION
Follow up to #267 that should:

1. Prevent the frontend from sending a diagram to Decapodes that has not been validated
2. Enable use of anonymous objects (#270) by sending the diagram *after* type inference has been performed