### PR TITLE
UI to edit scalar constants in Decapodes analysis

### DIFF
--- a/packages/frontend/src/components/foldable.css
+++ b/packages/frontend/src/components/foldable.css
@@ -1,18 +1,17 @@
-.foldable button {
+.foldable-header {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    width: 100%;
+    padding: 5px 0;
+}
+
+.foldable-header button {
     background: none;
     border: none;
     cursor: pointer;
     outline: none;
     font: inherit;
-    width: 100%;
-    padding: 5px;
-}
-
-.foldable button .panel {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: none;
-    justify-content: space-between;
 }
 
 [data-corvu-disclosure-content] {

--- a/packages/frontend/src/components/foldable.tsx
+++ b/packages/frontend/src/components/foldable.tsx
@@ -18,22 +18,16 @@ export function Foldable(props: {
 
     // NOTE: Set the collapse behavior to "hide" to get a smooth animation.
     return (
-        <div class="foldable">
-            <Discloure
-                expanded={isExpanded()}
-                onExpandedChange={setIsExpanded}
-                collapseBehavior="hide"
-            >
+        <Discloure expanded={isExpanded()} onExpandedChange={setIsExpanded} collapseBehavior="hide">
+            <div class="foldable-header">
+                {props.header}
                 <Discloure.Trigger>
-                    <span class="panel">
-                        {props.header}
-                        <Show when={isExpanded()} fallback={<ChevronDown />}>
-                            <ChevronUp />
-                        </Show>
-                    </span>
+                    <Show when={isExpanded()} fallback={<ChevronDown />}>
+                        <ChevronUp />
+                    </Show>
                 </Discloure.Trigger>
-                <Discloure.Content>{props.children}</Discloure.Content>
-            </Discloure>
-        </div>
+            </div>
+            <Discloure.Content>{props.children}</Discloure.Content>
+        </Discloure>
     );
 }

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -100,7 +100,7 @@ h4 {
 }
 
 .content-panel {
-    overflow-x: scroll;
+    overflow-x: auto;
     overflow-y: hidden;
 }
 

--- a/packages/frontend/src/stdlib/analyses/base_styles.module.css
+++ b/packages/frontend/src/stdlib/analyses/base_styles.module.css
@@ -2,6 +2,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
+    width: 100%;
 
     & .filler {
         flex: 1;


### PR DESCRIPTION
Sequel to @KevinDCarlson's #274. Adds a tabular editor for scalar constants, similar to that used for Lotka-Volterra dynamics, and sends the constants to the Julia kernel.

Integration on the Julia side is pending.