### PR TITLE
Reactive helpers for Jupyter kernels

### DIFF
--- a/packages/frontend/src/stdlib/analyses/decapodes.tsx
+++ b/packages/frontend/src/stdlib/analyses/decapodes.tsx
@@ -21,7 +21,7 @@ import type { ModelJudgment, MorphismDecl } from "../../model";
 import type { DiagramAnalysisMeta } from "../../theory";
 import { uniqueIndexArray } from "../../util/indexing";
 import { PDEPlot2D, type PDEPlotData2D } from "../../visualization";
-import { createKernel, executeAndRetrieve } from "./jupyter";
+import { createJuliaKernel, executeAndRetrieve } from "./jupyter";
 
 import Loader from "lucide-solid/icons/loader";
 import RotateCcw from "lucide-solid/icons/rotate-ccw";
@@ -68,15 +68,10 @@ export function configureDecapodes(options: {
  */
 export function Decapodes(props: DiagramAnalysisProps<DecapodesContent>) {
     // Step 1: Start the Julia kernel.
-    const [kernel, restartKernel] = createKernel(
-        {
-            baseUrl: "http://127.0.0.1:8888",
-            token: "",
-        },
-        {
-            name: "julia-1.11",
-        },
-    );
+    const [kernel, restartKernel] = createJuliaKernel({
+        baseUrl: "http://127.0.0.1:8888",
+        token: "",
+    });
 
     // Step 2: Run initialization code in the kernel.
     const startedKernel = () => (kernel.error ? undefined : kernel());

--- a/packages/frontend/src/stdlib/analyses/jupyter.ts
+++ b/packages/frontend/src/stdlib/analyses/jupyter.ts
@@ -1,15 +1,21 @@
 import type { ServerConnection } from "@jupyterlab/services";
 import type { IKernelConnection, IKernelOptions } from "@jupyterlab/services/lib/kernel/kernel";
-import { type Resource, type ResourceReturn, createResource, onCleanup } from "solid-js";
+import {
+    type Accessor,
+    type Resource,
+    type ResourceReturn,
+    createResource,
+    onCleanup,
+} from "solid-js";
 
 type ResourceRefetch<T> = ResourceReturn<T>[1]["refetch"];
 
 type ServerSettings = Parameters<typeof ServerConnection.makeSettings>[0];
 
-/** Create a Jupyter kernel as a Solid resource.
+/** Create a Jupyter kernel in a reactive context.
 
-Returns a handle to the resource and a callback to restart the kernel. The
-kernel is automatically shut down when the component is unmounted.
+Returns a kernel as a Solid.js resource and a callback to restart the kernel.
+The kernel is automatically shut down when the component is unmounted.
  */
 export function createKernel(
     serverOptions: ServerSettings,
@@ -30,3 +36,66 @@ export function createKernel(
 
     return [kernel, restartKernel];
 }
+
+/** Execute code in a Jupyter kernel and retrieve JSON data reactively.
+
+Returns the post-processed data as a Solid.js resource and a callback to rerun
+the computation.
+
+The resource depends reactively on the kernel: if the kernel changes, the code
+will be automatically re-executed. It does *not* depend reactively on the code.
+If the code changes, it must be rerun manually.
+ */
+export function executeAndRetrieve<S, T>(
+    kernel: Accessor<IKernelConnection | undefined>,
+    executeCode: Accessor<string | undefined>,
+    postprocess: (data: S) => T,
+): [Resource<T | undefined>, ResourceRefetch<T>] {
+    const [data, { refetch: reexecute }] = createResource(kernel, async (kernel) => {
+        // Request that kernel execute code, if defined.
+        const code = executeCode();
+        if (code === undefined) {
+            return undefined;
+        }
+        const future = kernel.requestExecute({ code });
+
+        // Set up handler for result from kernel.
+        let result: { data: S } | undefined;
+        future.onIOPub = (msg) => {
+            if (
+                msg.header.msg_type === "execute_result" &&
+                msg.parent_header.msg_id === future.msg.header.msg_id
+            ) {
+                const content = msg.content as JsonDataContent<S>;
+                const data = content["data"]?.["application/json"];
+                if (data !== undefined) {
+                    result = { data };
+                }
+            }
+        };
+
+        // Wait for execution to finish and process result.
+        const reply = await future.done;
+        if (reply.content.status === "abort") {
+            throw new Error("Execution was aborted");
+        }
+        if (reply.content.status === "error") {
+            // Trackback list already includes `reply.content.evalue`.
+            const msg = reply.content.traceback.join("\n");
+            throw new Error(msg);
+        }
+        if (result === undefined) {
+            throw new Error("Data was not received from the kernel");
+        }
+        return postprocess(result.data);
+    });
+
+    return [data, reexecute];
+}
+
+/** JSON data returned from a Jupyter kernel. */
+type JsonDataContent<T> = {
+    data?: {
+        "application/json"?: T;
+    };
+};

--- a/packages/frontend/src/stdlib/analyses/jupyter.ts
+++ b/packages/frontend/src/stdlib/analyses/jupyter.ts
@@ -37,10 +37,19 @@ export function createKernel(
     return [kernel, restartKernel];
 }
 
+/** Create a Julia kernel in a reactive context. */
+export function createJuliaKernel(serverOptions: ServerSettings) {
+    return createKernel(serverOptions, {
+        // XXX: Do I have to specify the Julia version?
+        name: "julia-1.11",
+    });
+}
+
 /** Execute code in a Jupyter kernel and retrieve JSON data reactively.
 
-Returns the post-processed data as a Solid.js resource and a callback to rerun
-the computation.
+Assumes that the computation will return JSON data using the "application/json"
+MIME type in Jupyter. Returns the post-processed data as a Solid.js resource and
+a callback to rerun the computation.
 
 The resource depends reactively on the kernel: if the kernel changes, the code
 will be automatically re-executed. It does *not* depend reactively on the code.

--- a/packages/frontend/src/stdlib/analyses/jupyter.ts
+++ b/packages/frontend/src/stdlib/analyses/jupyter.ts
@@ -1,0 +1,32 @@
+import type { ServerConnection } from "@jupyterlab/services";
+import type { IKernelConnection, IKernelOptions } from "@jupyterlab/services/lib/kernel/kernel";
+import { type Resource, type ResourceReturn, createResource, onCleanup } from "solid-js";
+
+type ResourceRefetch<T> = ResourceReturn<T>[1]["refetch"];
+
+type ServerSettings = Parameters<typeof ServerConnection.makeSettings>[0];
+
+/** Create a Jupyter kernel as a Solid resource.
+
+Returns a handle to the resource and a callback to restart the kernel. The
+kernel is automatically shut down when the component is unmounted.
+ */
+export function createKernel(
+    serverOptions: ServerSettings,
+    kernelOptions: IKernelOptions,
+): [Resource<IKernelConnection>, ResourceRefetch<IKernelConnection>] {
+    const [kernel, { refetch: restartKernel }] = createResource(async () => {
+        const jupyter = await import("@jupyterlab/services");
+
+        const serverSettings = jupyter.ServerConnection.makeSettings(serverOptions);
+
+        const kernelManager = new jupyter.KernelManager({ serverSettings });
+        const kernel = await kernelManager.startNew(kernelOptions);
+
+        return kernel;
+    });
+
+    onCleanup(() => kernel()?.shutdown());
+
+    return [kernel, restartKernel];
+}


### PR DESCRIPTION
Refactor following #283. Equivalent in functionality but the Jupyter kernel management is separated into an independent, reusable module.