### PR TITLE
Remove redundant mesh parameter in Decapodes interop

### DIFF
--- a/packages/algjulia-service/src/decapodes-service/geometry.jl
+++ b/packages/algjulia-service/src/decapodes-service/geometry.jl
@@ -70,7 +70,6 @@ end
 
 struct Geometry
     domain::Domain
-    mesh::HasDeltaSet
     dualmesh::HasDeltaSet
 end
 
@@ -88,7 +87,7 @@ function Geometry(r::Rectangle, division::SimplexCenter=Circumcenter())
     s = triangulated_grid(r.max_x, r.max_y, r.dx, r.dy, Point2{Float64})
     sd = EmbeddedDeltaDualComplex2D{Bool, Float64, Point2{Float64}}(s)
     subdivide_duals!(sd, division)
-    Geometry(r, s, sd)
+    Geometry(r, sd)
 end
 
 # function Geometry(r::Periodic, division::SimplexCenter=Circumcenter()) end
@@ -97,14 +96,14 @@ function Geometry(m::Sphere, division::SimplexCenter=Circumcenter())
     s = loadmesh(Icosphere(m.dim, m.radius))
     sd = EmbeddedDeltaDualComplex2D{Bool, Float64, Point3{Float64}}(s)
     subdivide_duals!(sd, division)
-    Geometry(m, s, sd)
+    Geometry(m, sd)
 end
 
 function Geometry(m::UV, division::SimplexCenter=Circumcenter())
     s, _, _ = makeSphere(m)
     sd = EmbeddedDeltaDualComplex2D{Bool, Float64, Point3{Float64}}(s)
     subdivide_duals!(sd, division)
-    Geometry(m, s, sd)
+    Geometry(m, sd)
 end
 
 ## Prefined meshes

--- a/packages/algjulia-service/src/decapodes-service/simulation.jl
+++ b/packages/algjulia-service/src/decapodes-service/simulation.jl
@@ -70,7 +70,7 @@ function PodeSystem(json_object::AbstractDict, hodge=GeometricHodge())
 end
 export PodeSystem
 
-points(system::PodeSystem) = collect(values(system.geometry.mesh.subparts.point.m))
+points(system::PodeSystem) = collect(values(system.geometry.dualmesh.subparts.point.m))
 indexing_bounds(system::PodeSystem) = indexing_bounds(system.geometry.domain)
 
 function run_sim(fm, u0, t0, constparam)


### PR DESCRIPTION
We can access data about the mesh associated to a dual mesh from within the dual mesh, so storing `mesh` in the `Geometry` struct is redundant.

For example, we can retrieve the points of a mesh from the same field in `dual_mesh`.

I've verified with Gaussian initial conditions for [this diagram](http://localhost:5173/analysis/01939916-b367-70f0-bdbf-3ff92b4c700d) in the model of 2D DEC that the simulation still runs and appears to diffuse as expected.