### PR TITLE
Plot non-state variables in Decapodes

### DIFF
--- a/packages/algjulia-service/test/runtests.jl
+++ b/packages/algjulia-service/test/runtests.jl
@@ -107,27 +107,27 @@ end
 #= XXX ERRORING
 we are trying to index `soln.u[t]` by `Ċ `, but only `C` is present. I think this is because we generating initial conditions based on what was specified to the `initial_conditions` parameter, whereas in the past we were using `infer_state_names` to obtain that.
 =#
-# @testset "Simulation - Diffusion with Two Variables" begin
+@testset "Simulation - Diffusion with Two Variables" begin
 
-#     json_string = read(joinpath(@__DIR__, "test_jsons", "diffusion_data_twovars.json"), String);
-#     @test Set(keys(JSON3.read(json_string))) == KEYS
+    json_string = read(joinpath(@__DIR__, "test_jsons", "diffusion_data_twovars.json"), String);
+    @test Set(keys(JSON3.read(json_string))) == KEYS
 
-#     system = PodeSystem(json_string);
+    system = PodeSystem(json_string);
 
-#     simulator = evalsim(system.pode)
-#     f = simulator(system.geometry.dualmesh, system.generate, DiagonalHodge())
+    simulator = evalsim(system.pode)
+    f = simulator(system.geometry.dualmesh, system.generate, DiagonalHodge())
 
-#     soln = run_sim(f, system.init, 50.0, ComponentArray(k=0.5,)); 
+    soln = run_sim(f, system.init, 50.0, ComponentArray(k=0.5,));
 
-#     @test soln.retcode == ReturnCode.Success
+    @test soln.retcode == ReturnCode.Success
   
-#     result = SimResult(soln, system);
+    result = SimResult(soln, system);
 
-#     @test typeof(result.state) == Dict{String, Vector{AbstractArray{SVector{3, Float64}}}}
+    @test typeof(result.state) == Dict{String, Vector{AbstractArray{SVector{3, Float64}}}}
 
-#     jvs = JsonValue(result);
+    jvs = JsonValue(result);
 
-# end
+end
 
 @testset "Parsing the Model JSON Object - Diffusion Long Trip" begin
 

--- a/packages/algjulia-service/test/test_jsons/diffusion_data_twovars.json
+++ b/packages/algjulia-service/test/test_jsons/diffusion_data_twovars.json
@@ -68,11 +68,8 @@
       },
       "id": "01932404-10e5-7128-bb94-835e5d8d643f",
       "morType": {
-        "content": {
-          "content": "Object",
+          "content": "Nonscalar",
           "tag": "Basic"
-        },
-        "tag": "Hom"
       },
       "name": "",
       "over": {


### PR DESCRIPTION
This feature allows us to plot non-state variables.

Currently, state variables are able to be retrieved from the ODESolution object, and therefore plotted, because they are passed in as initial conditions to the solver. However the variables specified for plotting are stored in a separate field, `plotVars`, and therefore may not have initial conditions.

The design decision made in this draft PR intends to also endow variables in plotVars with a default initial condition called "Zeros." The `initial_conditions` function dispatches on `Zeroes` initial condition type, returning `zeros(geometry.dualmesh[:point])`.

At the time of opening this draft PR, _all variables_ in the `uuid2symb` mapping are given Zeroes ICs if they are not specified in the `initialConditions` field in the JSON.

My question is
1. should AlgebraicJuliaService restrict giving ICs to just symbols in either initial conditions (`ic_specs`) or specified to be plotted, or should every variable be given ICs?
2. Is giving a default IC always valid? For instance if we give Zeroes, what if the model has a singularity at 0?
3. Are there ways of extracting the trajectories of variables where ICs are not provided? I've checked [ODESolution](https://github.com/SciML/SciMLBase.jl/blob/acabca532aa383477b0967b29e21a1a36ce0e0d8/src/solutions/ode_solutions.jl#L92) source and I'm doubtful.