### PR TITLE
Fix wrong placement of caesuras when multiple graphs share edges

### DIFF
--- a/packages/frontend/src/visualization/graph_layout.ts
+++ b/packages/frontend/src/visualization/graph_layout.ts
@@ -19,7 +19,9 @@ export interface Graph<Id> {
     edges: Array<Edge<Id>>;
 }
 
-export interface Node<Id> extends GraphElement<Id> {
+export interface Node<Id> extends GraphElement {
+    id: Id;
+
     /** Position of node, with origin at center of node. */
     pos: Point;
 
@@ -33,7 +35,9 @@ export interface Node<Id> extends GraphElement<Id> {
     label?: string;
 }
 
-export interface Edge<Id> extends GraphElement<Id> {
+export interface Edge<Id> extends GraphElement {
+    id?: Id;
+
     /** Source node of edge. */
     source: Id;
 
@@ -59,10 +63,7 @@ export interface Edge<Id> extends GraphElement<Id> {
     style?: ArrowStyle;
 }
 
-export interface GraphElement<Id> {
-    /** ID of element, unique within graph. */
-    id: Id;
-
+export interface GraphElement {
     /** CSS class (or classes) to apply to element. */
     cssClass?: string;
 }

--- a/packages/frontend/src/visualization/graph_svg.tsx
+++ b/packages/frontend/src/visualization/graph_svg.tsx
@@ -1,5 +1,5 @@
 import { destructure } from "@solid-primitives/destructure";
-import { type Component, For, Index, Match, Show, Switch } from "solid-js";
+import { type Component, For, Index, Match, Show, Switch, createUniqueId } from "solid-js";
 import { Dynamic } from "solid-js/web";
 
 import type * as GraphLayout from "./graph_layout";
@@ -69,7 +69,9 @@ export function EdgeSVG<Id>(props: { edge: GraphLayout.Edge<Id> }) {
         const marker = styleToMarker[style];
         return `url(#arrowhead-${marker})`;
     };
-    const pathId = () => `path${props.edge.id}`;
+
+    const componentId = createUniqueId();
+    const pathId = () => `edge-path-${componentId}`;
     const defaultPath = () => <path id={pathId()} marker-end={markerUrl()} d={path()} />;
 
     const tgtLabel = (text: string) => {

--- a/packages/frontend/src/visualization/graphviz.ts
+++ b/packages/frontend/src/visualization/graphviz.ts
@@ -79,9 +79,6 @@ export function parseGraphvizJSON(graphviz: GraphvizJSON.Graph): GraphLayout.Gra
             // Omit invisible edges, used to tweak the layout in Graphviz.
             continue;
         }
-        const id = edge.id;
-        invariant(id, "Edge ID should be defined");
-
         const [sourceNode, targetNode] = [nodeByNumber(edge.head), nodeByNumber(edge.tail)];
         invariant(sourceNode && targetNode, "Source and target nodes should be defined");
 
@@ -92,7 +89,7 @@ export function parseGraphvizJSON(graphviz: GraphvizJSON.Graph): GraphLayout.Gra
         invariant(sourcePos && targetPos, "Source and target positions should be defined");
 
         edges.push({
-            id,
+            id: edge.id,
             source: sourceNode.id,
             target: targetNode.id,
             label: edge.xlabel ?? edge.label,


### PR DESCRIPTION
SVG path IDs must be unique across the whole document when SVG is included inline. Fun stuff.

Follow up to #322.