### PR TITLE
Distinguish icons for different kinds of help

### DIFF
--- a/packages/frontend/src/page/menubar.tsx
+++ b/packages/frontend/src/page/menubar.tsx
@@ -4,14 +4,13 @@ import { getAuth, signOut } from "firebase/auth";
 import { useAuth, useFirebaseApp } from "solid-firebase";
 import { type JSX, Show, createSignal } from "solid-js";
 
-import { Dialog, IconButton } from "../components";
-import { Login } from "../user";
-
-import CircleHelp from "lucide-solid/icons/circle-help";
+import Info from "lucide-solid/icons/info";
 import LogInIcon from "lucide-solid/icons/log-in";
 import LogOutIcon from "lucide-solid/icons/log-out";
 import MenuIcon from "lucide-solid/icons/menu";
 import SettingsIcon from "lucide-solid/icons/settings";
+import { Dialog, IconButton } from "../components";
+import { Login } from "../user";
 
 import "./menubar.css";
 
@@ -83,8 +82,8 @@ function HelpMenuItem() {
 
     return (
         <MenuItem onSelect={() => navigate("/help")}>
-            <CircleHelp />
-            <MenuItemLabel>Help</MenuItemLabel>
+            <Info />
+            <MenuItemLabel>{"About"}</MenuItemLabel>
         </MenuItem>
     );
 }
@@ -117,7 +116,7 @@ function SettingsMenuItem() {
     return (
         <MenuItem onSelect={() => navigate("/profile")}>
             <SettingsIcon />
-            <MenuItemLabel>Settings</MenuItemLabel>
+            <MenuItemLabel>{"Settings"}</MenuItemLabel>
         </MenuItem>
     );
 }

--- a/packages/frontend/src/page/menubar.tsx
+++ b/packages/frontend/src/page/menubar.tsx
@@ -4,16 +4,16 @@ import { getAuth, signOut } from "firebase/auth";
 import { useAuth, useFirebaseApp } from "solid-firebase";
 import { type JSX, Show, createSignal } from "solid-js";
 
+import { Dialog, IconButton } from "../components";
+import { Login } from "../user";
+
 import Info from "lucide-solid/icons/info";
 import LogInIcon from "lucide-solid/icons/log-in";
 import LogOutIcon from "lucide-solid/icons/log-out";
 import MenuIcon from "lucide-solid/icons/menu";
 import SettingsIcon from "lucide-solid/icons/settings";
-import { Dialog, IconButton } from "../components";
-import { Login } from "../user";
 
 import "./menubar.css";
-
 /** Menu triggered from a hamburger button. */
 export function HamburgerMenu(props: {
     children: JSX.Element;

--- a/packages/frontend/src/page/menubar.tsx
+++ b/packages/frontend/src/page/menubar.tsx
@@ -83,7 +83,7 @@ function HelpMenuItem() {
     return (
         <MenuItem onSelect={() => navigate("/help")}>
             <Info />
-            <MenuItemLabel>{"About"}</MenuItemLabel>
+            <MenuItemLabel>Info & documentation</MenuItemLabel>
         </MenuItem>
     );
 }
@@ -116,7 +116,7 @@ function SettingsMenuItem() {
     return (
         <MenuItem onSelect={() => navigate("/profile")}>
             <SettingsIcon />
-            <MenuItemLabel>{"Settings"}</MenuItemLabel>
+            <MenuItemLabel>Settings</MenuItemLabel>
         </MenuItem>
     );
 }


### PR DESCRIPTION
Closes #319 

To clarify interface for different kinds of help. This also includes a small change to have the syntax be the same for all the menu items. 