### PR TITLE
Duration parameter for Decapodes simulations

### DIFF
--- a/packages/algjulia-service/src/decapodes-service/simulation.jl
+++ b/packages/algjulia-service/src/decapodes-service/simulation.jl
@@ -6,6 +6,7 @@ struct PodeSystem
     init::ComponentArray
     generate::Any
     uuiddict::Dict{Symbol, String}
+    duration::Int
 end
 export PodeSystem
 
@@ -66,7 +67,10 @@ function PodeSystem(json_object::AbstractDict, hodge=GeometricHodge())
     # symbol => uuid. we need this to reassociate the var 
     symb2uuid = Dict([v => k for (k,v) in pairs(uuid2symb)])
 
-    return PodeSystem(decapode, plotvars, anons, geometry, u0, sys_generate, symb2uuid)
+    # duration
+    duration = json_object[:duration]
+
+    return PodeSystem(decapode, plotvars, anons, geometry, u0, sys_generate, symb2uuid, duration)
 end
 export PodeSystem
 

--- a/packages/algjulia-service/test/runtests.jl
+++ b/packages/algjulia-service/test/runtests.jl
@@ -13,7 +13,7 @@ using StaticArrays
 using LinearAlgebra
 import OrdinaryDiffEq: ReturnCode
 
-const KEYS = Set([:mesh, :plotVariables, :initialConditions, :domain, :diagram, :model, :scalars])
+const KEYS = Set([:mesh, :plotVariables, :initialConditions, :domain, :diagram, :model, :scalars, :duration])
 
 # load data
 data = open(JSON3.read, joinpath(@__DIR__, "test_jsons", "diffusivity_constant.json"), "r")

--- a/packages/algjulia-service/test/test_jsons/diffusion_long_trip.json
+++ b/packages/algjulia-service/test/test_jsons/diffusion_long_trip.json
@@ -4,6 +4,7 @@
   "initialConditions": {
 	"01936ee4-8a1d-7bd7-a2c4-0f5291893346": "Gaussian"
   },
+  "duration": 10,
   "plotVariables": ["01936ee4-8a1d-7bd7-a2c4-0f5291893346"],
     "diagram": [
         {

--- a/packages/algjulia-service/test/test_jsons/diffusivity_constant.json
+++ b/packages/algjulia-service/test/test_jsons/diffusivity_constant.json
@@ -5,6 +5,7 @@
 	"01936f2e-2f39-738d-8af2-5caf75b29f3a": "Gaussian"
   },
   "plotVariables": ["01936f2e-2f39-738d-8af2-5caf75b29f3a"],
+  "duration": 10,
   "diagram": [
     {
       "tag": "object",

--- a/packages/algjulia-service/test/test_jsons/ns_vorticity.json
+++ b/packages/algjulia-service/test/test_jsons/ns_vorticity.json
@@ -532,6 +532,7 @@
             "tag": "morphism"
         }
     ],
+	"duration": 10,
     "domain": "Sphere",
     "mesh": "Icosphere6",
     "initialConditions": {

--- a/packages/frontend/src/stdlib/analyses/decapodes.tsx
+++ b/packages/frontend/src/stdlib/analyses/decapodes.tsx
@@ -1,5 +1,4 @@
-
-     0.0
+0.0;
 import { For, Match, Show, Switch, createMemo } from "solid-js";
 import { isMatching } from "ts-pattern";
 
@@ -38,7 +37,7 @@ export type DecapodesContent = {
     initialConditions: Record<string, string>;
     plotVariables: Record<string, boolean>;
     scalars: Record<string, number>;
-	duration: number;
+    duration: number;
 };
 
 export function configureDecapodes(options: {
@@ -62,7 +61,7 @@ export function configureDecapodes(options: {
             initialConditions: {},
             plotVariables: {},
             scalars: {},
-			duration: 10,
+            duration: 10,
         }),
     };
 }
@@ -177,17 +176,17 @@ export function Decapodes(props: DiagramAnalysisProps<DecapodesContent>) {
         },
     ];
 
-	const toplevelSchema: ColumnSchema<null>[] = [
-		createNumericalColumn({
-			name: "Duration",
-			data: (_) => props.content.duration,
-			validate: (_, data) => data >= 0,
-			setData: (_, data) =>
-				props.changeContent((content) => {
-					content.duration = data;
-				}),
-			}),
-		];
+    const toplevelSchema: ColumnSchema<null>[] = [
+        createNumericalColumn({
+            name: "Duration",
+            data: (_) => props.content.duration,
+            validate: (_, data) => data >= 0,
+            setData: (_, data) =>
+                props.changeContent((content) => {
+                    content.duration = data;
+                }),
+        }),
+    ];
 
     const RestartOrRerunButton = () => (
         <Switch>
@@ -259,7 +258,7 @@ export function Decapodes(props: DiagramAnalysisProps<DecapodesContent>) {
                 <div class="parameters">
                     <FixedTableEditor rows={obDecls()} schema={variableSchema} />
                     <FixedTableEditor rows={scalarDecls()} schema={scalarSchema} />
-					<FixedTableEditor rows={[null]} schema={toplevelSchema} />
+                    <FixedTableEditor rows={[null]} schema={toplevelSchema} />
                 </div>
             </Foldable>
             <Switch>
@@ -340,8 +339,8 @@ type SimulationData = {
     /** Mapping from UIIDs of scalar operations to numerical values. */
     scalars: Record<string, number>;
 
-	/** Duration */
-	duration: number;
+    /** Duration */
+    duration: number;
 };
 
 /** Julia code run after kernel is started. */
@@ -393,6 +392,6 @@ const makeSimulationData = (
         initialConditions,
         plotVariables: Object.keys(plotVariables).filter((v) => plotVariables[v]),
         scalars,
-		duration,
+        duration,
     };
 };

--- a/packages/frontend/src/stdlib/analyses/decapodes.tsx
+++ b/packages/frontend/src/stdlib/analyses/decapodes.tsx
@@ -1,4 +1,3 @@
-0.0;
 import { For, Match, Show, Switch, createMemo } from "solid-js";
 import { isMatching } from "ts-pattern";
 
@@ -362,7 +361,7 @@ const makeSimulationCode = (data: SimulationData) =>
 
     f = simulator(system.geometry.dualmesh, system.generate, DiagonalHodge());
 
-    soln = run_sim(f, system.init, ${data.duration}, ComponentArray(k=0.5,));
+    soln = run_sim(f, system.init, system.duration, ComponentArray(k=0.5,));
 
     JsonValue(SimResult(soln, system))
     `;


### PR DESCRIPTION
This PR adds another table, "Duration," to capture a timestep that the simulation runs in. I've tested this with [diffusion](http://localhost:5173/analysis/0193b10e-e3a9-7772-8cf2-db157bc796d8) by setting duration to be 5 and 50 respectively, observing that t=50 appears to take an amount of time I'd expect to be 10x longer.

Setting the duration to t=100 gave me a "kernel failed to return data" (probably not exact wording) error. So it might be the case that setting longer durations would break the sim.