### PR TITLE
Have menu bar float with scroll in model

### DIFF
--- a/packages/frontend/src/page/toolbar.css
+++ b/packages/frontend/src/page/toolbar.css
@@ -15,6 +15,12 @@
     }
 }
 
+@media (max-width: 1100px) {
+    .toolbar {
+        position: static;
+    }
+}
+
 .brand {
     display: flex;
     flex-direction: row;

--- a/packages/frontend/src/page/toolbar.css
+++ b/packages/frontend/src/page/toolbar.css
@@ -1,4 +1,6 @@
 .toolbar {
+    position: sticky;
+    top: 0;
     display: flex;
     flex-direction: row;
     gap: 5px;


### PR DESCRIPTION
Closes #358 

If the screen is less than 1100px wide there was an issue with the toolbar overlapping the content:

![image](https://github.com/user-attachments/assets/888eb148-84b5-4808-950a-961643f0d2df)

To work around this the toolbar is only sticky if the screen is at least 1100px wide