### PR TITLE
Page container and reorganized menubar

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import { ErrorBoundary, Show, createResource, lazy } from "solid-js";
 import { type Api, ApiContext, createRpcClient, useApi } from "./api";
 import { helpRoutes } from "./help/routes";
 import { createModel } from "./model/document";
+import { PageContainer } from "./page/page_container";
 import { TheoryLibraryContext, stdTheories } from "./stdlib";
 import { ErrorBoundaryDialog } from "./util/errors";
 
@@ -42,7 +43,9 @@ const Root = (props: RouteSectionProps<unknown>) => {
                 [TheoryLibraryContext, stdTheories],
             ]}
         >
-            <FirebaseProvider app={firebaseApp}>{props.children}</FirebaseProvider>
+            <FirebaseProvider app={firebaseApp}>
+                <PageContainer>{props.children}</PageContainer>
+            </FirebaseProvider>
         </MultiProvider>
     );
 };

--- a/packages/frontend/src/analysis/analysis_editor.tsx
+++ b/packages/frontend/src/analysis/analysis_editor.tsx
@@ -142,7 +142,7 @@ export function AnalysisDocumentEditor(props: {
 const AnalysisMenu = (props: {
     liveAnalysis?: LiveAnalysisDocument;
 }) => {
-    const liveDocument = (() => {
+    const liveDocument = () => {
         switch (props.liveAnalysis?.analysisType) {
             case "diagram":
                 return props.liveAnalysis.liveDiagram;
@@ -151,11 +151,11 @@ const AnalysisMenu = (props: {
             default:
                 return undefined;
         }
-    })();
+    };
 
     return (
-        <AppMenu disabled={liveDocument === undefined}>
-            <Show when={liveDocument}>
+        <AppMenu disabled={liveDocument() === undefined}>
+            <Show when={liveDocument()}>
                 {(liveDocument) => <LiveDocumentMenuItems liveDocument={liveDocument()} />}
             </Show>
         </AppMenu>

--- a/packages/frontend/src/analysis/analysis_editor.tsx
+++ b/packages/frontend/src/analysis/analysis_editor.tsx
@@ -22,7 +22,7 @@ import {
     NotebookEditor,
     newFormalCell,
 } from "../notebook";
-import { AppMenu, TheoryHelpButton, Toolbar } from "../page";
+import { AppMenu, DocumentMenuItems, TheoryHelpButton, Toolbar } from "../page";
 import { TheoryLibraryContext } from "../stdlib";
 import type { AnalysisMeta } from "../theory";
 import { LiveAnalysisContext } from "./context";
@@ -36,7 +36,6 @@ import type { Analysis } from "./types";
 
 import PanelRight from "lucide-solid/icons/panel-right";
 import PanelRightClose from "lucide-solid/icons/panel-right-close";
-import { LiveDocumentMenuItems } from "../page/live_document_menu";
 
 export default function AnalysisPage() {
     const api = useApi();
@@ -156,7 +155,7 @@ const AnalysisMenu = (props: {
     return (
         <AppMenu disabled={liveDocument() === undefined}>
             <Show when={liveDocument()}>
-                {(liveDocument) => <LiveDocumentMenuItems liveDocument={liveDocument()} />}
+                {(liveDocument) => <DocumentMenuItems liveDocument={liveDocument()} />}
             </Show>
         </AppMenu>
     );

--- a/packages/frontend/src/diagram/diagram_editor.tsx
+++ b/packages/frontend/src/diagram/diagram_editor.tsx
@@ -13,7 +13,7 @@ import {
     cellShortcutModifier,
     newFormalCell,
 } from "../notebook";
-import { TheoryHelpButton, Toolbar } from "../page";
+import { DocumentMenu, TheoryHelpButton, Toolbar } from "../page";
 import { TheoryLibraryContext } from "../stdlib";
 import type { InstanceTypeMeta } from "../theory";
 import { MaybePermissionsButton } from "../user";
@@ -31,7 +31,6 @@ import {
 } from "./types";
 
 import "./diagram_editor.css";
-import { LiveDocumentMenu } from "../page/live_document_menu";
 
 export default function DiagramPage() {
     const api = useApi();
@@ -54,7 +53,7 @@ export function DiagramDocumentEditor(props: {
     return (
         <div class="growable-container">
             <Toolbar>
-                <LiveDocumentMenu liveDocument={props.liveDiagram} />
+                <DocumentMenu liveDocument={props.liveDiagram} />
                 <span class="filler" />
                 <TheoryHelpButton theory={props.liveDiagram?.liveModel.theory()} />
                 <MaybePermissionsButton

--- a/packages/frontend/src/model/model_editor.tsx
+++ b/packages/frontend/src/model/model_editor.tsx
@@ -11,7 +11,7 @@ import {
     cellShortcutModifier,
     newFormalCell,
 } from "../notebook";
-import { TheoryHelpButton, Toolbar } from "../page";
+import { DocumentMenu, TheoryHelpButton, Toolbar } from "../page";
 import { TheoryLibraryContext } from "../stdlib";
 import type { ModelTypeMeta } from "../theory";
 import { MaybePermissionsButton } from "../user";
@@ -30,7 +30,6 @@ import {
 } from "./types";
 
 import "./model_editor.css";
-import { LiveDocumentMenu } from "../page/live_document_menu";
 
 export default function ModelPage() {
     const api = useApi();
@@ -53,7 +52,7 @@ export function ModelDocumentEditor(props: {
     return (
         <div class="growable-container">
             <Toolbar>
-                <LiveDocumentMenu liveDocument={props.liveModel} />
+                <DocumentMenu liveDocument={props.liveModel} />
                 <span class="filler" />
                 <TheoryHelpButton theory={props.liveModel?.theory()} />
                 <MaybePermissionsButton

--- a/packages/frontend/src/page/context.ts
+++ b/packages/frontend/src/page/context.ts
@@ -1,0 +1,13 @@
+import { createContext } from "solid-js";
+
+/** Actions that can be performed from any page. */
+export type PageActions = {
+    /** Show a dialog to log-in or signup. */
+    showLoginDialog: () => void;
+
+    /** Show a dialog to import a document. */
+    showImportDialog: () => void;
+};
+
+/** Context for actions performable on any page. */
+export const PageActionsContext = createContext<PageActions>();

--- a/packages/frontend/src/page/document_menu.tsx
+++ b/packages/frontend/src/page/document_menu.tsx
@@ -9,7 +9,15 @@ import {
     createDiagramFromDocument,
 } from "../diagram/document";
 import { type LiveModelDocument, createModel } from "../model/document";
-import { AppMenu, MenuItem, MenuItemLabel, MenuSeparator, NewModelItem } from "../page";
+import {
+    AppMenu,
+    ImportMenuItem,
+    MenuItem,
+    MenuItemLabel,
+    MenuSeparator,
+    NewModelItem,
+} from "../page";
+import { assertExhaustive } from "../util/assert_exhaustive";
 import { copyToClipboard, downloadJson } from "../util/json_export";
 
 import ChartSpline from "lucide-solid/icons/chart-spline";
@@ -18,23 +26,22 @@ import Copy from "lucide-solid/icons/copy";
 import Export from "lucide-solid/icons/download";
 import FilePlus from "lucide-solid/icons/file-plus";
 import Network from "lucide-solid/icons/network";
-import { assertExhaustive } from "../util/assert_exhaustive";
 
-/** Hamburger menu for any live document. */
-export function LiveDocumentMenu(props: {
+/** Hamburger menu for any model or diagram document. */
+export function DocumentMenu(props: {
     liveDocument?: LiveDiagramDocument | LiveModelDocument;
 }) {
     return (
         <AppMenu disabled={props.liveDocument === undefined}>
             <Show when={props.liveDocument}>
-                {(liveDocument) => <LiveDocumentMenuItems liveDocument={liveDocument()} />}
+                {(liveDocument) => <DocumentMenuItems liveDocument={liveDocument()} />}
             </Show>
         </AppMenu>
     );
 }
 
-/** Menu items for any live document. */
-export function LiveDocumentMenuItems(props: {
+/** Menu items for any model or diagram document. */
+export function DocumentMenuItems(props: {
     liveDocument: LiveDiagramDocument | LiveModelDocument;
 }) {
     const api = useApi();
@@ -134,6 +141,7 @@ export function LiveDocumentMenuItems(props: {
                 <ChartSpline />
                 <MenuItemLabel>{`New analysis of this ${props.liveDocument.type}`}</MenuItemLabel>
             </MenuItem>
+            <ImportMenuItem />
             <MenuSeparator />
             <MenuItem onSelect={() => onDuplicateDocument()}>
                 <Copy />
@@ -141,7 +149,7 @@ export function LiveDocumentMenuItems(props: {
             </MenuItem>
             <MenuItem onSelect={() => onDownloadJSON()}>
                 <Export />
-                <MenuItemLabel>{"Export notebook"}</MenuItemLabel>
+                <MenuItemLabel>{`Export ${props.liveDocument.type}`}</MenuItemLabel>
             </MenuItem>
             <MenuItem onSelect={() => onCopy()}>
                 <CopyToClipboard />

--- a/packages/frontend/src/page/import_document.tsx
+++ b/packages/frontend/src/page/import_document.tsx
@@ -6,13 +6,16 @@ import { type DiagramDocument, createDiagramFromDocument } from "../diagram";
 import { type ModelDocument, createModel } from "../model";
 
 type ImportableDocument = ModelDocument | DiagramDocument;
+
 function isImportableDocument(doc: Document<string>): doc is ImportableDocument {
     return doc.type === "model" || doc.type === "diagram";
 }
 
-export function Import(props: { onComplete?: () => void }) {
+/** Imports a document and navigates to the newly created page. */
+export function ImportDocument(props: { onComplete?: () => void }) {
     const api = useApi();
     const navigate = useNavigate();
+
     const handleImport = async (data: Document<string>) => {
         invariant(
             isImportableDocument(data),
@@ -56,9 +59,5 @@ export function Import(props: { onComplete?: () => void }) {
         return true;
     };
 
-    return (
-        <div>
-            <JsonImport<"model" | "diagram"> onImport={handleImport} validate={validateJson} />
-        </div>
-    );
+    return <JsonImport<"model" | "diagram"> onImport={handleImport} validate={validateJson} />;
 }

--- a/packages/frontend/src/page/index.ts
+++ b/packages/frontend/src/page/index.ts
@@ -1,2 +1,3 @@
+export * from "./document_menu";
 export * from "./menubar";
 export * from "./toolbar";

--- a/packages/frontend/src/page/live_document_menu.tsx
+++ b/packages/frontend/src/page/live_document_menu.tsx
@@ -20,7 +20,7 @@ import FilePlus from "lucide-solid/icons/file-plus";
 import Network from "lucide-solid/icons/network";
 import { assertExhaustive } from "../util/assert_exhaustive";
 
-/** Hamburger menu for a diagram in a model. */
+/** Hamburger menu for any live document. */
 export function LiveDocumentMenu(props: {
     liveDocument?: LiveDiagramDocument | LiveModelDocument;
 }) {

--- a/packages/frontend/src/page/menubar.tsx
+++ b/packages/frontend/src/page/menubar.tsx
@@ -2,16 +2,14 @@ import { DropdownMenu } from "@kobalte/core/dropdown-menu";
 import { useNavigate } from "@solidjs/router";
 import { getAuth, signOut } from "firebase/auth";
 import { useAuth, useFirebaseApp } from "solid-firebase";
-import { type JSX, Show, createSignal, useContext } from "solid-js";
+import { type JSX, Show, useContext } from "solid-js";
 import invariant from "tiny-invariant";
 
 import { useApi } from "../api";
-import { Dialog, IconButton } from "../components";
+import { IconButton } from "../components";
 import { createModel } from "../model/document";
 import { TheoryLibraryContext } from "../stdlib";
-
-import { Login } from "../user";
-import { Import } from "./import";
+import { PageActionsContext } from "./context";
 
 import FilePlus from "lucide-solid/icons/file-plus";
 import Info from "lucide-solid/icons/info";
@@ -59,14 +57,11 @@ export function AppMenu(props: {
     const firebaseApp = useFirebaseApp();
     const auth = useAuth(getAuth(firebaseApp));
 
-    const [loginOpen, setLoginOpen] = createSignal(false);
-    const [openImport, setImportOpen] = createSignal(false);
-
     // Root the dialog here so that it is not destroyed when the menu closes.
     return (
         <>
             <HamburgerMenu>
-                <ImportMenuItem showImport={() => setImportOpen(true)} />
+                <ImportMenuItem />
                 {props.children}
                 <Show when={props.children}>
                     <MenuSeparator />
@@ -74,20 +69,11 @@ export function AppMenu(props: {
 
                 <HelpMenuItem />
 
-                <Show
-                    when={auth.data}
-                    fallback={<LogInMenuItem showLogin={() => setLoginOpen(true)} />}
-                >
+                <Show when={auth.data} fallback={<LogInMenuItem />}>
                     <SettingsMenuItem />
                     <LogOutMenuItem />
                 </Show>
             </HamburgerMenu>
-            <Dialog open={loginOpen()} onOpenChange={setLoginOpen} title="Log in">
-                <Login onComplete={() => setLoginOpen(false)} />
-            </Dialog>
-            <Dialog open={openImport()} onOpenChange={setImportOpen} title="Import">
-                <Import onComplete={() => setImportOpen(false)} />
-            </Dialog>
         </>
     );
 }
@@ -132,11 +118,12 @@ function HelpMenuItem() {
     );
 }
 
-function LogInMenuItem(props: {
-    showLogin: () => void;
-}) {
+function LogInMenuItem() {
+    const actions = useContext(PageActionsContext);
+    invariant(actions, "Page actions should be provided");
+
     return (
-        <MenuItem onSelect={props.showLogin}>
+        <MenuItem onSelect={actions.showLoginDialog}>
             <LogInIcon />
             <MenuItemLabel>{"Log in or sign up"}</MenuItemLabel>
         </MenuItem>
@@ -165,11 +152,12 @@ function SettingsMenuItem() {
     );
 }
 
-function ImportMenuItem(props: {
-    showImport: () => void;
-}) {
+function ImportMenuItem() {
+    const actions = useContext(PageActionsContext);
+    invariant(actions, "Page actions should be provided");
+
     return (
-        <MenuItem onSelect={props.showImport}>
+        <MenuItem onSelect={actions.showImportDialog}>
             <UploadIcon />
             <MenuItemLabel>{"Import notebook"}</MenuItemLabel>
         </MenuItem>

--- a/packages/frontend/src/page/menubar.tsx
+++ b/packages/frontend/src/page/menubar.tsx
@@ -60,8 +60,7 @@ export function AppMenu(props: {
     // Root the dialog here so that it is not destroyed when the menu closes.
     return (
         <>
-            <HamburgerMenu>
-                <ImportMenuItem />
+            <HamburgerMenu disabled={props.disabled}>
                 {props.children}
                 <Show when={props.children}>
                     <MenuSeparator />
@@ -82,6 +81,7 @@ export function AppMenu(props: {
 export const DefaultAppMenu = () => (
     <AppMenu>
         <NewModelItem />
+        <ImportMenuItem />
     </AppMenu>
 );
 
@@ -102,6 +102,19 @@ export function NewModelItem() {
         <MenuItem onSelect={onNewModel}>
             <FilePlus />
             <MenuItemLabel>{"New model"}</MenuItemLabel>
+        </MenuItem>
+    );
+}
+
+/** Menu item to import a document. */
+export function ImportMenuItem() {
+    const actions = useContext(PageActionsContext);
+    invariant(actions, "Page actions should be provided");
+
+    return (
+        <MenuItem onSelect={actions.showImportDialog}>
+            <UploadIcon />
+            <MenuItemLabel>{"Import notebook"}</MenuItemLabel>
         </MenuItem>
     );
 }
@@ -148,18 +161,6 @@ function SettingsMenuItem() {
         <MenuItem onSelect={() => navigate("/profile")}>
             <SettingsIcon />
             <MenuItemLabel>{"Edit user profile"}</MenuItemLabel>
-        </MenuItem>
-    );
-}
-
-function ImportMenuItem() {
-    const actions = useContext(PageActionsContext);
-    invariant(actions, "Page actions should be provided");
-
-    return (
-        <MenuItem onSelect={actions.showImportDialog}>
-            <UploadIcon />
-            <MenuItemLabel>{"Import notebook"}</MenuItemLabel>
         </MenuItem>
     );
 }

--- a/packages/frontend/src/page/page_container.tsx
+++ b/packages/frontend/src/page/page_container.tsx
@@ -1,0 +1,38 @@
+import { type JSX, createSignal } from "solid-js";
+
+import { Dialog } from "../components";
+import { Login } from "../user";
+import { type PageActions, PageActionsContext } from "./context";
+import { ImportDocument } from "./import_document";
+
+/** Container for any page in the application.
+
+For now, this serves to anchor dialogs at a high level in the component
+hierarchy. If you naively create them in the menu bar items that show the
+dialogs, the dialogs will be unmounted when the menu is.
+ */
+export function PageContainer(props: {
+    children?: JSX.Element;
+}) {
+    const [loginOpen, setLoginOpen] = createSignal(false);
+    const [openImport, setImportOpen] = createSignal(false);
+
+    const actions: PageActions = {
+        showLoginDialog: () => setLoginOpen(true),
+        showImportDialog: () => setImportOpen(true),
+    };
+
+    return (
+        <>
+            <PageActionsContext.Provider value={actions}>
+                {props.children}
+            </PageActionsContext.Provider>
+            <Dialog open={loginOpen()} onOpenChange={setLoginOpen} title="Log in">
+                <Login onComplete={() => setLoginOpen(false)} />
+            </Dialog>
+            <Dialog open={openImport()} onOpenChange={setImportOpen} title="Import">
+                <ImportDocument onComplete={() => setImportOpen(false)} />
+            </Dialog>
+        </>
+    );
+}


### PR DESCRIPTION
Follow-up to #332 and #407.

All I originally *wanted* to do was put the "Import" menu item in the appropriate place, rather than hard-coded as the first item in any menu. This forced me to address the real issue, which was decoupling the rooting of dialogs from the menubar items that open them, hence `PageContainer`.