### PR TITLE
Add Jason's ssh public key to catcolab-next

### DIFF
--- a/infrastructure/hosts/catcolab-next/default.nix
+++ b/infrastructure/hosts/catcolab-next/default.nix
@@ -3,6 +3,7 @@
 let
     owen     = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIF2sBTuqGoEXRWpBRqTBwZZPDdLGGJ0GQcuX5dfIZKb4 o@red-special";
     epatters = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAKXx6wMJSeYKCHNmbyR803RQ72uto9uYsHhAPPWNl2D evan@epatters.org";
+    jmoggr   = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMiaHaeJ5PQL0mka/lY1yGXIs/bDK85uY1O3mLySnwHd j@jmoggr.com";
 in
 {
     imports = [
@@ -24,7 +25,7 @@ in
     users.users.catcolab = {
         isNormalUser = true;
         group = "catcolab";
-        openssh.authorizedKeys.keys = [ owen epatters ];
+        openssh.authorizedKeys.keys = [ owen epatters jmoggr ];
     };
 
     users.users.owen = {
@@ -39,7 +40,13 @@ in
         openssh.authorizedKeys.keys = [ epatters ];
     };
 
-    users.users.root.openssh.authorizedKeys.keys = [ owen epatters ];
+    users.users.jmoggr = {
+        isNormalUser = true;
+        extraGroups = [ "wheel" ];
+        openssh.authorizedKeys.keys = [ jmoggr ];
+    };
+
+    users.users.root.openssh.authorizedKeys.keys = [ owen epatters jmoggr ];
 
     time.timeZone = "America/New_York";
 

--- a/infrastructure/secrets/secrets.nix
+++ b/infrastructure/secrets/secrets.nix
@@ -8,7 +8,7 @@ let
 in
 builtins.mapAttrs (_: publicKeys: {inherit publicKeys;})
   ({
-      ".env.next.age"   = [ catcolab-next owen epatters ];
+      ".env.next.age"   = [ catcolab-next owen epatters jmoggr ];
       ".env.prod.age"   = [ catcolab owen epatters ];
       "rclone.conf.age" = [ catcolab owen epatters ];
   })

--- a/infrastructure/secrets/secrets.nix
+++ b/infrastructure/secrets/secrets.nix
@@ -4,6 +4,7 @@ let
   catcolab-next = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBZaycYjvaZ5XhxVIvFr8zXvcy1GrViCKLIZCalZuk1l root@ip-172-31-9-45.us-east-2.compute.internal";
   owen          = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIF2sBTuqGoEXRWpBRqTBwZZPDdLGGJ0GQcuX5dfIZKb4 o@red-special";
   epatters      = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAKXx6wMJSeYKCHNmbyR803RQ72uto9uYsHhAPPWNl2D evan@epatters.org";
+  jmoggr        = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMiaHaeJ5PQL0mka/lY1yGXIs/bDK85uY1O3mLySnwHd j@jmoggr.com";
 in
 builtins.mapAttrs (_: publicKeys: {inherit publicKeys;})
   ({


### PR DESCRIPTION
Instructions: https://catcolab.org/dev/unstable-264.xml

my understanding:
- the instructions will re-encrypt .env.next.age using my public key as well
- that will allow me to decrypt the .env.next secrets locally
- .env.next will have the ssh keys for the catcolab-next AWS instance