### PR TITLE
Automate the deployment of the backend for catcolab-next

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -193,7 +193,7 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.CATCOLAB_NEXT_DEPLOYUSER_KEY }}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan ec2-18-217-205-18.us-east-2.compute.amazonaws.com >> ~/.ssh/known_hosts
+          ssh-keyscan backend-next.catcolab.org >> ~/.ssh/known_hosts
 
       - name: Deploy via SSH
-        run: ssh deployuser@ec2-18-217-205-18.us-east-2.compute.amazonaws.com
+        run: ssh deployuser@backend-next.catcolab.org

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -179,3 +179,21 @@ jobs:
         with:
           message: |
             Preview url: ${{ steps.url_preview.outputs.NETLIFY_PREVIEW_URL }}
+
+  deploy_backend:
+    name: Deploy backend to AWS
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' && github.ref_name == 'main'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.CATCOLAB_NEXT_DEPLOYUSER_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan ec2-18-217-205-18.us-east-2.compute.amazonaws.com >> ~/.ssh/known_hosts
+
+      - name: Deploy via SSH
+        run: ssh deployuser@ec2-18-217-205-18.us-east-2.compute.amazonaws.com

--- a/infrastructure/hosts/catcolab-next/backend.nix
+++ b/infrastructure/hosts/catcolab-next/backend.nix
@@ -1,6 +1,8 @@
 { inputs, pkgs, config, ... }:
 
 let
+    catcolabnextDeployuserKey = "";
+
     automergePort = "8010";
     backendPort = "8000";
 
@@ -73,6 +75,30 @@ let
         /var/lib/catcolab/infrastructure/scripts/build.sh
     '';
 
+    updateScript = pkgs.writeShellScriptBin "catcolab-update" ''
+        #!/usr/bin/env bash
+
+        set -e
+
+        echo -e "\n#### stoping services...\n"
+        catcolab-stop
+
+        echo -e "\n#### pulling changes...\n"
+        cd /var/lib/catcolab
+        git pull --force
+
+        echo -e "\n#### applying migrations...\n"
+        catcolab-migrate
+
+        echo -e "\n#### building...\n"
+        catcolab-build
+
+        echo -e "\n#### starting services...\n"
+        catcolab-start
+
+        echo -e "\n#### update finished...\n"
+    '';
+
     packages = with pkgs; [
         rustup
         nodejs
@@ -91,6 +117,7 @@ let
         statusScript
         migrateScript
         buildScript
+        updateScript
     ];
 
 in {
@@ -183,7 +210,7 @@ in {
     };
 
     security.sudo.extraRules = [{
-        users = [ "catcolab" ]; 
+        users = [ "catcolab" "deployuser" ];
         commands = [
             { command = "/run/current-system/sw/bin/systemctl start automerge"; options = [ "NOPASSWD" ]; } 
             { command = "/run/current-system/sw/bin/systemctl stop automerge"; options = [ "NOPASSWD" ]; } 
@@ -191,8 +218,19 @@ in {
             { command = "/run/current-system/sw/bin/systemctl start backend"; options = [ "NOPASSWD" ]; } 
             { command = "/run/current-system/sw/bin/systemctl stop backend"; options = [ "NOPASSWD" ]; } 
             { command = "/run/current-system/sw/bin/systemctl restart backend"; options = [ "NOPASSWD" ]; }
+            { command = "${updateScript}/bin/catcolab-update";  options = [ "NOPASSWD" ]; }
         ]; 
     }];
+
+
+    users.users.deployuser = {
+        isNormalUser = true;
+        openssh.authorizedKeys.keys = [
+            ''
+                command="${updateScript}/bin/catcolab-update",no-port-forwarding,no-agent-forwarding,no-X11-forwarding,no-pty ${catcolabnextDeployuserKey}
+            ''
+        ];
+    };
 
     environment.systemPackages = packages ++ scripts;
 

--- a/infrastructure/hosts/catcolab-next/backend.nix
+++ b/infrastructure/hosts/catcolab-next/backend.nix
@@ -1,4 +1,4 @@
-{ inputs, pkgs, config, ... }:
+{ lib, inputs, pkgs, config, ... }:
 
 let
     catcolabnextDeployuserKey = "";
@@ -218,7 +218,6 @@ in {
             { command = "/run/current-system/sw/bin/systemctl start backend"; options = [ "NOPASSWD" ]; } 
             { command = "/run/current-system/sw/bin/systemctl stop backend"; options = [ "NOPASSWD" ]; } 
             { command = "/run/current-system/sw/bin/systemctl restart backend"; options = [ "NOPASSWD" ]; }
-            { command = "${updateScript}/bin/catcolab-update";  options = [ "NOPASSWD" ]; }
         ]; 
     }];
 
@@ -227,7 +226,7 @@ in {
         isNormalUser = true;
         openssh.authorizedKeys.keys = [
             ''
-                command="${updateScript}/bin/catcolab-update",no-port-forwarding,no-agent-forwarding,no-X11-forwarding,no-pty ${catcolabnextDeployuserKey}
+                command="${lib.getExe updateScript}",no-port-forwarding,no-agent-forwarding,no-X11-forwarding,no-pty ${catcolabnextDeployuserKey}
             ''
         ];
     };


### PR DESCRIPTION
This creates a new user `deployuser` which is restricted to running a single command `catcolab-update`. When the `deployuser` user connects via SSH the `catcolab-update` script will start running and the ssh session will terminate when the script exits. If the script exists unsuccessfully the gitub action will be marked as failed.

We need to give the `deployuser` the same access to the sudo command as the `catcolab` user because `deployuser` needs to run the same `systemctl` commands to manage services. 

Additional configuration required from Eval:
- Create a new ssh keypair
- assign the public key to the `catcolabnextDeployuserKey` variable in `infrastructure/hosts/catcolab-next/backend.nix`
- assign the private key to a new github action repository secret named `CATCOLAB_NEXT_DEPLOYUSER_KEY`

Notes:
- I'm only 60% confident that this will work on the first go. These changes were cut and pasted from a hacked together config targeting a separate deployment. It is most likely that something trivial will go wrong in `catcolab-update`
- This does not automate the backend deployment to the production catcolab backend, however it should be easy to cut and paste the changes after we've confirmed that they work on staging.

Closes #349.