### PR TITLE
Universal property of composites in VDCs

### DIFF
--- a/packages/catlog/src/dbl/category.rs
+++ b/packages/catlog/src/dbl/category.rs
@@ -16,12 +16,7 @@ satisfying a universal property ([Cruttwell-Shulman
 2008](crate::refs::GeneralizedMulticategories), Section 5). In our usage of
 virtual double categories as double theories, we will assume that *units*
 (nullary composites) exist. We will not assume that any other composites exist,
-though they often do. Like anything defined by a universal property, composites
-are not strictly unique if they exist but they *are* unique up to unique
-isomorphism. As often when working with (co)limits, our trait for virtual double
-categories assumes that a *choice* of composites has been made whenever they are
-needed. We do not attempt to "recognize" whether an arbitrary cell has the
-relevant universal property.
+though often they do.
 
 Virtual double categories have pros and cons compared with ordinary double
 categories. We prefer VDCs in `catlog` because pastings of cells are much
@@ -29,7 +24,7 @@ simpler in a VDC than in a double category: a pasting diagram in VDC is a
 well-typed [tree](super::tree) of cells, rather than a kind of planar string
 diagram, and the notorious
 [pinwheel](https://ncatlab.org/nlab/show/double+category#Unbiased) obstruction
-to composition in a double category does not arise.
+to composition in a double category does not arise in VDCs.
 
 # Examples
 
@@ -58,8 +53,6 @@ use crate::one::path::Path;
 /** A virtual double category (VDC).
 
 See the [module-level docs](super::category) for background on VDCs.
-
-TODO: The universal property of a composite is not part of the interface.
  */
 pub trait VDblCategory {
     /// Type of objects in the VDC.
@@ -147,7 +140,17 @@ pub trait VDblCategory {
     fn id_cell(&self, m: Self::Pro) -> Self::Cell {
         self.compose_cells(DblTree::empty(m))
     }
+}
 
+/** A virtual double category with some or all chosen composites.
+
+Like anything defined by a universal property, composites in a VDC are not
+strictly unique if they exist but they *are* unique up to unique isomorphism. As
+often when working with (co)limits, this trait assumes that a *choice* of
+composites has been made whenever they are exist. We do not attempt to
+"recognize" whether an arbitrary cell has the relevant universal property.
+ */
+pub trait VDCWithComposites: VDblCategory {
     /** Does the path of proarrows have a chosen composite?
 
     The default implementation checks whether [`composite`](Self::composite)
@@ -169,20 +172,19 @@ pub trait VDblCategory {
     /** Gets the chosen cell witnessing a composite of proarrows, if there is one.
 
     Such a cell is called an **extension or **opcartesian** cell.
-
-    The default implementation handles the one special kind of composite that
-    always exist: unary composites.
      */
-    fn composite_ext(&self, path: Path<Self::Ob, Self::Pro>) -> Option<Self::Cell> {
-        path.only().map(|m| self.id_cell(m))
-    }
+    fn composite_ext(&self, path: Path<Self::Ob, Self::Pro>) -> Option<Self::Cell>;
 
     /// Gets the chosen cell witnessing a composite of two proarrows, if there is one.
     fn composite2_ext(&self, m: Self::Pro, n: Self::Pro) -> Option<Self::Cell> {
         self.composite_ext(Path::pair(m, n))
     }
 
-    /// Gets the chosen composite for a path of proarrows, if there is one.
+    /** Gets the chosen composite for a path of proarrows, if there is one.
+
+    The default implementation returns the codomain of the extension cell
+    returned by [`composite_ext`](Self::composite_ext).
+     */
     fn composite(&self, path: Path<Self::Ob, Self::Pro>) -> Option<Self::Pro> {
         self.composite_ext(path).map(|α| self.cell_cod(&α))
     }
@@ -381,6 +383,10 @@ impl VDblCategory for WalkingCategory {
     fn compose_cells(&self, tree: DblTree<Self::Arr, Self::Pro, Self::Cell>) -> Self::Cell {
         tree.dom(UnderlyingDblGraph::ref_cast(self)).len()
     }
+}
+
+impl VDCWithComposites for WalkingCategory {
+    /// In the walking category, every cell is an extension.
     fn composite_ext(&self, path: Path<Self::Ob, Self::Pro>) -> Option<Self::Cell> {
         Some(path.len())
     }
@@ -503,6 +509,10 @@ pub mod WalkingBimodule {
             assert!(self.has_cell(&path));
             path
         }
+    }
+
+    impl VDCWithComposites for Main {
+        /// In the walking bimodule, every cell is an extension.
         fn composite_ext(&self, path: Path<Self::Ob, Self::Pro>) -> Option<Self::Cell> {
             Some(path)
         }
@@ -673,6 +683,9 @@ pub mod WalkingFunctor {
             assert_eq!(f, g, "Cells in walking functor have the same source and target");
             Cell::with_src_and_tgt(f, n)
         }
+    }
+
+    impl VDCWithComposites for Main {
         fn composite_ext(&self, path: Path<Self::Ob, Self::Pro>) -> Option<Self::Cell> {
             let graph = ProedgeGraph::ref_cast(UnderlyingDblGraph::ref_cast(self));
             let (x, y) = (path.src(graph), path.tgt(graph));


### PR DESCRIPTION
Another sequel to #428 that extends the traits for VDCs to enable invoking the universal property of a composite proarrow (and, in particular, of a unit). Previously this was omitted from the interface.