### PR TITLE
Remove `vite-plugin-top-level-await` to fix source maps

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -70,7 +70,6 @@
         "typescript": "^5.2.2",
         "vite": "^5.3.1",
         "vite-plugin-solid": "^2.10.2",
-        "vite-plugin-top-level-await": "^1.4.1",
         "vite-plugin-wasm": "^3.3.0",
         "vitest": "^3.0.2",
         "wasm-pack": "^0.13.1"

--- a/packages/frontend/pnpm-lock.yaml
+++ b/packages/frontend/pnpm-lock.yaml
@@ -162,9 +162,6 @@ importers:
       vite-plugin-solid:
         specifier: ^2.10.2
         version: 2.10.2(solid-js@1.9.2)(vite@5.4.8(@types/node@22.7.4))
-      vite-plugin-top-level-await:
-        specifier: ^1.4.1
-        version: 1.4.4(@swc/helpers@0.5.13)(rollup@4.22.5)(vite@5.4.8(@types/node@22.7.4))
       vite-plugin-wasm:
         specifier: ^3.3.0
         version: 3.3.0(vite@5.4.8(@types/node@22.7.4))
@@ -1052,15 +1049,6 @@ packages:
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.14.0 || >=17
-
-  '@rollup/plugin-virtual@3.0.2':
-    resolution: {integrity: sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
 
   '@rollup/rollup-android-arm-eabi@4.22.5':
     resolution: {integrity: sha512-SU5cvamg0Eyu/F+kLeMXS7GoahL+OoizlclVFX3l5Ql6yNlywJJ0OuqTzUx0v+aHhPHEB/56CT06GQrRrGNYww==}
@@ -2775,10 +2763,6 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    hasBin: true
-
   uuid@11.0.3:
     resolution: {integrity: sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==}
     hasBin: true
@@ -2856,11 +2840,6 @@ packages:
     peerDependenciesMeta:
       '@testing-library/jest-dom':
         optional: true
-
-  vite-plugin-top-level-await@1.4.4:
-    resolution: {integrity: sha512-QyxQbvcMkgt+kDb12m2P8Ed35Sp6nXP+l8ptGrnHV9zgYDUpraO0CPdlqLSeBqvY2DToR52nutDG7mIHuysdiw==}
-    peerDependencies:
-      vite: '>=2.8'
 
   vite-plugin-wasm@3.3.0:
     resolution: {integrity: sha512-tVhz6w+W9MVsOCHzxo6SSMSswCeIw4HTrXEi6qL3IRzATl83jl09JVO1djBqPSwfjgnpVHNLYcaMbaDX5WB/pg==}
@@ -4059,10 +4038,6 @@ snapshots:
       react: 18.3.1
       react-is: 18.3.1
 
-  '@rollup/plugin-virtual@3.0.2(rollup@4.22.5)':
-    optionalDependencies:
-      rollup: 4.22.5
-
   '@rollup/rollup-android-arm-eabi@4.22.5':
     optional: true
 
@@ -4280,8 +4255,10 @@ snapshots:
       '@swc/core-win32-ia32-msvc': 1.7.26
       '@swc/core-win32-x64-msvc': 1.7.26
       '@swc/helpers': 0.5.13
+    optional: true
 
-  '@swc/counter@0.1.3': {}
+  '@swc/counter@0.1.3':
+    optional: true
 
   '@swc/helpers@0.5.13':
     dependencies:
@@ -4290,6 +4267,7 @@ snapshots:
   '@swc/types@0.1.12':
     dependencies:
       '@swc/counter': 0.1.3
+    optional: true
 
   '@tsconfig/node10@1.0.11': {}
 
@@ -6102,8 +6080,6 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@10.0.0: {}
-
   uuid@11.0.3: {}
 
   uuid@9.0.1: {}
@@ -6207,16 +6183,6 @@ snapshots:
       vitefu: 0.2.5(vite@5.4.8(@types/node@22.7.4))
     transitivePeerDependencies:
       - supports-color
-
-  vite-plugin-top-level-await@1.4.4(@swc/helpers@0.5.13)(rollup@4.22.5)(vite@5.4.8(@types/node@22.7.4)):
-    dependencies:
-      '@rollup/plugin-virtual': 3.0.2(rollup@4.22.5)
-      '@swc/core': 1.7.26(@swc/helpers@0.5.13)
-      uuid: 10.0.0
-      vite: 5.4.8(@types/node@22.7.4)
-    transitivePeerDependencies:
-      - '@swc/helpers'
-      - rollup
 
   vite-plugin-wasm@3.3.0(vite@5.4.8(@types/node@22.7.4)):
     dependencies:

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -2,7 +2,6 @@ import { nodeTypes } from "@mdx-js/mdx";
 import rehypeRaw from "rehype-raw";
 import { defineConfig } from "vite";
 import solid from "vite-plugin-solid";
-import topLevelAwait from "vite-plugin-top-level-await";
 import wasm from "vite-plugin-wasm";
 
 // @ts-expect-error Types are missing.
@@ -14,7 +13,6 @@ const { default: mdx } = pkg;
 export default defineConfig({
     plugins: [
         wasm(),
-        topLevelAwait(),
         mdx.withImports({})({
             jsx: true,
             jsxImportSource: "solid-js",
@@ -27,7 +25,8 @@ export default defineConfig({
     ],
     build: {
         chunkSizeWarningLimit: 2000,
-        sourcemap: false,
+        sourcemap: true,
+        target: "es2022",
     },
     server: {
         proxy: {


### PR DESCRIPTION
For some unknown reason the vite plugin `topLevelAwait` was stripping the source mapping comments (`//# sourceMappingURL=...`) from the compiled .js files, and this is what was causing source mapping to not work.

The `top-level-await` feature is included in `es2022`, so we can drop the polyfill and target the newer version. Vite by default targets `es2020` so this would remove support for browsers from 2020-2022, however I don't think we should be putting any effort into supporting browsers that old anyway.

I'll add a discussion point about which browsers we should support to the next meeting.