### PR TITLE
Remove deployuser script and run build commands over ssh

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -184,8 +184,11 @@ jobs:
     name: Deploy backend to AWS
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' && github.ref_name == 'main'
+    env:
+      TARGET_HOST: backend-next.catcolab.org
+      HOST_CONFIG: catcolab-next
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v4
 
       - name: Set up SSH key
@@ -193,8 +196,12 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.CATCOLAB_NEXT_DEPLOYUSER_KEY }}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan backend-next.catcolab.org >> ~/.ssh/known_hosts
+          ssh-keyscan ${TARGET_HOST} >> ~/.ssh/known_hosts
 
-      - name: Deploy via SSH
-        run: ssh deployuser@backend-next.catcolab.org "${GITHUB_SHA}"
+      - name: Rsync the repo to remote host
+        run: |
+          rsync -az --delete ./ deployuser@${TARGET_HOST}:~/catcolab/
 
+      - name: Run nixos-rebuild switch remotely
+        run: |
+          ssh deployuser@${TARGET_HOST} "sudo /run/current-system/sw/bin/nixos-rebuild switch --flake ./catcolab#${HOST_CONFIG}"

--- a/infrastructure/modules/host.nix
+++ b/infrastructure/modules/host.nix
@@ -1,38 +1,8 @@
 {
   lib,
-  pkgs,
   config,
   ...
 }:
-let
-  # This script is run when deployuser logs in via ssh.
-  # Modifications to this script (like changing the branch name), should be manually deployed with
-  # deploy-rs. 'Dangerous' changes to system configuration like modifying users or changing network setting
-  # should also be done with deploy-rs to take advantage of the rollback system.
-  deployuserScript = pkgs.writeShellScriptBin "deployuser-script" ''
-    #!/usr/bin/env bash
-    set -ex
-
-    commit_sha="$SSH_ORIGINAL_COMMAND"
-
-    if [ -z "$commit_sha" ]; then
-      echo "Missing commit SHA"
-      exit 1
-    fi
-
-    if [ -d "catcolab" ]; then
-      rm -rf ./catcolab
-    fi
-
-    git clone https://github.com/ToposInstitute/CatColab.git catcolab
-    cd catcolab
-    git checkout "$commit_sha"
-
-    # hostname will return the hosts networking.hostname, which should, by convention match a key in
-    # deploy.nodes in flake.nix
-    sudo /run/current-system/sw/bin/nixos-rebuild switch --flake .#"$(hostname)"
-  '';
-in
 with lib;
 {
   options.catcolab.host = {
@@ -56,11 +26,7 @@ with lib;
         };
         deployuser = {
           isNormalUser = true;
-          openssh.authorizedKeys.keys = [
-            ''
-              command="${lib.getExe deployuserScript}",no-port-forwarding,no-agent-forwarding,no-X11-forwarding,no-pty ${config.catcolab.host.deployuserKey}
-            ''
-          ];
+          openssh.authorizedKeys.keys = [ config.catcolab.host.deployuserKey ];
           extraGroups = [ "catcolab" ];
         };
         root.openssh.authorizedKeys.keys = config.catcolab.host.userKeys;
@@ -91,15 +57,6 @@ with lib;
       80
       443
     ];
-
-    # install all packages used in this module
-    environment.systemPackages =
-      with pkgs;
-      [
-        git
-        bash
-      ]
-      ++ [ deployuserScript ];
 
     services.openssh.enable = true;
     nix.extraOptions = ''


### PR DESCRIPTION
tl;dr: the deploy process no longer uses a script on the remote host and instead copies the repo and runs commands over SSH.

### Major changes
#### deploy script
Remove the deploy script managed by nix in favour of running commands over ssh from github actions.

I think using Nix to manage the deploy script was a mistake. It made it too easy to misreason about the script, since the one being executed was different from the one in source control. (#461 is similar to this).

#### `deployuser`
`deployuser` is no longer restricted and is functionally equivalent to root (similar to the `catcolab` user). In practice locking down `deployuser` added little extra security, anybody who was able to access the secrets for it would also be able to commit changes which could then be deployed. I initially set it up this way under a (possibly misguided) notion of defence-in-depth and to keep as much of the process in nix as possible with the script. 

We could simplify the setup slightly be removing `deployuser` and just using `root` instead, but should work for now and we can easily change it in the future.


### Other things I tried
#### Fixing the issue with the commit SHA not being available publicly
no idea what going on here, it never seems to work on TopoInstitute, and works most(?) of the time on my fork.

#### Using deploy-rs from the github action
This would be ideal, but I was unable to get caching to work for /nix/store in the github action. You'd think this would be easy, but I was unable to get any 3rd party github actions to work and managing the caching myself (which I've done before) resulted in cryptic errors.

Caching in github actions is fairly limited, and it seems like most people using nix+github actions are using some sort of 3rd party service for handling caching. That seems overly complicated for what we need.