### PR TITLE
Document breadcrumbs

### DIFF
--- a/packages/frontend/src/analysis/analysis_editor.tsx
+++ b/packages/frontend/src/analysis/analysis_editor.tsx
@@ -106,6 +106,7 @@ export function AnalysisDocumentEditor(props: {
                         >
                             <Toolbar>
                                 <AnalysisMenu liveAnalysis={props.liveAnalysis} />
+                                <DocumentBreadcrumbs document={props.liveAnalysis} />
                                 <span class="filler" />
                                 <TheoryHelpButton theory={theoryForAnalysis(props.liveAnalysis)} />
                                 <IconButton
@@ -134,8 +135,10 @@ export function AnalysisDocumentEditor(props: {
                             onExpand={() => setSidePanelOpen(true)}
                         >
                             <div class="notebook-container">
+                                <div class="toolbar">
+                                    <div class="toolbar-spacer" />
+                                </div>
                                 <h2>Analysis</h2>
-                                <DocumentBreadcrumbs document={props.liveAnalysis} />
                                 <AnalysisNotebookEditor liveAnalysis={props.liveAnalysis} />
                             </div>
                         </Resizable.Panel>

--- a/packages/frontend/src/analysis/analysis_editor.tsx
+++ b/packages/frontend/src/analysis/analysis_editor.tsx
@@ -22,7 +22,13 @@ import {
     NotebookEditor,
     newFormalCell,
 } from "../notebook";
-import { DocumentLoadingScreen, DocumentMenu, TheoryHelpButton, Toolbar } from "../page";
+import {
+    DocumentBreadcrumbs,
+    DocumentLoadingScreen,
+    DocumentMenu,
+    TheoryHelpButton,
+    Toolbar,
+} from "../page";
 import { TheoryLibraryContext } from "../stdlib";
 import type { AnalysisMeta } from "../theory";
 import { assertExhaustive } from "../util/assert_exhaustive";
@@ -129,6 +135,7 @@ export function AnalysisDocumentEditor(props: {
                         >
                             <div class="notebook-container">
                                 <h2>Analysis</h2>
+                                <DocumentBreadcrumbs document={props.liveAnalysis} />
                                 <AnalysisNotebookEditor liveAnalysis={props.liveAnalysis} />
                             </div>
                         </Resizable.Panel>

--- a/packages/frontend/src/diagram/diagram_editor.tsx
+++ b/packages/frontend/src/diagram/diagram_editor.tsx
@@ -13,7 +13,13 @@ import {
     cellShortcutModifier,
     newFormalCell,
 } from "../notebook";
-import { DocumentLoadingScreen, DocumentMenu, TheoryHelpButton, Toolbar } from "../page";
+import {
+    DocumentBreadcrumbs,
+    DocumentLoadingScreen,
+    DocumentMenu,
+    TheoryHelpButton,
+    Toolbar,
+} from "../page";
 import { TheoryLibraryContext } from "../stdlib";
 import type { InstanceTypeMeta } from "../theory";
 import { PermissionsButton } from "../user";
@@ -58,6 +64,7 @@ export function DiagramDocumentEditor(props: {
         <div class="growable-container">
             <Toolbar>
                 <DocumentMenu liveDocument={props.liveDiagram} />
+                <DocumentBreadcrumbs document={props.liveDiagram} />
                 <span class="filler" />
                 <TheoryHelpButton theory={props.liveDiagram.liveModel.theory()} />
                 <PermissionsButton

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -115,3 +115,8 @@ h4 {
     font-size: var(--formal-judgment-font-size);
     line-height: 1.1;
 }
+
+.toolbar-spacer {
+    /* 24px is the height of the icon buttons in the toolbar */
+    height: 24px;
+}

--- a/packages/frontend/src/model/model_editor.tsx
+++ b/packages/frontend/src/model/model_editor.tsx
@@ -11,7 +11,13 @@ import {
     cellShortcutModifier,
     newFormalCell,
 } from "../notebook";
-import { DocumentLoadingScreen, DocumentMenu, TheoryHelpButton, Toolbar } from "../page";
+import {
+    DocumentBreadcrumbs,
+    DocumentLoadingScreen,
+    DocumentMenu,
+    TheoryHelpButton,
+    Toolbar,
+} from "../page";
 import { TheoryLibraryContext } from "../stdlib";
 import type { ModelTypeMeta } from "../theory";
 import { PermissionsButton } from "../user";
@@ -57,6 +63,7 @@ export function ModelDocumentEditor(props: {
         <div class="growable-container">
             <Toolbar>
                 <DocumentMenu liveDocument={props.liveModel} />
+                <DocumentBreadcrumbs document={props.liveModel} />
                 <span class="filler" />
                 <TheoryHelpButton theory={props.liveModel.theory()} />
                 <PermissionsButton

--- a/packages/frontend/src/page/document_breadcrumbs.css
+++ b/packages/frontend/src/page/document_breadcrumbs.css
@@ -10,3 +10,9 @@
 .breadcrumb-link:hover {
     text-decoration: underline;
 }
+
+.breadcrumbs-wrapper {
+    display: flex;
+    align-items: center;
+    padding-left: 1em;
+}

--- a/packages/frontend/src/page/document_breadcrumbs.css
+++ b/packages/frontend/src/page/document_breadcrumbs.css
@@ -1,0 +1,12 @@
+.breadcrumb-spacer {
+    padding-left: 5px;
+    padding-right: 5px;
+}
+
+.breadcrumb-link {
+    text-decoration: none;
+}
+
+.breadcrumb-link:hover {
+    text-decoration: underline;
+}

--- a/packages/frontend/src/page/document_breadcrumbs.tsx
+++ b/packages/frontend/src/page/document_breadcrumbs.tsx
@@ -20,12 +20,12 @@ export function DocumentBreadcrumbs(props: {
 
     return (
         <div class="breadcrumbs-wrapper">
-            <Show when={documentChain()} fallback={<span>Loading...</span>}>
+            <Show when={documentChain()} fallback={<div />}>
                 <For each={documentChain()}>
                     {(doc, index) => (
                         <>
                             {index() > 0 && <span class="breadcrumb-spacer">/</span>}
-                            <a class="breadcrumb-link" href={`${doc.document.type}/${doc.refId}`}>
+                            <a class="breadcrumb-link" href={`/${doc.document.type}/${doc.refId}`}>
                                 {doc.document.name || "untitled"}
                             </a>
                         </>

--- a/packages/frontend/src/page/document_breadcrumbs.tsx
+++ b/packages/frontend/src/page/document_breadcrumbs.tsx
@@ -19,23 +19,18 @@ export function DocumentBreadcrumbs(props: {
     const [documentChain] = createResource(() => props.document, getDocumentChain);
 
     return (
-        <div>
+        <div class="breadcrumbs-wrapper">
             <Show when={documentChain()} fallback={<span>Loading...</span>}>
-                <ol>
-                    <For each={documentChain()}>
-                        {(doc, index) => (
-                            <>
-                                {index() > 0 && <span class="breadcrumb-spacer">/</span>}
-                                <a
-                                    class="breadcrumb-link"
-                                    href={`${doc.document.type}/${doc.refId}`}
-                                >
-                                    {doc.document.name || "untitled"}
-                                </a>
-                            </>
-                        )}
-                    </For>
-                </ol>
+                <For each={documentChain()}>
+                    {(doc, index) => (
+                        <>
+                            {index() > 0 && <span class="breadcrumb-spacer">/</span>}
+                            <a class="breadcrumb-link" href={`${doc.document.type}/${doc.refId}`}>
+                                {doc.document.name || "untitled"}
+                            </a>
+                        </>
+                    )}
+                </For>
             </Show>
         </div>
     );

--- a/packages/frontend/src/page/document_breadcrumbs.tsx
+++ b/packages/frontend/src/page/document_breadcrumbs.tsx
@@ -1,0 +1,82 @@
+import { For, Show, createResource } from "solid-js";
+import type { AnalysisDocument, LiveAnalysisDocument } from "../analysis";
+import { getLiveDoc, useApi } from "../api";
+import type { DiagramDocument, LiveDiagramDocument } from "../diagram";
+import type { LiveModelDocument, ModelDocument } from "../model";
+import { assertExhaustive } from "../util/assert_exhaustive";
+import "./document_breadcrumbs.css";
+
+type AnyDocument = ModelDocument | DiagramDocument | AnalysisDocument;
+type AnyLiveDocument = LiveModelDocument | LiveDiagramDocument | LiveAnalysisDocument;
+type AnyDocumentWithRefId = {
+    document: AnyDocument;
+    refId: string;
+};
+
+export function DocumentBreadcrumbs(props: {
+    document: AnyLiveDocument;
+}) {
+    const [documentChain] = createResource(() => props.document, getDocumentChain);
+
+    return (
+        <div>
+            <Show when={documentChain()} fallback={<span>Loading...</span>}>
+                <ol>
+                    <For each={documentChain()}>
+                        {(doc, index) => (
+                            <>
+                                {index() > 0 && <span class="breadcrumb-spacer">/</span>}
+                                <a
+                                    class="breadcrumb-link"
+                                    href={`${doc.document.type}/${doc.refId}`}
+                                >
+                                    {doc.document.name || "untitled"}
+                                </a>
+                            </>
+                        )}
+                    </For>
+                </ol>
+            </Show>
+        </div>
+    );
+}
+
+export function getParentRefId(document: AnyDocument): string | null {
+    switch (document.type) {
+        case "model":
+            return null;
+        case "diagram":
+            return document.diagramIn._id;
+        case "analysis":
+            return document.analysisOf._id;
+        default:
+            assertExhaustive(document);
+    }
+}
+
+async function getDocumentChain(document: AnyLiveDocument): Promise<AnyDocumentWithRefId[]> {
+    const api = useApi();
+    const documentChain: AnyDocumentWithRefId[] = [
+        { document: document.liveDoc.doc, refId: document.refId },
+    ];
+
+    while (true) {
+        // biome-ignore lint/style/noNonNullAssertion: the array initializer guarantees that there will always be at least one item in the array
+        const parentRefId = getParentRefId(documentChain[0]?.document!);
+        if (!parentRefId) {
+            break;
+        }
+
+        // In a worst case this results in sequential round trips to the server. However it should be
+        // reasonable to hope that either the parents are already in the local automerge repo, or that
+        // they will be needed by the app at some point in the near future. The alternative is picking
+        // apart a JSON blob in postgres, and that sounds neither fun nor maintainable.
+        const parentDocument = await getLiveDoc<AnyDocument>(api, parentRefId);
+        documentChain.unshift({
+            document: parentDocument.doc,
+            refId: parentRefId,
+        });
+    }
+
+    return documentChain;
+}

--- a/packages/frontend/src/page/index.ts
+++ b/packages/frontend/src/page/index.ts
@@ -2,3 +2,4 @@ export * from "./document_loading_screen";
 export * from "./document_menu";
 export * from "./menubar";
 export * from "./toolbar";
+export * from "./document_breadcrumbs";


### PR DESCRIPTION
This is stacked on #463, but it would be trivial to rebase it onto main.

I tried ~2 other ways of loading the the information necessary for the breadcrumbs more efficiently, and they were both far more complicated than this. I did not feel that the additional complexity was worth it.

The document objects not having access to their own ref id was a continuous pain point. In a separate issue/PR it might be worth considering adding a documents id to the document object during it's creation.