### PR TITLE
Generate numeric IDs for egglog rather coercing to symbols

### DIFF
--- a/packages/catlog-wasm/Cargo.toml
+++ b/packages/catlog-wasm/Cargo.toml
@@ -12,7 +12,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 all-the-same = "1.1.0"
-catlog = { path = "../catlog", features = ["ode", "serde-wasm", "uuid"] }
+catlog = { path = "../catlog", features = ["ode", "serde-wasm"] }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 derive_more = { version = "1", features = ["from", "try_into"] }
 egglog = { version = "0.4", default-features = false, features = ["wasm-bindgen"] }

--- a/packages/catlog-wasm/src/model_morphism.rs
+++ b/packages/catlog-wasm/src/model_morphism.rs
@@ -5,7 +5,6 @@ use tsify_next::Tsify;
 use uuid::Uuid;
 
 use catlog::dbl::{model, model_morphism};
-use catlog::egglog_util::ToSymbol;
 use catlog::one::{FgCategory, fp_category::UstrFpCategory};
 
 use super::model::DblModel;
@@ -27,7 +26,7 @@ pub fn motifs<Id>(
     options: MotifsOptions,
 ) -> Result<Vec<DblModel>, String>
 where
-    Id: Clone + Eq + Hash + ToSymbol,
+    Id: Clone + Eq + Hash,
 {
     let model: &model::DiscreteDblModel<_, _> = (&model.0)
         .try_into()

--- a/packages/catlog/Cargo.toml
+++ b/packages/catlog/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2024"
 ode = ["dep:ode_solvers", "dep:nalgebra"]
 serde = ["dep:serde", "nonempty/serialize", "ustr/serde"]
 serde-wasm = ["serde", "dep:wasm-bindgen", "dep:tsify-next"]
-uuid = ["dep:uuid"]
 
 [dependencies]
 derivative = "2"

--- a/packages/catlog/src/dbl/model.rs
+++ b/packages/catlog/src/dbl/model.rs
@@ -47,7 +47,6 @@ use tsify_next::Tsify;
 
 use super::category::VDblCategory;
 use super::theory::{DblTheory, DiscreteDblTheory};
-use crate::egglog_util::ToSymbol;
 use crate::one::fp_category::{FpCategory, InvalidFpCategory, UstrFpCategory};
 use crate::one::*;
 use crate::validate::{self, Validate};
@@ -206,7 +205,7 @@ pub type UstrDiscreteDblModel = DiscreteDblModel<Ustr, UstrFpCategory>;
 
 impl<Id, Cat> DiscreteDblModel<Id, Cat>
 where
-    Id: Eq + Clone + Hash + ToSymbol,
+    Id: Eq + Clone + Hash,
     Cat: FgCategory,
     Cat::Ob: Hash,
     Cat::Mor: Hash,
@@ -305,7 +304,7 @@ where
 
 impl<Id, Cat> Category for DiscreteDblModel<Id, Cat>
 where
-    Id: Eq + Clone + Hash + ToSymbol,
+    Id: Eq + Clone + Hash,
     Cat: FgCategory,
     Cat::Ob: Hash,
     Cat::Mor: Hash,
@@ -332,7 +331,7 @@ where
 
 impl<Id, Cat> FgCategory for DiscreteDblModel<Id, Cat>
 where
-    Id: Eq + Clone + Hash + ToSymbol,
+    Id: Eq + Clone + Hash,
     Cat: FgCategory,
     Cat::Ob: Hash,
     Cat::Mor: Hash,
@@ -359,7 +358,7 @@ where
 
 impl<Id, Cat> DblModel for DiscreteDblModel<Id, Cat>
 where
-    Id: Eq + Clone + Hash + ToSymbol,
+    Id: Eq + Clone + Hash,
     Cat: FgCategory,
     Cat::Ob: Hash,
     Cat::Mor: Hash,
@@ -393,7 +392,7 @@ where
 
 impl<Id, Cat> FgDblModel for DiscreteDblModel<Id, Cat>
 where
-    Id: Eq + Clone + Hash + ToSymbol,
+    Id: Eq + Clone + Hash,
     Cat: FgCategory,
     Cat::Ob: Hash,
     Cat::Mor: Hash,
@@ -415,7 +414,7 @@ where
 
 impl<Id, Cat> MutDblModel for DiscreteDblModel<Id, Cat>
 where
-    Id: Eq + Clone + Hash + ToSymbol,
+    Id: Eq + Clone + Hash,
     Cat: FgCategory,
     Cat::Ob: Hash,
     Cat::Mor: Hash,
@@ -451,7 +450,7 @@ where
 
 impl<Id, Cat> Validate for DiscreteDblModel<Id, Cat>
 where
-    Id: Eq + Clone + Hash + ToSymbol,
+    Id: Eq + Clone + Hash,
     Cat: FgCategory,
     Cat::Ob: Hash,
     Cat::Mor: Hash,

--- a/packages/catlog/src/dbl/model_diagram.rs
+++ b/packages/catlog/src/dbl/model_diagram.rs
@@ -25,7 +25,6 @@ use serde::{Deserialize, Serialize};
 use tsify_next::{Tsify, declare};
 
 use super::{model::*, model_morphism::*};
-use crate::egglog_util::ToSymbol;
 use crate::one::{Category, FgCategory};
 use crate::validate;
 
@@ -78,8 +77,8 @@ pub type InvalidDiscreteDblModelDiagram<DomId> =
 
 impl<DomId, CodId, Cat> DiscreteDblModelDiagram<DomId, CodId, Cat>
 where
-    DomId: Eq + Clone + Hash + ToSymbol,
-    CodId: Eq + Clone + Hash + ToSymbol,
+    DomId: Eq + Clone + Hash,
+    CodId: Eq + Clone + Hash,
     Cat: FgCategory,
     Cat::Ob: Hash,
     Cat::Mor: Hash,

--- a/packages/catlog/src/dbl/model_morphism.rs
+++ b/packages/catlog/src/dbl/model_morphism.rs
@@ -31,7 +31,6 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "serde-wasm")]
 use tsify_next::Tsify;
 
-use crate::egglog_util::ToSymbol;
 use crate::one::graph_algorithms::{bounded_simple_paths, simple_paths, spec_order};
 use crate::one::*;
 use crate::validate::{self, Validate};
@@ -90,8 +89,8 @@ pub struct DiscreteDblModelMapping<DomId, CodId> {
 
 impl<DomId, CodId> DiscreteDblModelMapping<DomId, CodId>
 where
-    DomId: Clone + Eq + Hash + ToSymbol,
-    CodId: Clone + Eq + Hash + ToSymbol,
+    DomId: Clone + Eq + Hash,
+    CodId: Clone + Eq + Hash,
 {
     /// Applies the mapping at a basic morphism in the domain model.
     pub fn apply_basic_mor(&self, e: &DomId) -> Option<Path<CodId, CodId>> {
@@ -185,8 +184,8 @@ where
 
 impl<DomId, CodId> DblModelMapping for DiscreteDblModelMapping<DomId, CodId>
 where
-    DomId: Clone + Eq + Hash + ToSymbol,
-    CodId: Clone + Eq + Hash + ToSymbol,
+    DomId: Clone + Eq + Hash,
+    CodId: Clone + Eq + Hash,
 {
     type DomOb = DomId;
     type DomMor = Path<DomId, DomId>;
@@ -233,8 +232,8 @@ pub type DiscreteDblModelMorphism<'a, DomId, CodId, Cat> = DblModelMorphism<
 
 impl<'a, DomId, CodId, Cat> DiscreteDblModelMorphism<'a, DomId, CodId, Cat>
 where
-    DomId: Eq + Clone + Hash + ToSymbol,
-    CodId: Eq + Clone + Hash + ToSymbol,
+    DomId: Eq + Clone + Hash,
+    CodId: Eq + Clone + Hash,
     Cat: FgCategory,
     Cat::Ob: Hash,
     Cat::Mor: Hash,
@@ -361,8 +360,8 @@ where
 
 impl<DomId, CodId, Cat> Validate for DiscreteDblModelMorphism<'_, DomId, CodId, Cat>
 where
-    DomId: Eq + Clone + Hash + ToSymbol,
-    CodId: Eq + Clone + Hash + ToSymbol,
+    DomId: Eq + Clone + Hash,
+    CodId: Eq + Clone + Hash,
     Cat: FgCategory,
     Cat::Ob: Hash,
     Cat::Mor: Hash,
@@ -443,8 +442,8 @@ pub struct DiscreteDblModelMorphismFinder<'a, DomId, CodId, Cat: FgCategory> {
 
 impl<'a, DomId, CodId, Cat> DiscreteDblModelMorphismFinder<'a, DomId, CodId, Cat>
 where
-    DomId: Clone + Eq + Hash + ToSymbol,
-    CodId: Clone + Eq + Hash + ToSymbol,
+    DomId: Clone + Eq + Hash,
+    CodId: Clone + Eq + Hash,
     Cat: FgCategory,
     Cat::Ob: Hash,
     Cat::Mor: Hash,

--- a/packages/catlog/src/egglog_util.rs
+++ b/packages/catlog/src/egglog_util.rs
@@ -2,12 +2,9 @@
 
 use std::fmt::Display;
 
-use egglog::ast::{Action, Command, Expr, Fact, Schedule, Symbol};
+use egglog::ast::{Action, Command, Expr, Fact, Schedule};
 use egglog::{EGraph, Error, span};
 use ref_cast::RefCast;
-use ustr::Ustr;
-#[cfg(feature = "uuid")]
-use uuid::Uuid;
 
 /** An egglog program.
 
@@ -63,38 +60,3 @@ impl Program {
         }
     }
 }
-
-/** A type convertible into an egglog [`Symbol`].
-
-The default implementation converts the object into a `String` and from that
-into a `Symbol`. Some types will allow more efficient conversions.
- */
-pub trait ToSymbol: ToString {
-    /// Converts this object into a `Symbol`.
-    fn to_symbol(&self) -> Symbol {
-        self.to_string().into()
-    }
-}
-
-impl ToSymbol for char {}
-
-impl ToSymbol for String {
-    fn to_symbol(&self) -> Symbol {
-        self.into()
-    }
-}
-
-impl ToSymbol for Symbol {
-    fn to_symbol(&self) -> Symbol {
-        *self
-    }
-}
-
-impl ToSymbol for Ustr {
-    fn to_symbol(&self) -> Symbol {
-        self.as_str().into()
-    }
-}
-
-#[cfg(feature = "uuid")]
-impl ToSymbol for Uuid {}

--- a/packages/catlog/src/stdlib/analyses/ode/lotka_volterra.rs
+++ b/packages/catlog/src/stdlib/analyses/ode/lotka_volterra.rs
@@ -12,7 +12,6 @@ use tsify_next::Tsify;
 
 use super::ODEAnalysis;
 use crate::dbl::model::{DiscreteDblModel, FgDblModel};
-use crate::egglog_util::ToSymbol;
 use crate::one::fp_category::UstrFpCategory;
 use crate::one::{FgCategory, Path};
 use crate::simulate::ode::{LotkaVolterraSystem, ODEProblem};
@@ -88,7 +87,7 @@ impl LotkaVolterraAnalysis {
         data: LotkaVolterraProblemData<Id>,
     ) -> ODEAnalysis<Id, LotkaVolterraSystem>
     where
-        Id: Eq + Clone + Hash + Ord + ToSymbol,
+        Id: Eq + Clone + Hash + Ord,
     {
         let mut objects: Vec<_> = model.ob_generators_with_type(&self.var_ob_type).collect();
         objects.sort();


### PR DESCRIPTION
Besides removing the interop trait `ToSymbol` that was annoyingly infecting the codebase, this design will better support the compound IDs that arise in hierarchical model composition.