### PR TITLE
Stock-flow visualization: Larger boxes, ortho flows, and blue links

### DIFF
--- a/packages/frontend/src/stdlib/analyses/graph_visualization.css
+++ b/packages/frontend/src/stdlib/analyses/graph_visualization.css
@@ -1,3 +1,7 @@
 .graph-visualization {
     overflow-x: auto;
 }
+
+g.link path {
+    stroke: blue;
+}

--- a/packages/frontend/src/stdlib/analyses/stock_flow_diagram.tsx
+++ b/packages/frontend/src/stdlib/analyses/stock_flow_diagram.tsx
@@ -44,10 +44,10 @@ const STOCKFLOW_ATTRIBUTES: GV.GraphvizAttributes = {
         splines: "ortho",
     },
     node: {
-        width: .55,
-        height: .55,
+        width: 0.55,
+        height: 0.55,
     },
-}
+};
 
 /** Visualize a stock flow diagram.
  */

--- a/packages/frontend/src/stdlib/analyses/stock_flow_diagram.tsx
+++ b/packages/frontend/src/stdlib/analyses/stock_flow_diagram.tsx
@@ -39,6 +39,16 @@ export function configureStockFlowDiagram(options: {
     };
 }
 
+const STOCKFLOW_ATTRIBUTES: GV.GraphvizAttributes = {
+    graph: {
+        splines: "ortho",
+    },
+    node: {
+        width: .55,
+        height: .55,
+    },
+}
+
 /** Visualize a stock flow diagram.
  */
 export function StockFlowDiagram(props: ModelAnalysisProps<GV.GraphConfig>) {
@@ -60,6 +70,7 @@ export function StockFlowDiagram(props: ModelAnalysisProps<GV.GraphConfig>) {
                             model={props.liveModel.formalJudgments()}
                             theory={theory()}
                             options={GV.graphvizOptions(props.content)}
+                            attributes={STOCKFLOW_ATTRIBUTES}
                             ref={setSvgRef}
                         />
                     )}
@@ -165,6 +176,7 @@ function StockFlowSVG(props: {
         </svg>
     );
 }
+
 /** Quadratic Bezier curve from one point to another.
  */
 function quadraticCurve(src: GraphLayout.Point, tgt: GraphLayout.Point, ratio: number) {


### PR DESCRIPTION
Minor changes to Stock & Flow diagram visualizations. Make the flow arrows ortho-style, make the minimum stock size a little bigger, and make link arrows blue. 

**Note**: the change that I made to the CSS assumes that the class name "link" is only ever used for Stock & Flow diagram links, and so all "link"s will be blue. As far as I can tell from looking through the code, that is currently the case. However, I can make a new class for Stock & Flow links specifically if you'd prefer. 

**Before:** 
![image](https://github.com/user-attachments/assets/9f6a9d42-a215-430c-911b-0e169a3cf2f6)

**After:**
![image](https://github.com/user-attachments/assets/0e962921-b101-40a3-8ae2-1a96062b88d9)