### PR TITLE
Upgrade from `tsify_next` back to `tsify`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,7 +326,7 @@ dependencies = [
  "serde",
  "textplots",
  "thiserror 1.0.69",
- "tsify-next",
+ "tsify",
  "ustr",
  "uuid",
  "wasm-bindgen",
@@ -345,7 +345,7 @@ dependencies = [
  "js-sys",
  "nonempty",
  "serde",
- "tsify-next",
+ "tsify",
  "ustr",
  "uuid",
  "wasm-bindgen",
@@ -3492,24 +3492,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "tsify-next"
-version = "0.5.4"
+name = "tsify"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4a645dca4ee0800f5ab60ce166deba2db6a0315de795a2691e138a3d55d756"
+checksum = "b2ec91b85e6c6592ed28636cb1dd1fac377ecbbeb170ff1d79f97aac5e38926d"
 dependencies = [
  "gloo-utils",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
- "tsify-next-macros",
+ "tsify-macros",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "tsify-next-macros"
-version = "0.5.4"
+name = "tsify-macros"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5c06f8a51d759bb58129e30b2631739e7e1e4579fad1f30ac09a6c88e488a6"
+checksum = "9a324606929ad11628a19206d7853807481dcaecd6c08be70a235930b8241955"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/packages/catlog-wasm/Cargo.toml
+++ b/packages/catlog-wasm/Cargo.toml
@@ -20,7 +20,7 @@ getrandom = { version = "0.2", features = ["js"] }
 js-sys = "0.3.77"
 nonempty = { version = "0.10", features = ["serialize"] }
 serde = { version = "1", features = ["derive"] }
-tsify-next = { version = "0.5.4", features = ["js"] }
+tsify = { version = "0.5.5", features = ["js"] }
 ustr = "1"
 uuid = { version = "=1.11", features = ["v7", "serde", "js"] }
 wasm-bindgen = "0.2.100"

--- a/packages/catlog-wasm/src/analyses.rs
+++ b/packages/catlog-wasm/src/analyses.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use tsify_next::Tsify;
+use tsify::Tsify;
 use uuid::Uuid;
 
 use super::result::JsResult;

--- a/packages/catlog-wasm/src/model.rs
+++ b/packages/catlog-wasm/src/model.rs
@@ -8,7 +8,7 @@ use ustr::{IdentityHasher, Ustr};
 use uuid::Uuid;
 
 use serde::{Deserialize, Serialize};
-use tsify_next::Tsify;
+use tsify::Tsify;
 use wasm_bindgen::prelude::*;
 
 use catlog::dbl::model::{self as dbl_model, FgDblModel, InvalidDblModel, MutDblModel};

--- a/packages/catlog-wasm/src/model_diagram.rs
+++ b/packages/catlog-wasm/src/model_diagram.rs
@@ -5,7 +5,7 @@ use derive_more::From;
 use uuid::Uuid;
 
 use serde::{Deserialize, Serialize};
-use tsify_next::Tsify;
+use tsify::Tsify;
 use wasm_bindgen::prelude::*;
 
 use catlog::dbl::model::{FgDblModel, MutDblModel};

--- a/packages/catlog-wasm/src/model_morphism.rs
+++ b/packages/catlog-wasm/src/model_morphism.rs
@@ -1,7 +1,7 @@
 use std::hash::Hash;
 
 use serde::{Deserialize, Serialize};
-use tsify_next::Tsify;
+use tsify::Tsify;
 use uuid::Uuid;
 
 use catlog::dbl::{model, model_morphism};

--- a/packages/catlog-wasm/src/result.rs
+++ b/packages/catlog-wasm/src/result.rs
@@ -1,7 +1,7 @@
 //! Result of fallible computation that translates to/from JavaScript.
 
 use serde::{Deserialize, Serialize};
-use tsify_next::Tsify;
+use tsify::Tsify;
 
 /** A `Result`-like type that translates to/from JavaScript.
 

--- a/packages/catlog-wasm/src/theory.rs
+++ b/packages/catlog-wasm/src/theory.rs
@@ -9,7 +9,7 @@ use derive_more::From;
 use ustr::Ustr;
 
 use serde::{Deserialize, Serialize};
-use tsify_next::Tsify;
+use tsify::Tsify;
 use wasm_bindgen::prelude::*;
 
 use catlog::dbl::theory;

--- a/packages/catlog/Cargo.toml
+++ b/packages/catlog/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 [features]
 ode = ["dep:ode_solvers", "dep:nalgebra"]
 serde = ["dep:serde", "nonempty/serialize", "ustr/serde"]
-serde-wasm = ["serde", "dep:wasm-bindgen", "dep:tsify-next"]
+serde-wasm = ["serde", "dep:wasm-bindgen", "dep:tsify"]
 
 [dependencies]
 derivative = "2"
@@ -24,7 +24,7 @@ ode_solvers = { version = "0.5.0", optional = true }
 ref-cast = "1"
 serde = { version = "1", features = ["derive"], optional = true }
 thiserror = "1"
-tsify-next = { version = "0.5", features = ["js"], optional = true }
+tsify = { version = "0.5", features = ["js"], optional = true }
 ustr = "1"
 uuid = { version = "=1.11", optional = true }
 wasm-bindgen = { version = "0.2.100", optional = true }

--- a/packages/catlog/src/dbl/category.rs
+++ b/packages/catlog/src/dbl/category.rs
@@ -12,7 +12,7 @@ has gone by many other names, notably *fc-multicategory* ([Leinster
 2004](crate::refs::HigherOperads)).
 
 *Composites* of proarrows in a VDC, if they exist, are represented by cells
-satisfying a universal property ([Cruttwell-Shulman
+satsifying a universal property ([Cruttwell-Shulman
 2008](crate::refs::GeneralizedMulticategories), Section 5). In our usage of
 virtual double categories as double theories, we will assume that *units*
 (nullary composites) exist. We will not assume that any other composites exist,

--- a/packages/catlog/src/dbl/model.rs
+++ b/packages/catlog/src/dbl/model.rs
@@ -43,7 +43,7 @@ use ustr::{IdentityHasher, Ustr};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "serde-wasm")]
-use tsify_next::Tsify;
+use tsify::Tsify;
 
 use super::category::VDblCategory;
 use super::theory::{DblTheory, DiscreteDblTheory};

--- a/packages/catlog/src/dbl/model_diagram.rs
+++ b/packages/catlog/src/dbl/model_diagram.rs
@@ -22,7 +22,7 @@ use nonempty::NonEmpty;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "serde-wasm")]
-use tsify_next::{Tsify, declare};
+use tsify::{Tsify, declare};
 
 use super::{model::*, model_morphism::*};
 use crate::one::{Category, FgCategory};

--- a/packages/catlog/src/dbl/model_morphism.rs
+++ b/packages/catlog/src/dbl/model_morphism.rs
@@ -29,7 +29,7 @@ use thiserror::Error;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "serde-wasm")]
-use tsify_next::Tsify;
+use tsify::Tsify;
 
 use crate::one::graph_algorithms::{bounded_simple_paths, simple_paths, spec_order};
 use crate::one::*;

--- a/packages/catlog/src/one/path.rs
+++ b/packages/catlog/src/one/path.rs
@@ -12,7 +12,7 @@ use std::{collections::HashSet, hash::Hash};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "serde-wasm")]
-use tsify_next::Tsify;
+use tsify::Tsify;
 
 use super::graph::Graph;
 use crate::validate;

--- a/packages/catlog/src/stdlib/analyses/ode/lotka_volterra.rs
+++ b/packages/catlog/src/stdlib/analyses/ode/lotka_volterra.rs
@@ -8,7 +8,7 @@ use ustr::Ustr;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "serde-wasm")]
-use tsify_next::Tsify;
+use tsify::Tsify;
 
 use super::ODEAnalysis;
 use crate::dbl::model::{DiscreteDblModel, FgDblModel};

--- a/packages/catlog/src/stdlib/analyses/ode/mass_action.rs
+++ b/packages/catlog/src/stdlib/analyses/ode/mass_action.rs
@@ -14,7 +14,7 @@ use ustr::{IdentityHasher, Ustr, ustr};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "serde-wasm")]
-use tsify_next::Tsify;
+use tsify::Tsify;
 
 use super::ODEAnalysis;
 use crate::dbl::{

--- a/packages/catlog/src/stdlib/analyses/ode/mod.rs
+++ b/packages/catlog/src/stdlib/analyses/ode/mod.rs
@@ -8,7 +8,7 @@ use ode_solvers::dop_shared::IntegrationError;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "serde-wasm")]
-use tsify_next::Tsify;
+use tsify::Tsify;
 
 use crate::simulate::ode::{ODEProblem, ODESystem};
 


### PR DESCRIPTION
The fork has been merged back into the original repo: https://github.com/madonoharu/tsify/pull/60