### PR TITLE
Pin rust toolchain version used in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_TOOLCHAIN: 1.86.0
 
 jobs:
   rust_tests:
@@ -16,7 +17,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - stable
+          - ${{ env.RUST_TOOLCHAIN }}
           - beta
     steps:
       - name: Checkout Repository
@@ -24,7 +25,9 @@ jobs:
 
       - name: Tests
         run: |
-          rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+          rustup toolchain install ${{ matrix.toolchain }}
+          rustup default ${{ matrix.toolchain }}
+
           cargo build --all-features --verbose
           cargo test --all-features --verbose
 
@@ -37,7 +40,10 @@ jobs:
 
       - name: Check formatting
         run: |
-          rustup update stable && rustup default stable
+          rustup toolchain install ${{ env.RUST_TOOLCHAIN }}
+          rustup default ${{ env.RUST_TOOLCHAIN }}
+          rustup component add rustfmt
+
           cargo fmt --check
 
   rust_lints:
@@ -49,7 +55,10 @@ jobs:
 
       - name: Check clippy warnings
         run: |
-          rustup update stable && rustup default stable
+          rustup toolchain install ${{ env.RUST_TOOLCHAIN }}
+          rustup default ${{ env.RUST_TOOLCHAIN }}
+          rustup component add clippy 
+
           cargo clippy -- -D warnings
 
   rust_docs:
@@ -61,7 +70,9 @@ jobs:
 
       - name: Check rustdoc warnings
         run: |
-          rustup update stable && rustup default stable
+          rustup toolchain install ${{ env.RUST_TOOLCHAIN }}
+          rustup default ${{ env.RUST_TOOLCHAIN }}
+
           RUSTDOCFLAGS='--deny warnings' cargo doc --no-deps
 
   npm_checks:


### PR DESCRIPTION
The rust toolchain installed by running `rustup update stable` recently changed to `latest update on 2025-05-15, rust version 1.87.0 (17067e9ac 2025-05-09)`, this update caused this error:

```
Checking jsonrpsee v0.24.9
error: replacing an `Option` with `Some(..)`
   --> packages/catlog/src/zero/column.rs:219:9
    |
219 |         std::mem::replace(&mut self.0[i], Some(y))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Option::replace()` instead: `self.0[i].replace(y)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#mem_replace_option_with_some
    = note: `-D clippy::mem-replace-option-with-some` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::mem_replace_option_with_some)]`

error: could not compile `catlog` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

[example run where this failure occurred](https://github.com/ToposInstitute/CatColab/actions/runs/15073078251/job/42374032182)

This PR temporarily fixes this problem by pinning the rust toolchain version used in CI to be the same one used by nix. While this doesn't fix the underlying problem, it does address the existing problem that the toolcain used in CI was different from the one used in deployments.

The breaking change is [here](https://github.com/rust-lang/rust-clippy/pull/14197)
docs for the new lint are [here](https://rust-lang.github.io/rust-clippy/stable/index.html#mem_replace_option_with_some).

Issue tracking the rust toolchain update is here: https://github.com/ToposInstitute/CatColab/issues/506