### PR TITLE
Use rust-toolchain.toml as source of truth for rust version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_TOOLCHAIN: 1.86.0
 
 jobs:
   rust_tests:
@@ -17,7 +16,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - ${{ env.RUST_TOOLCHAIN }}
+          - stable
           - beta
     steps:
       - name: Checkout Repository
@@ -38,12 +37,11 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Install Rust toolchain from file
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
       - name: Check formatting
         run: |
-          rustup toolchain install ${{ env.RUST_TOOLCHAIN }}
-          rustup default ${{ env.RUST_TOOLCHAIN }}
-          rustup component add rustfmt
-
           cargo fmt --check
 
   rust_lints:
@@ -53,12 +51,11 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Install Rust toolchain from file
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
       - name: Check clippy warnings
         run: |
-          rustup toolchain install ${{ env.RUST_TOOLCHAIN }}
-          rustup default ${{ env.RUST_TOOLCHAIN }}
-          rustup component add clippy 
-
           cargo clippy -- -D warnings
 
   rust_docs:
@@ -68,11 +65,11 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Install Rust toolchain from file
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
       - name: Check rustdoc warnings
         run: |
-          rustup toolchain install ${{ env.RUST_TOOLCHAIN }}
-          rustup default ${{ env.RUST_TOOLCHAIN }}
-
           RUSTDOCFLAGS='--deny warnings' cargo doc --no-deps
 
   npm_checks:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,10 +31,8 @@ jobs:
           node-version: 20
           cache: "pnpm"
 
-      - name: Setup Rust
-        run: |
-          rustup toolchain install stable
-          rustup target add wasm32-unknown-unknown
+      - name: Install Rust toolchain from file
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build for Prod
         if: github.event_name == 'release'
@@ -71,9 +69,8 @@ jobs:
       - name: Repository Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Rust
-        run: |
-          rustup toolchain install stable
+      - name: Install Rust toolchain from file
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build
         run: |

--- a/flake.lock
+++ b/flake.lock
@@ -323,6 +323,27 @@
         "type": "github"
       }
     },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1747392669,
+        "narHash": "sha256-zky3+lndxKRu98PAwVK8kXPdg+Q1NVAhaI7YGrboKYA=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "c3c27e603b0d9b5aac8a16236586696338856fbb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "locked": {
         "lastModified": 1696426674,
@@ -783,17 +804,18 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1745234285,
-        "narHash": "sha256-GfpyMzxwkfgRVN0cTGQSkTC0OHhEkv3Jf6Tcjm//qZ0=",
-        "owner": "NixOS",
+        "lastModified": 1747209494,
+        "narHash": "sha256-fLise+ys+bpyjuUUkbwqo5W/UyIELvRz9lPBPoB0fbM=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c11863f1e964833214b767f4a369c6e6a7aba141",
+        "rev": "5d736263df906c5da72ab0f372427814de2f52f8",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-unstable",
-        "type": "indirect"
+        "owner": "nixos",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "pre-commit-hooks": {
@@ -901,7 +923,25 @@
         "agenix": "agenix",
         "crate2nix": "crate2nix",
         "deploy-rs": "deploy-rs",
+        "fenix": "fenix",
         "nixpkgs": "nixpkgs_8"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747323949,
+        "narHash": "sha256-G4NwzhODScKnXqt2mEQtDFOnI0wU3L1WxsiHX3cID/0=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "f8e784353bde7cbf9a9046285c1caf41ac484ebe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "systems": {

--- a/infrastructure/modules/backend.nix
+++ b/infrastructure/modules/backend.nix
@@ -1,8 +1,8 @@
 {
   lib,
   pkgs,
-  inputs,
   config,
+  rustToolchain,
   ...
 }:
 let
@@ -40,6 +40,7 @@ let
 
   catcolabPackages = {
     backend = pkgs.lib.callPackageWith pkgs ../../packages/backend/default.nix {
+      inherit rustToolchain;
     };
 
     automerge-doc-server =

--- a/packages/backend/default.nix
+++ b/packages/backend/default.nix
@@ -1,9 +1,26 @@
 {
   pkgs,
+  rustToolchain,
   ...
 }:
 let
-  cargoNix = pkgs.callPackage ../../Cargo.nix { };
+  # Why do this instaed of creating a global overlay for rustc and cargo?
+  #
+  # Fenix can provide a rustc and cargo, however they are derivations, which means they are lacking many
+  # of the attributes that other packages expect them to have. So creating an overlay with the fenix rustc
+  # and cargo will cause other packages to break.
+  #
+  # The correct way to handle this is to use fenix to configure pkgs.rustPlatform, which other packages
+  # should be using. However crate2nix does not use this API and instaed uses the older pkgs.buildRustCrate.
+  # As a result we need to manually pass the rust toolchain to the cargoNix callsite.
+  buildRustCrateForPkgs =
+    crate:
+    pkgs.buildRustCrate.override {
+      rustc = rustToolchain;
+      cargo = rustToolchain;
+    };
+
+  cargoNix = import ../../Cargo.nix { inherit pkgs buildRustCrateForPkgs; };
   backend = cargoNix.workspaceMembers.catcolab-backend.build;
 in
 backend.overrideAttrs (attrs: {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.86.0"
+components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
Use the `rust-toolchain.toml` file ([docs](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file)) as the source of truth for the rust version to use in Nix and CI.

This also allows us to get of the `unstable` branch for NixOS. Unfortunately the change in the NixOS version means that a manual deploy is required since the github runner will likely timeout.