### PR TITLE
Add `db-utils` script for database development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,5 +91,8 @@ instrument.mjs
 # direnv cache
 .direnv
 
-# bild build output
+# nix build output
 /infrastructure/result
+
+# Database dumps
+/dumps

--- a/flake.nix
+++ b/flake.nix
@@ -104,6 +104,9 @@
               else
                 ""
             }
+
+            export PATH=$PWD/infrastructure/scripts:$PATH
+
             # Load DATABASE_URL into the environment
             if [ -f packages/backend/.env ]; then
               export $(grep -v '^#' packages/backend/.env | xargs)

--- a/infrastructure/scripts/db-utils
+++ b/infrastructure/scripts/db-utils
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/db-utils-lib.sh"
+
+STAGING_SSH_PID=""
+STAGING_LOCAL_PGPORT="5434"
+
+PROD_SSH_PID=""
+PROD_PGPORT="5433"
+
+function print_help {
+  echo "Usage: $0 <subcommand> [options]"
+  echo ""
+  echo "Subcommands:"
+  echo "  reset                 Reset the local database"
+  echo "  load                  Load a dump into a target (local|staging|production)"
+  echo "  dump                  Dump a target (local|staging|production) database"
+  echo "  connect               Connect to a target (local|staging|production)"
+  echo ""
+  echo "Use '$0 <subcommand> --help' for more information."
+}
+
+function print_connect_help {
+  echo "Usage: $0 connect <target>"
+  echo "Targets: local, staging, production"
+}
+
+function print_dump_help {
+  echo "Usage: $0 dump [options]"
+  echo ""
+  echo "Options:"
+  echo "  -f, --from <target>    Target: local (default), staging, or production"
+  echo "  -t, --to <filename>    Filename to write (defaults to './dumps/<target>_dump_<timestamp>.sql')"
+  echo "  -h, --help             Print this help message"
+}
+
+function print_load_help {
+  echo "Usage: $0 load [options]"
+  echo ""
+  echo "Options:"
+  echo "  -t, --to <target>      Target: local (default), staging, or production"
+  echo "  -f, --from <file|source>"
+  echo "                         Dump file to load, or one of:"
+  echo "                           local, staging, production"
+  echo "                         to pick the most recent dump for that source"
+  echo "  -h, --help             Print this help message"
+  echo "  -n, --no-migrate       Skip running migrations after loading"
+}
+
+function print_reset_help {
+  echo "Usage: $0 reset local"
+  echo "Only the local database may be reset."
+}
+
+function run_connect() {
+  local target="$1"
+  if [[ "$target" == "-h" || "$target" == "--help" ]]; then
+    print_connect_help
+    exit 0
+  fi
+
+  case "$target" in
+    local)
+      load_target_env local
+      psql
+      ;;
+    staging)
+      load_target_env staging
+      psql
+      ;;
+    production)
+      load_target_env production
+      psql
+      ;;
+    *)
+      echo "Unknown target: $target"
+      echo ""
+      print_connect_help
+      exit 1
+      ;;
+  esac
+}
+
+function run_dump() {
+  local target="local"
+  local dump_file=""
+
+  while [[ ${1-} ]]; do
+    case "$1" in
+      "-f" | "--from")
+        shift
+        target="$1"
+        ;;
+      "-t" | "--to")
+        shift
+        dump_file="$1"
+        ;;
+      "-h" | "--help")
+        print_dump_help
+        exit 0
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        echo ""
+        print_dump_help
+        exit 1
+        ;;
+    esac
+    shift
+  done
+
+  local dumps_dir="$(find_git_root)/dumps"
+  mkdir -p "$dumps_dir"
+
+  if [[ -z $dump_file ]]; then
+    dump_file="${dumps_dir}/${target}_dump_$(date +%Y%m%d_%H%M%S).sql"
+  else
+    dump_file="${dumps_dir}/${dump_file}"
+  fi
+
+  case "$target" in
+    local)
+      echo "Dumping local to $dump_file..."
+      load_target_env local
+      pg_dump --clean --if-exists > "$dump_file"
+      ;;
+    staging)
+      echo "Dumping staging to $dump_file..."
+      load_target_env staging
+      pg_dump --clean --if-exists > "$dump_file"
+      ;;
+    production)
+      echo "Dumping production to $dump_file..."
+      load_target_env production
+      pg_dump --clean --if-exists > "$dump_file"
+      ;;
+    *)
+      echo "Unknown target: $target"
+      echo ""
+      print_dump_help
+      exit 1
+      ;;
+  esac
+}
+
+function run_load() {
+  local target="local"
+  local dump_file=""
+  local skip_migrate=false
+
+  while [[ ${1-} ]]; do
+    case "$1" in
+      "-s"|"--skip-migrate")
+        skip_migrate=true
+        ;;
+      "-t" | "--to")
+        shift
+        target="$1"
+        ;;
+      "-f" | "--from")
+        shift
+        dump_file="$1"
+        ;;
+      "-h" | "--help")
+        print_load_help
+        exit 0
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        echo ""
+        print_load_help
+        exit 1
+        ;;
+    esac
+    shift
+  done
+
+  if [[ -z $dump_file ]]; then
+    echo "Missing dump specifier."
+    print_load_help
+    exit 1
+  fi
+
+  if [[ $dump_file =~ ^(local|staging|production)$ ]]; then
+    local source_name="$dump_file"
+    local files=("$(find_git_root)/dumps/${source_name}_dump_"*.sql)
+
+    if [[ ${#files[@]} -eq 0 ]]; then
+      echo "No dump files found for source '$source_name'."
+      exit 1
+    fi
+
+    dump_file="${files[${#files[@]}-1]}"
+
+    echo "Using most recent dump for '$source_name': $dump_file"
+  fi
+
+  if [[ ! -f $dump_file ]]; then
+    echo "Dump not found: $dump_file"
+    exit 1
+  fi
+
+  case "$target" in
+    local)
+      load_target_env local
+      echo "Loading into local..."
+      psql --dbname="$PGDATABASE" -f "$dump_file"
+
+      if [[ "$skip_migrate" != "true" ]]; then
+        echo ""
+        run_local_migrations
+      fi
+    ;;
+    staging|production)
+      echo "Not allow to modify target: $target"
+      echo ""
+      exit 1
+    ;;
+    *)
+      echo "Unknown target: $target"
+      echo ""
+      print_load_help
+      exit 1
+      ;;
+  esac
+}
+
+function run_reset() {
+  local target="$1"
+  local skip_migrate="${2:-false}"
+
+  if [[ "$target" == "-h" || "$target" == "--help" ]]; then
+    echo ""
+    print_reset_help
+    exit 0
+  fi
+
+  if [[ "$target" != "local" ]]; then
+    echo "Error: reset only supports 'local'." >&2
+    echo ""
+    print_reset_help
+    exit 1
+  fi
+
+  echo "WARNING: This will reset your local 'catcolab' database."
+  read -n1 -r -p "Continue? [y/N] " yn
+  if [[ $yn != [yY] ]]; then
+    echo "Aborted."
+    exit 1
+  fi
+
+  load_target_env local
+  local pwd="$PGPASSWORD"
+  load_target_env local_superuser
+
+  if ! psql --dbname=postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='catcolab'" | grep -q 1; then
+    psql --dbname=postgres --command "CREATE USER catcolab WITH ENCRYPTED PASSWORD '$pwd';"
+  fi
+
+  psql --dbname=postgres --command "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='catcolab' AND pid<>pg_backend_pid();"
+  psql --dbname=postgres --command "DROP DATABASE IF EXISTS catcolab;"
+  psql --dbname=postgres --command "CREATE DATABASE catcolab;"
+  psql --dbname=postgres --command "ALTER DATABASE catcolab OWNER TO catcolab;"
+  psql --dbname=catcolab --command "GRANT ALL ON SCHEMA public TO catcolab;"
+
+
+  if [[ "$skip_migrate" != "true" ]]; then
+    run_local_migrations
+  fi
+}
+
+# Entry point
+subcommand="$1"
+shift || true
+
+case "$subcommand" in
+  connect)
+    run_connect "$@"
+    ;;
+  dump)
+    run_dump "$@"
+    ;;
+  load)
+    run_load "$@"
+    ;;
+  reset)
+    run_reset "$@"
+    ;;
+  "-h" | "--help" | "")
+    print_help
+    ;;
+  *)
+    echo "Unknown subcommand: $subcommand"
+    echo ""
+    print_help
+    exit 1
+    ;;
+esac

--- a/infrastructure/scripts/db-utils-lib.sh
+++ b/infrastructure/scripts/db-utils-lib.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function load_env() {
+  local varname="$1"
+  local env_file="$2"
+
+  if [[ -z $varname || -z $env_file ]]; then
+    echo "Usage: load_env VAR ENV_FILE" >&2
+    exit 1
+  fi
+
+  if [[ ! -f $env_file ]]; then
+    echo "Error: '$env_file' not found." >&2
+    exit 1
+  fi
+
+  # Decrypt if it’s an agenix file
+  local content
+  if [[ $env_file == *.age ]]; then
+    pushd "$(dirname "$env_file")" >/dev/null
+    content=$(agenix -d "$(basename "$env_file")")
+    popd >/dev/null
+  else
+    content=$(<"$env_file")
+  fi
+
+  # extract VAR=
+  local url
+  url=$(printf '%s\n' "$content" | grep -E "^${varname}=" | cut -d '=' -f2-)
+  if [[ -z $url ]]; then
+    echo "Error: '$varname' missing in $env_file." >&2
+    exit 1
+  fi
+
+  # strip off protocol if it exists
+  url="${url#postgresql://}"
+  url="${url#postgres://}"
+
+  # split into components
+  IFS=':@/' read -r PGUSER PGPASSWORD PGHOST PGPORT PGDATABASE <<< "$url"
+  export PGUSER PGPASSWORD PGHOST PGPORT PGDATABASE
+}
+
+function open_tunnel() {
+  local user="$1" host="$2" local_port="$3" remote_port="$4" pid_var="$5"
+
+  # only open once
+  if [[ -z "${!pid_var-}" ]]; then
+    ssh -N -L "${local_port}:localhost:${remote_port}" "${user}@${host}" &
+    # stash its PID in the named variable
+    eval "$pid_var=$!"
+    # ensure cleanup on exit
+    trap "kill ${!pid_var} 2>/dev/null || true" EXIT
+
+    wait_for_port localhost "$local_port" || {
+      echo "Failed to open tunnel to $host:$remote_port" >&2
+      exit 1
+    }
+  fi
+}
+
+function wait_for_port() {
+  local host=$1 port=$2 timeout=${3:-5}
+  local elapsed=0
+
+  while ! nc -z "$host" "$port" 2>/dev/null; do
+    if (( elapsed >= timeout * 10 )); then
+      echo "Timeout waiting for $host:$port" >&2
+      return 1
+    fi
+    sleep 0.1
+    (( elapsed++ ))
+  done
+}
+
+function load_target_env() {
+  case "$1" in
+    local_superuser)
+      load_env DATABASE_SUPERUSER_URL "$(find_git_root)/packages/backend/.env"
+      ;;
+    local)
+      load_env DATABASE_URL "$(find_git_root)/packages/backend/.env"
+      ;;
+    staging)
+      load_env DATABASE_URL "$(find_git_root)/infrastructure/secrets/.env.next.age"
+
+      open_tunnel "catcolab" "backend-next.catcolab.org" "$STAGING_LOCAL_PGPORT" "$PGPORT" "STAGING_SSH_PID"
+
+      export PGPORT="$STAGING_LOCAL_PGPORT"
+      ;;
+    production)
+      load_env DATABASE_URL "$(find_git_root)/infrastructure/secrets/.env.prod.age"
+
+      open_tunnel "catcolab" "backend.catcolab.org" "$PROD_LOCAL_PGPORT" "$PGPORT" "PROD_SSH_PID"
+
+      export PGPORT="$PROD_LOCAL_PGPORT"
+      ;;
+    *)
+      echo "Unknown target: $1" >&2
+      print_help
+      exit 1
+      ;;
+  esac
+}
+
+function find_git_root() {
+  local dir="$PWD"
+  while [[ $dir != "/" ]]; do
+    if [[ -d "$dir/.git" ]]; then
+      echo "$dir"
+      return
+    fi
+    dir=$(dirname "$dir")
+  done
+  return 1
+}
+
+function run_local_migrations() {
+  echo "Running local migrations..."
+  cargo run -p migrator apply
+}


### PR DESCRIPTION
Adds a utility script to make developing against a local database suck less by making it easy to save and restore snapshots of any CatColab DB.

My most recent usecase for developing migrations looked like:
1. `db-utils dump --from staging`
2. `db-utils load --from staging --to local --skip-migrate`
3. develop migrations manually, running above command again to get a clean state
4. `db-utils load --from staging --to local` to test the migrations script

This also makes it trivial to develop/test against the staging or prod DB, and a bunch of other usecases. It also codifies the process for setting up the DB on a new development machine.

It would be understandable if you didn't want to accept this PR: this is a relatively large amount of bash and the rest of the world seems to manage just fine without this script (which I find confusing). Other people have found it useful in the past and I'll keep using it regardless (unless prohibited).

aside: do we have a process for restoring from our DB backups? Has that been tested?

fun fact: I've carried some version of this script with me through every job (12 years!).