### PR TITLE
FIX: pass custom `rustToolchain` to migrator package

### DIFF
--- a/Cargo.nix
+++ b/Cargo.nix
@@ -1067,10 +1067,6 @@ rec {
         src = lib.cleanSourceWith { filter = sourceFilter;  src = ./packages/backend; };
         dependencies = [
           {
-            name = "async-trait";
-            packageId = "async-trait";
-          }
-          {
             name = "axum";
             packageId = "axum";
           }

--- a/infrastructure/modules/backend.nix
+++ b/infrastructure/modules/backend.nix
@@ -71,6 +71,7 @@ let
     };
 
     migrator = pkgs.lib.callPackageWith pkgs ../../packages/migrator/default.nix {
+      inherit rustToolchain;
     };
 
     automerge-doc-server =

--- a/packages/migrator/default.nix
+++ b/packages/migrator/default.nix
@@ -1,9 +1,18 @@
 {
   pkgs,
+  rustToolchain,
   ...
 }:
 let
-  cargoNix = pkgs.callPackage ../../Cargo.nix { };
+  # see comment in packages/backend/default.nix
+  buildRustCrateForPkgs =
+    crate:
+    pkgs.buildRustCrate.override {
+      rustc = rustToolchain;
+      cargo = rustToolchain;
+    };
+
+  cargoNix = import ../../Cargo.nix { inherit pkgs buildRustCrateForPkgs; };
   migrator = cargoNix.workspaceMembers.migrator.build;
 in
 migrator


### PR DESCRIPTION
This issue came up due to a rebase/merge.

Originally, this branch was developed against `nixos-unstable`, which included a newer Rust version. Later, when `rust-toolchain.toml` changes were merged, we downgraded `nixpkgs` to `24.11`. This brought in an older Rust version via `nixpkgs`, but we had stopped using Rust from `nixpkgs` at that point. After the rebase, the migrator package was still using Rust from nixpkgs, since its Rust version wasn’t explicitly set.

Not sure why the Cargo.nix changed ¯\_(ツ)_/¯ 