### PR TITLE
Fix paths in backupdb script and add option for different envs

### DIFF
--- a/infrastructure/hosts/catcolab-next/default.nix
+++ b/infrastructure/hosts/catcolab-next/default.nix
@@ -12,6 +12,7 @@ in
   imports = [
     ../../modules/backend.nix
     ../../modules/host.nix
+    ../../modules/backup.nix
     "${inputs.nixpkgs}/nixos/modules/virtualisation/amazon-image.nix"
   ];
 
@@ -39,6 +40,9 @@ in
       automergePort = "8010";
       backendHostname = "backend-next.catcolab.org";
       automergeHostname = "automerge-next.catcolab.org";
+    };
+    backup = {
+      backupdbBucket = "catcolab-next";
     };
     host = {
       userKeys = [

--- a/infrastructure/hosts/catcolab/default.nix
+++ b/infrastructure/hosts/catcolab/default.nix
@@ -38,6 +38,9 @@ in
       backendHostname = "backend.catcolab.org";
       automergeHostname = "automerge.catcolab.org";
     };
+    backup = {
+      backupdbBucket = "catcolab";
+    };
     host = {
       userKeys = [
         owen


### PR DESCRIPTION
Why we must use Nix store paths for executables in systemd units:
Systemd uses a fixed PATH defined at compile time, which typically excludes programs installed via Nix. As a result, we need to specify the full Nix store path for any executable used in systemd scripts.

The bigger mystery now is why this script ever worked in the past.