### PR TITLE
Run backupd script at end of deploys to act as a canary for the backup timer

### DIFF
--- a/infrastructure/modules/backup.nix
+++ b/infrastructure/modules/backup.nix
@@ -49,6 +49,32 @@ with lib;
       };
     };
 
+    # run backup script at end of deploy to act as a canary for the backup script
+    system.activationScripts.backupdb = {
+      text = ''
+        echo "Running backupdb script as a transient systemd unit..."
+
+        since=$(date --iso-8601=seconds)
+
+        # we can't run the backupdb unit because at this point systemd doesn't know about the new unit,
+        # so we run a transient unit with the same config.
+        ${pkgs.systemd}/bin/systemd-run --system --wait \
+          --unit=backupdb-activation \
+          --description="One-off activation backupdb" \
+          --property=Type=${config.systemd.services.backupdb.serviceConfig.Type} \
+          --property=User=${config.systemd.services.backupdb.serviceConfig.User} \
+          --property=EnvironmentFile=${config.systemd.services.backupdb.serviceConfig.EnvironmentFile} \
+          --property=Environment=PATH=/run/current-system/sw/bin \
+          ${lib.getExe backupScript}
+
+        exit_code=$?
+        if [ $exit_code -ne 0 ]; then
+          echo "activation‐time backup failed with code $exit_code"
+          ${pkgs.systemd}/bin/journalctl -u backupdb-activation.service --since "$since"
+        fi
+      '';
+    };
+
     # install all packages used in this module
     environment.systemPackages =
       with pkgs;


### PR DESCRIPTION
This is stacked on top of [backup-fix](https://github.com/ToposInstitute/CatColab/pull/518) (it could/should work in a different order, but I didn't test that)