### PR TITLE
Add `--clean` argument to `pg_dump` for database backups

### DIFF
--- a/infrastructure/modules/backup.nix
+++ b/infrastructure/modules/backup.nix
@@ -13,7 +13,7 @@ let
 
     cd ~
 
-    "${pkgs.postgresql}/bin/pg_dump" catcolab > $DUMPFILE
+    ${pkgs.postgresql}/bin/pg_dump --clean --if-exists > $DUMPFILE
 
     ${lib.getExe pkgs.rclone} --config="/run/agenix/rclone.conf" copy "$DUMPFILE" backup:${config.catcolab.backup.backupdbBucket}
 
@@ -45,7 +45,6 @@ with lib;
         User = "catcolab";
         ExecStart = getExe backupScript;
         Type = "oneshot";
-        EnvironmentFile = config.age.secrets.backendSecretsForCatcolab.path;
       };
     };
 
@@ -63,7 +62,6 @@ with lib;
           --description="One-off activation backupdb" \
           --property=Type=${config.systemd.services.backupdb.serviceConfig.Type} \
           --property=User=${config.systemd.services.backupdb.serviceConfig.User} \
-          --property=EnvironmentFile=${config.systemd.services.backupdb.serviceConfig.EnvironmentFile} \
           --property=Environment=PATH=/run/current-system/sw/bin \
           ${lib.getExe backupScript}
 


### PR DESCRIPTION
This is stacked on top of https://github.com/ToposInstitute/CatColab/pull/519/

This change allows the DB to be restored by running `psql < dump.sql` as the `catcolab` user, previously the database would have to be dropped and recreated by a postgres admin. The new flags do not break any behaviour that would have been possible previously.

It's still possible to restore from the previously created backups, it's just more of a pain.