### PR TITLE
FIX: make automerge-doc-server standalone so it can be invoked by the migrator tool

### DIFF
--- a/infrastructure/modules/backend.nix
+++ b/infrastructure/modules/backend.nix
@@ -163,7 +163,7 @@ with lib;
 
       serviceConfig = {
         User = "catcolab";
-        ExecStart = "${lib.getExe pkgs.nodejs_23} ${catcolabPackages.automerge-doc-server}/main.cjs";
+        ExecStart = "${lib.getExe catcolabPackages.automerge-doc-server}";
         Type = "simple";
         Restart = "on-failure";
       };

--- a/packages/automerge-doc-server/default.nix
+++ b/packages/automerge-doc-server/default.nix
@@ -15,6 +15,7 @@ pkgs.stdenv.mkDerivation {
   nativeBuildInputs = with pkgs; [
     pnpm_9.configHook
     esbuild
+    makeWrapper
   ];
 
   buildInputs = with pkgs; [
@@ -38,7 +39,11 @@ pkgs.stdenv.mkDerivation {
       echo "❌ Error: Node.js automerge WASM file not found!"
       exit 1
     fi
+
     cp "$automerge_wasm_path" "$out/"
+
+    mkdir -p $out/bin
+    makeWrapper ${pkgs.nodejs_23}/bin/node $out/bin/${name} --add-flags "$out/main.cjs"
   '';
 
   pnpmDeps = pkgs.pnpm_9.fetchDeps {


### PR DESCRIPTION
The `automerge-doc-server` package did not provide an standalone executable, resulting in this error from the migrator.

```
called `Result::unwrap()` on an `Err` value: Box("Failed to run `automerge-doc-server`: No such file or directory (os error 2)")
```

This fixes the error by making it a standalone executable.