### PR TITLE
Fixed link syntax error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,4 +106,4 @@ The library of domain-specific logics in CatColab, available now and to grow
 over time, is inspired by a wide body of research in applied category theory and
 beyond. Incomplete bibliographies are in the [dev
 docs](https://next.catcolab.org/dev/bib-0001.xml) and the [core
-docs](https://next.catcolab.org/dev/rust/catlog/refs
+docs](https://next.catcolab.org/dev/rust/catlog/refs).


### PR DESCRIPTION
The last link in README didn't have a closing parenthesis (or full-stop).