### PR TITLE
Functors between finitely presented categories

### DIFF
--- a/packages/catlog-wasm/src/model_diagram.rs
+++ b/packages/catlog-wasm/src/model_diagram.rs
@@ -10,8 +10,8 @@ use wasm_bindgen::prelude::*;
 
 use catlog::dbl::model::{FgDblModel, MutDblModel};
 use catlog::dbl::model_diagram as diagram;
-use catlog::dbl::model_morphism::DblModelMapping;
-use catlog::one::FgCategory;
+use catlog::one::{FgCategory, FgCategoryMap};
+use catlog::zero::MutMapping;
 use notebook_types::current::*;
 
 use super::model::{CanElaborate, CanQuote, Elaborator, Quoter};
@@ -142,7 +142,7 @@ impl DblModelDiagram {
                         name: "".into(),
                         id: x,
                         ob_type: Quoter.quote(&model.ob_generator_type(&x)),
-                        over: mapping.apply_ob(&x).map(|ob| Quoter.quote(&ob))
+                        over: mapping.ob_generator_map().get(&x).map(|ob| Quoter.quote(ob))
                     }
                 });
                 decls.collect()
@@ -161,7 +161,7 @@ impl DblModelDiagram {
                         name: "".into(),
                         id: f,
                         mor_type: Quoter.quote(&model.mor_generator_type(&f)),
-                        over: mapping.apply_basic_mor(&f).map(|mor| Quoter.quote(&mor)),
+                        over: mapping.mor_generator_map().get(&f).map(|mor| Quoter.quote(mor)),
                         dom: model.get_dom(&f).cloned().map(|ob| Quoter.quote(&ob)),
                         cod: model.get_cod(&f).cloned().map(|ob| Quoter.quote(&ob)),
                     }

--- a/packages/catlog-wasm/src/model_diagram.rs
+++ b/packages/catlog-wasm/src/model_diagram.rs
@@ -75,7 +75,7 @@ impl DblModelDiagram {
                     model.set_cod(decl.id, cod);
                 }
                 if let Some(over) = decl.over.as_ref().map(|mor| Elaborator.elab(mor)).transpose()? {
-                    mapping.assign_basic_mor(decl.id, over);
+                    mapping.assign_mor(decl.id, over);
                 }
                 Ok(())
             }

--- a/packages/catlog/src/dbl/model.rs
+++ b/packages/catlog/src/dbl/model.rs
@@ -342,15 +342,12 @@ where
     fn ob_generators(&self) -> impl Iterator<Item = Self::ObGen> {
         self.category.ob_generators()
     }
-
     fn mor_generators(&self) -> impl Iterator<Item = Self::MorGen> {
         self.category.mor_generators()
     }
-
     fn mor_generator_dom(&self, f: &Self::MorGen) -> Self::Ob {
         self.category.mor_generator_dom(f)
     }
-
     fn mor_generator_cod(&self, f: &Self::MorGen) -> Self::Ob {
         self.category.mor_generator_cod(f)
     }

--- a/packages/catlog/src/dbl/model.rs
+++ b/packages/catlog/src/dbl/model.rs
@@ -398,10 +398,10 @@ where
     Cat::Mor: Hash,
 {
     fn ob_generator_type(&self, ob: &Self::ObGen) -> Self::ObType {
-        self.ob_types.apply(ob).expect("Object should have type")
+        self.ob_types.get(ob).cloned().expect("Object should have type")
     }
     fn mor_generator_type(&self, mor: &Self::MorGen) -> Self::MorType {
-        self.mor_types.apply(mor).expect("Morphism should have type")
+        self.mor_types.get(mor).cloned().expect("Morphism should have type")
     }
 
     fn ob_generators_with_type(&self, typ: &Self::ObType) -> impl Iterator<Item = Self::ObGen> {
@@ -640,14 +640,18 @@ where
 
     fn src(&self, edge: &Self::E) -> Self::V {
         match edge {
-            TabEdge::Basic(e) => self.dom.apply(e).expect("Domain of morphism should be defined"),
+            TabEdge::Basic(e) => {
+                self.dom.get(e).cloned().expect("Domain of morphism should be defined")
+            }
             TabEdge::Square { dom, .. } => TabOb::Tabulated(dom.clone()),
         }
     }
 
     fn tgt(&self, edge: &Self::E) -> Self::V {
         match edge {
-            TabEdge::Basic(e) => self.cod.apply(e).expect("Codomain of morphism should be defined"),
+            TabEdge::Basic(e) => {
+                self.cod.get(e).cloned().expect("Codomain of morphism should be defined")
+            }
             TabEdge::Square { cod, .. } => TabOb::Tabulated(cod.clone()),
         }
     }
@@ -780,10 +784,10 @@ where
     }
 
     fn mor_generator_dom(&self, f: &Self::MorGen) -> Self::Ob {
-        self.generators.dom.apply(f).expect("Domain should be defined")
+        self.generators.dom.get(f).cloned().expect("Domain should be defined")
     }
     fn mor_generator_cod(&self, f: &Self::MorGen) -> Self::Ob {
-        self.generators.cod.apply(f).expect("Codomain should be defined")
+        self.generators.cod.get(f).cloned().expect("Codomain should be defined")
     }
 }
 
@@ -840,10 +844,10 @@ where
     S: BuildHasher,
 {
     fn ob_generator_type(&self, ob: &Self::ObGen) -> Self::ObType {
-        self.ob_types.apply(ob).expect("Object should have type")
+        self.ob_types.get(ob).cloned().expect("Object should have type")
     }
     fn mor_generator_type(&self, mor: &Self::MorGen) -> Self::MorType {
-        self.mor_types.apply(mor).expect("Morphism should have type")
+        self.mor_types.get(mor).cloned().expect("Morphism should have type")
     }
 
     fn ob_generators_with_type(&self, obtype: &Self::ObType) -> impl Iterator<Item = Self::ObGen> {

--- a/packages/catlog/src/dbl/model.rs
+++ b/packages/catlog/src/dbl/model.rs
@@ -152,29 +152,29 @@ pub trait FgDblModel: DblModel + FgCategory {
 
 /// A mutable, finitely generated model of a double theory.
 pub trait MutDblModel: FgDblModel {
-    /// Adds a basic object to the model.
+    /// Adds an object generator to the model.
     fn add_ob(&mut self, x: Self::ObGen, ob_type: Self::ObType);
 
-    /// Adds a basic morphism to the model.
+    /// Adds a morphism generator to the model.
     fn add_mor(&mut self, f: Self::MorGen, dom: Self::Ob, cod: Self::Ob, mor_type: Self::MorType) {
         self.make_mor(f.clone(), mor_type);
         self.set_dom(f.clone(), dom);
         self.set_cod(f, cod);
     }
 
-    /// Adds a basic morphism to the model without setting its (co)domain.
+    /// Adds a morphism generator to the model without setting its (co)domain.
     fn make_mor(&mut self, f: Self::MorGen, mor_type: Self::MorType);
 
-    /// Gets the domain of a basic morphism, if it is set.
+    /// Gets the domain of a morphism generator, if it is set.
     fn get_dom(&self, f: &Self::MorGen) -> Option<&Self::Ob>;
 
-    /// Gets the codomain of a basic morphism, if it is set.
+    /// Gets the codomain of a morphism generator, if it is set.
     fn get_cod(&self, f: &Self::MorGen) -> Option<&Self::Ob>;
 
-    /// Sets the domain of a basic morphism.
+    /// Sets the domain of a morphism generator.
     fn set_dom(&mut self, f: Self::MorGen, x: Self::Ob);
 
-    /// Sets the codomain of a basic morphism.
+    /// Sets the codomain of a morphism generator.
     fn set_cod(&mut self, f: Self::MorGen, x: Self::Ob);
 }
 
@@ -473,22 +473,22 @@ types on left and right hand sides.
 #[cfg_attr(feature = "serde-wasm", derive(Tsify))]
 #[cfg_attr(feature = "serde-wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum InvalidDblModel<Id> {
-    /// Domain of basic morphism is undefined or invalid.
+    /// Domain of morphism generator is undefined or invalid.
     Dom(Id),
 
-    /// Codomain of basic morphism is missing or invalid.
+    /// Codomain of morphism generator is missing or invalid.
     Cod(Id),
 
-    /// Basic object has invalid object type.
+    /// Object generator has invalid object type.
     ObType(Id),
 
-    /// Basic morphism has invalid morphism type.
+    /// Morphism generator has invalid morphism type.
     MorType(Id),
 
-    /// Domain of basic morphism has type incompatible with morphism type.
+    /// Domain of morphism generator has type incompatible with morphism type.
     DomType(Id),
 
-    /// Codomain of basic morphism has type incompatible with morphism type.
+    /// Codomain of morphism generator has type incompatible with morphism type.
     CodType(Id),
 
     /// Equation has left hand side that is not a well defined path.

--- a/packages/catlog/src/dbl/model.rs
+++ b/packages/catlog/src/dbl/model.rs
@@ -191,7 +191,7 @@ category"](https://ncatlab.org/nlab/show/displayed+category).
 pub struct DiscreteDblModel<Id, Cat: FgCategory> {
     #[derivative(PartialEq(compare_with = "Rc::ptr_eq"))]
     theory: Rc<DiscreteDblTheory<Cat>>,
-    category: FpCategory<Id, Id>,
+    pub(super) category: FpCategory<Id, Id>,
     ob_types: IndexedHashColumn<Id, Cat::Ob>,
     mor_types: IndexedHashColumn<Id, Cat::Mor>,
 }

--- a/packages/catlog/src/dbl/model_diagram.rs
+++ b/packages/catlog/src/dbl/model_diagram.rs
@@ -25,13 +25,13 @@ use serde::{Deserialize, Serialize};
 use tsify::{Tsify, declare};
 
 use super::{model::*, model_morphism::*};
-use crate::one::{Category, FgCategory};
+use crate::one::{Category, CategoryMap, FgCategory, FgCategoryMap};
 use crate::validate;
 
 /** A diagram in a model of a double theory.
 
 This struct owns its data, namely, the domain of the diagram (a model) and the
-model [mapping](DblModelMapping) itself.
+model mapping itself.
 */
 #[derive(Clone, Into)]
 #[into(owned, ref, ref_mut)]
@@ -39,15 +39,15 @@ pub struct DblModelDiagram<Map, Dom>(pub Map, pub Dom);
 
 impl<Map, Dom> DblModelDiagram<Map, Dom>
 where
-    Map: DblModelMapping,
+    Map: CategoryMap,
 {
     /// Gets an object indexed by the diagram.
-    pub fn ob(&self, i: &Map::DomOb) -> Map::CodOb {
+    pub fn ob(&self, i: Map::DomOb) -> Map::CodOb {
         self.0.apply_ob(i).expect("Diagram should be defined at object")
     }
 
     /// Gets a morphism indexed by the diagram.
-    pub fn mor(&self, h: &Map::DomMor) -> Map::CodMor {
+    pub fn mor(&self, h: Map::DomMor) -> Map::CodMor {
         self.0.apply_mor(h).expect("Diagram should be defined at morphism")
     }
 }
@@ -116,7 +116,7 @@ where
         let (mapping, domain) = self.into();
         domain.infer_missing();
         for e in domain.mor_generators() {
-            let Some(g) = mapping.apply_basic_mor(&e) else {
+            let Some(g) = mapping.apply_mor_generator(e.clone()) else {
                 continue;
             };
             if !model.has_mor(&g) {
@@ -156,8 +156,8 @@ mod tests {
         f.assign_basic_mor(ustr("attr"), Path::pair('p', 'q'));
 
         let diagram = DblModelDiagram(f, model);
-        assert_eq!(diagram.ob(&entity), 'x');
-        assert_eq!(diagram.mor(&Path::single(ustr("attr"))), Path::pair('p', 'q'));
+        assert_eq!(diagram.ob(entity), 'x');
+        assert_eq!(diagram.mor(Path::single(ustr("attr"))), Path::pair('p', 'q'));
     }
 
     #[test]

--- a/packages/catlog/src/dbl/model_diagram.rs
+++ b/packages/catlog/src/dbl/model_diagram.rs
@@ -153,7 +153,7 @@ mod tests {
         let mut f: DiscreteDblModelMapping<_, _> = Default::default();
         f.assign_ob(entity, 'x');
         f.assign_ob(ustr("type"), 'y');
-        f.assign_basic_mor(ustr("attr"), Path::pair('p', 'q'));
+        f.assign_mor(ustr("attr"), Path::pair('p', 'q'));
 
         let diagram = DblModelDiagram(f, model);
         assert_eq!(diagram.ob(entity), 'x');
@@ -168,7 +168,7 @@ mod tests {
 
         let mut f: DiscreteDblModelMapping<_, _> = Default::default();
         f.assign_ob(ustr("x"), ustr("x"));
-        f.assign_basic_mor(ustr("loop"), Path::pair(ustr("loop"), ustr("loop")));
+        f.assign_mor(ustr("loop"), Path::pair(ustr("loop"), ustr("loop")));
         let diagram = DblModelDiagram(f, pos_loop);
         assert!(diagram.validate_in(&neg_loop).is_ok());
     }
@@ -179,7 +179,7 @@ mod tests {
         let mut domain = DiscreteDblModel::new(th.clone());
         domain.add_mor('f', 'x', 'y', ustr("Attr").into());
         let mut f: DiscreteDblModelMapping<_, _> = Default::default();
-        f.assign_basic_mor('f', Path::single(ustr("attr")));
+        f.assign_mor('f', Path::single(ustr("attr")));
         let mut diagram = DblModelDiagram(f, domain);
 
         let model = walking_attr(th);

--- a/packages/catlog/src/dbl/model_morphism.rs
+++ b/packages/catlog/src/dbl/model_morphism.rs
@@ -34,7 +34,7 @@ use tsify::Tsify;
 use crate::one::graph_algorithms::{bounded_simple_paths, simple_paths, spec_order};
 use crate::one::*;
 use crate::validate::{self, Validate};
-use crate::zero::{Column, HashColumn, MutMapping};
+use crate::zero::{Column, HashColumn, Mapping, MutMapping};
 
 use super::model::*;
 

--- a/packages/catlog/src/dbl/model_morphism.rs
+++ b/packages/catlog/src/dbl/model_morphism.rs
@@ -129,27 +129,23 @@ where
         Self(ColumnarGraphMapping::new(HashColumn::new(ob_map), HashColumn::new(mor_map)))
     }
 
-    /// Assigns the mapping at an object, returning the previous assignment.
+    /// Assigns an object generator, returning the previous assignment.
     pub fn assign_ob(&mut self, x: DomId, y: CodId) -> Option<CodId> {
         self.0.vertex_map_mut().set(x, y)
     }
 
-    /// Assigns the mapping at a basic morphism, returning the previous assignment.
-    pub fn assign_basic_mor(
-        &mut self,
-        e: DomId,
-        n: Path<CodId, CodId>,
-    ) -> Option<Path<CodId, CodId>> {
+    /// Assigns a morphism generator, returning the previous assignment.
+    pub fn assign_mor(&mut self, e: DomId, n: Path<CodId, CodId>) -> Option<Path<CodId, CodId>> {
         self.0.edge_map_mut().set(e, n)
     }
 
-    /// Unassigns the mapping at an object, returning the previous assignment.
+    /// Unassigns an object generator, returning the previous assignment.
     pub fn unassign_ob(&mut self, x: &DomId) -> Option<CodId> {
         self.0.vertex_map_mut().unset(x)
     }
 
-    /// Unassigns the mapping a basic morphism, returning the previous assignment.
-    pub fn unassign_basic_mor(&mut self, e: &DomId) -> Option<Path<CodId, CodId>> {
+    /// Unassigns a morphism generator, returning the previous assignment.
+    pub fn unassign_mor(&mut self, e: &DomId) -> Option<Path<CodId, CodId>> {
         self.0.edge_map_mut().unset(e)
     }
 
@@ -536,7 +532,7 @@ where
             GraphElem::Edge(m) => {
                 if self.mor_init.is_set(&m) {
                     let path = self.mor_init.get(&m).cloned().unwrap();
-                    self.map.assign_basic_mor(m, path);
+                    self.map.assign_mor(m, path);
                     self.search(depth + 1);
                 } else {
                     let mor_type = self.dom.mor_generator_type(&m);
@@ -555,7 +551,7 @@ where
                         if th_cat.morphisms_are_equal(self.cod.mor_type(&path), mor_type.clone())
                             && !(self.faithful && path.is_empty())
                         {
-                            self.map.assign_basic_mor(m.clone(), path);
+                            self.map.assign_mor(m.clone(), path);
                             self.search(depth + 1);
                         }
                     }
@@ -601,8 +597,8 @@ mod tests {
         f.assign_ob('b', 'y');
         assert!(f.is_ob_assigned(&'a'));
         assert_eq!(f.apply_ob('b'), Some('y'));
-        f.assign_basic_mor('f', Path::pair('p', 'q'));
-        f.assign_basic_mor('g', Path::pair('r', 's'));
+        f.assign_mor('f', Path::pair('p', 'q'));
+        f.assign_mor('g', Path::pair('r', 's'));
         assert!(f.is_mor_assigned(&Path::single('f')));
         assert_eq!(f.apply_mor(Path::pair('f', 'g')), Path::from_vec(vec!['p', 'q', 'r', 's']));
     }

--- a/packages/catlog/src/dbl/model_morphism.rs
+++ b/packages/catlog/src/dbl/model_morphism.rs
@@ -18,12 +18,13 @@ oplax.
   Section 7: Lax transformations
  */
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use std::rc::Rc;
 
 use derivative::Derivative;
 use nonempty::NonEmpty;
+use ref_cast::RefCast;
 use thiserror::Error;
 
 #[cfg(feature = "serde")]
@@ -38,53 +39,82 @@ use crate::zero::{Column, HashColumn, Mapping, MutMapping};
 
 use super::model::*;
 
-/** A mapping between models of a double theory.
-
-Analogous to a mapping between [sets](crate::zero::Mapping) or
-[graphs](crate::one::GraphMapping), a model mapping is a morphism between models
-of a double theory without specified domain or codomain models.
- */
-pub trait DblModelMapping {
-    /// Type of objects in the domain model.
-    type DomOb: Eq + Clone;
-
-    /// Type of morphisms in the domain model.
-    type DomMor: Eq + Clone;
-
-    /// Type of objects in the codomain model.
-    type CodOb: Eq + Clone;
-
-    /// Type of morphisms in the codomain model.
-    type CodMor: Eq + Clone;
-
-    /// Applies the mapping to an object in the domain model.
-    fn apply_ob(&self, x: &Self::DomOb) -> Option<Self::CodOb>;
-
-    /// Applies the mapping to a morphism in the domain model.
-    fn apply_mor(&self, m: &Self::DomMor) -> Option<Self::CodMor>;
-
-    /// Is the mapping defined at an object?
-    fn is_ob_assigned(&self, x: &Self::DomOb) -> bool {
-        self.apply_ob(x).is_some()
-    }
-
-    /// Is the mapping defined at a morphism?
-    fn is_mor_assigned(&self, m: &Self::DomMor) -> bool {
-        self.apply_mor(m).is_some()
-    }
-}
-
 /** A mapping between models of a discrete double theory.
 
 Because a discrete double theory has only trivial operations, the naturality
-axioms for a model morphism also become trivial.
+axioms for a model morphism are also trivial.
  */
 #[derive(Clone, Debug, Derivative)]
 #[derivative(Default(bound = ""))]
 #[derivative(PartialEq(bound = "DomId: Eq + Hash, CodId: PartialEq"))]
-pub struct DiscreteDblModelMapping<DomId, CodId> {
-    ob_map: HashColumn<DomId, CodId>,
-    mor_map: HashColumn<DomId, Path<CodId, CodId>>,
+pub struct DiscreteDblModelMapping<DomId, CodId>(
+    ColumnarGraphMapping<HashColumn<DomId, CodId>, HashColumn<DomId, Path<CodId, CodId>>>,
+);
+
+/// Auxiliary struct for morphism map of [`DiscreteDblModelMapping`].
+#[derive(RefCast)]
+#[repr(transparent)]
+pub struct DiscreteDblModelMorMap<DomId, CodId>(DiscreteDblModelMapping<DomId, CodId>);
+
+impl<DomId, CodId> Mapping for DiscreteDblModelMorMap<DomId, CodId>
+where
+    DomId: Clone + Eq + Hash,
+    CodId: Clone + Eq + Hash,
+{
+    type Dom = Path<DomId, DomId>;
+    type Cod = Path<CodId, CodId>;
+
+    fn apply(&self, mor: Self::Dom) -> Option<Self::Cod> {
+        let graph_map = &self.0.0;
+        mor.partial_map(|v| graph_map.apply_vertex(v), |e| graph_map.apply_edge(e))
+            .map(|path| path.flatten())
+    }
+
+    fn is_set(&self, mor: &Self::Dom) -> bool {
+        let graph_map = &self.0.0;
+        match mor {
+            Path::Id(v) => graph_map.is_vertex_assigned(v),
+            Path::Seq(edges) => edges.iter().all(|e| graph_map.is_edge_assigned(e)),
+        }
+    }
+}
+
+impl<DomId, CodId> CategoryMap for DiscreteDblModelMapping<DomId, CodId>
+where
+    DomId: Clone + Eq + Hash,
+    CodId: Clone + Eq + Hash,
+{
+    type DomOb = DomId;
+    type DomMor = Path<DomId, DomId>;
+    type CodOb = CodId;
+    type CodMor = Path<CodId, CodId>;
+    type ObMap = HashColumn<DomId, CodId>;
+    type MorMap = DiscreteDblModelMorMap<DomId, CodId>;
+
+    fn ob_map(&self) -> &Self::ObMap {
+        self.0.vertex_map()
+    }
+    fn mor_map(&self) -> &Self::MorMap {
+        RefCast::ref_cast(self)
+    }
+}
+
+impl<DomId, CodId> FgCategoryMap for DiscreteDblModelMapping<DomId, CodId>
+where
+    DomId: Clone + Eq + Hash,
+    CodId: Clone + Eq + Hash,
+{
+    type ObGen = DomId;
+    type MorGen = DomId;
+    type ObGenMap = HashColumn<DomId, CodId>;
+    type MorGenMap = HashColumn<DomId, Path<CodId, CodId>>;
+
+    fn ob_generator_map(&self) -> &Self::ObGenMap {
+        self.0.vertex_map()
+    }
+    fn mor_generator_map(&self) -> &Self::MorGenMap {
+        self.0.edge_map()
+    }
 }
 
 impl<DomId, CodId> DiscreteDblModelMapping<DomId, CodId>
@@ -92,19 +122,14 @@ where
     DomId: Clone + Eq + Hash,
     CodId: Clone + Eq + Hash,
 {
-    /// Applies the mapping at a basic morphism in the domain model.
-    pub fn apply_basic_mor(&self, e: &DomId) -> Option<Path<CodId, CodId>> {
-        self.mor_map.get(e).cloned()
-    }
-
-    /// Is the mapping defined at a basic morphism?
-    pub fn is_basic_mor_assigned(&self, e: &DomId) -> bool {
-        self.mor_map.is_set(e)
+    /// Constructs a model mapping from a pair of hash maps.
+    pub fn new(ob_map: HashMap<DomId, CodId>, mor_map: HashMap<DomId, Path<CodId, CodId>>) -> Self {
+        Self(ColumnarGraphMapping::new(HashColumn::new(ob_map), HashColumn::new(mor_map)))
     }
 
     /// Assigns the mapping at an object, returning the previous assignment.
     pub fn assign_ob(&mut self, x: DomId, y: CodId) -> Option<CodId> {
-        self.ob_map.set(x, y)
+        self.0.vertex_map_mut().set(x, y)
     }
 
     /// Assigns the mapping at a basic morphism, returning the previous assignment.
@@ -113,17 +138,17 @@ where
         e: DomId,
         n: Path<CodId, CodId>,
     ) -> Option<Path<CodId, CodId>> {
-        self.mor_map.set(e, n)
+        self.0.edge_map_mut().set(e, n)
     }
 
     /// Unassigns the mapping at an object, returning the previous assignment.
     pub fn unassign_ob(&mut self, x: &DomId) -> Option<CodId> {
-        self.ob_map.unset(x)
+        self.0.vertex_map_mut().unset(x)
     }
 
     /// Unassigns the mapping a basic morphism, returning the previous assignment.
     pub fn unassign_basic_mor(&mut self, e: &DomId) -> Option<Path<CodId, CodId>> {
-        self.mor_map.unset(e)
+        self.0.edge_map_mut().unset(e)
     }
 
     /** Basic objects and morphisms in the image of the model morphism.
@@ -150,10 +175,10 @@ where
         assert!(cod.is_free(), "Codomain model should be free");
 
         let mut im = DiscreteDblModel::new(cod.theory_rc());
-        for x in self.ob_map.values() {
+        for x in self.ob_generator_map().values() {
             im.add_ob(x.clone(), cod.ob_type(x));
         }
-        for path in self.mor_map.values() {
+        for path in self.mor_generator_map().values() {
             for e in path.iter() {
                 let (x, y) = (cod.mor_generator_dom(e), cod.mor_generator_cod(e));
                 if !im.has_ob(&x) {
@@ -182,39 +207,7 @@ where
     }
 }
 
-impl<DomId, CodId> DblModelMapping for DiscreteDblModelMapping<DomId, CodId>
-where
-    DomId: Clone + Eq + Hash,
-    CodId: Clone + Eq + Hash,
-{
-    type DomOb = DomId;
-    type DomMor = Path<DomId, DomId>;
-    type CodOb = CodId;
-    type CodMor = Path<CodId, CodId>;
-
-    fn apply_ob(&self, x: &Self::DomOb) -> Option<Self::CodOb> {
-        self.ob_map.get(x).cloned()
-    }
-
-    fn apply_mor(&self, m: &Self::DomMor) -> Option<Self::CodMor> {
-        m.clone()
-            .partial_map(|x| self.apply_ob(&x), |e| self.apply_basic_mor(&e))
-            .map(|path| path.flatten())
-    }
-
-    fn is_ob_assigned(&self, x: &Self::DomOb) -> bool {
-        self.ob_map.is_set(x)
-    }
-
-    fn is_mor_assigned(&self, m: &Self::DomMor) -> bool {
-        match m {
-            Path::Id(x) => self.is_ob_assigned(x),
-            Path::Seq(edges) => edges.iter().all(|e| self.is_basic_mor_assigned(e)),
-        }
-    }
-}
-
-/** A functor between models of a double theory defined by a [mapping](DblModelMapping).
+/** A functor between models of a double theory.
 
 This struct borrows its data to perform validation. The domain and codomain are
 assumed to be valid models of double theories. If that is in question, the
@@ -249,10 +242,10 @@ where
         assert!(dom.is_free(), "Domain model should be free");
 
         let ob_errors = dom.ob_generators().filter_map(|v| {
-            if let Some(f_v) = mapping.apply_ob(&v) {
-                if !cod.has_ob(&f_v) {
+            if let Some(f_v) = mapping.ob_generator_map().get(&v) {
+                if !cod.has_ob(f_v) {
                     Some(InvalidDblModelMorphism::Ob(v))
-                } else if dom.ob_type(&v) != cod.ob_type(&f_v) {
+                } else if dom.ob_type(&v) != cod.ob_type(f_v) {
                     Some(InvalidDblModelMorphism::ObType(v))
                 } else {
                     None
@@ -264,21 +257,21 @@ where
 
         let th_cat = cod.theory().category();
         let mor_errors = dom.mor_generators().flat_map(move |f| {
-            if let Some(f_f) = mapping.apply_basic_mor(&f) {
-                if !cod.has_mor(&f_f) {
+            if let Some(f_f) = mapping.mor_generator_map().get(&f) {
+                if !cod.has_mor(f_f) {
                     vec![InvalidDblModelMorphism::Mor(f)]
                 } else {
-                    let dom_f = mapping.apply_ob(&dom.mor_generator_dom(&f));
-                    let cod_f = mapping.apply_ob(&dom.mor_generator_cod(&f));
+                    let dom_f = mapping.apply_ob(dom.mor_generator_dom(&f));
+                    let cod_f = mapping.apply_ob(dom.mor_generator_cod(&f));
 
                     let mut errs = Vec::new();
-                    if Some(cod.dom(&f_f)) != dom_f {
+                    if Some(cod.dom(f_f)) != dom_f {
                         errs.push(InvalidDblModelMorphism::Dom(f.clone()));
                     }
-                    if Some(cod.cod(&f_f)) != cod_f {
+                    if Some(cod.cod(f_f)) != cod_f {
                         errs.push(InvalidDblModelMorphism::Cod(f.clone()));
                     }
-                    if !th_cat.morphisms_are_equal(dom.mor_generator_type(&f), cod.mor_type(&f_f)) {
+                    if !th_cat.morphisms_are_equal(dom.mor_generator_type(&f), cod.mor_type(f_f)) {
                         errs.push(InvalidDblModelMorphism::MorType(f));
                     }
                     errs
@@ -295,7 +288,7 @@ where
     fn is_simple(&self) -> bool {
         let DblModelMorphism(mapping, dom, _) = *self;
         dom.mor_generators()
-            .all(|e| mapping.apply_basic_mor(&e).map(|p| p.is_simple()).unwrap_or(true))
+            .all(|e| mapping.apply_mor_generator(e).map(|p| p.is_simple()).unwrap_or(true))
     }
 
     /// Is the model morphism injective on objects?
@@ -303,7 +296,7 @@ where
         let DblModelMorphism(mapping, dom, _) = *self;
         let mut seen_obs: HashSet<_> = HashSet::new();
         for x in dom.ob_generators() {
-            if let Some(f_x) = mapping.apply_ob(&x) {
+            if let Some(f_x) = mapping.apply_ob_generator(x) {
                 if seen_obs.contains(&f_x) {
                     return false; // not monic
                 } else {
@@ -333,7 +326,7 @@ where
             for y in dom.ob_generators() {
                 let mut seen: HashSet<_> = HashSet::new();
                 for path in simple_paths(dom.generating_graph(), &x, &y) {
-                    if let Some(f_path) = mapping.apply_mor(&path) {
+                    if let Some(f_path) = mapping.apply_mor(path) {
                         if seen.contains(&f_path) {
                             return false; // not faithful
                         } else {
@@ -568,11 +561,11 @@ where
                     let mor_type = self.dom.mor_generator_type(&m);
                     let w = self
                         .map
-                        .apply_ob(&self.dom.mor_generator_dom(&m))
+                        .apply_ob(self.dom.mor_generator_dom(&m))
                         .expect("Domain should already be assigned");
                     let z = self
                         .map
-                        .apply_ob(&self.dom.mor_generator_cod(&m))
+                        .apply_ob(self.dom.mor_generator_cod(&m))
                         .expect("Codomain should already be assigned");
 
                     let cod_graph = self.cod.generating_graph();
@@ -612,7 +605,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
     use ustr::ustr;
 
     use super::*;
@@ -627,22 +619,22 @@ mod tests {
         f.assign_ob('a', 'x');
         f.assign_ob('b', 'y');
         assert!(f.is_ob_assigned(&'a'));
-        assert_eq!(f.apply_ob(&'b'), Some('y'));
+        assert_eq!(f.apply_ob('b'), Some('y'));
         f.assign_basic_mor('f', Path::pair('p', 'q'));
         f.assign_basic_mor('g', Path::pair('r', 's'));
         assert!(f.is_mor_assigned(&Path::single('f')));
-        assert_eq!(f.apply_mor(&Path::pair('f', 'g')), Path::from_vec(vec!['p', 'q', 'r', 's']));
+        assert_eq!(f.apply_mor(Path::pair('f', 'g')), Path::from_vec(vec!['p', 'q', 'r', 's']));
     }
 
     #[test]
     fn find_positive_loops() {
         let th = Rc::new(th_signed_category());
         let positive_loop = positive_loop(th.clone());
-        let pos = positive_loop.mor_generators().next().unwrap().into();
+        let pos: Path<_, _> = positive_loop.mor_generators().next().unwrap().into();
 
         let maps = DiscreteDblModelMapping::morphisms(&positive_loop, &positive_loop).find_all();
         assert_eq!(maps.len(), 2);
-        let mors: Vec<_> = maps.into_iter().map(|mor| mor.apply_mor(&pos)).collect();
+        let mors: Vec<_> = maps.into_iter().map(|mor| mor.apply_mor(pos.clone())).collect();
         assert!(mors.iter().any(|mor| matches!(mor, Some(Path::Id(_)))));
         assert!(mors.iter().any(|mor| matches!(mor, Some(Path::Seq(_)))));
 
@@ -650,7 +642,7 @@ mod tests {
             .monic()
             .find_all();
         assert_eq!(maps.len(), 1);
-        assert!(matches!(maps[0].apply_mor(&pos), Some(Path::Seq(_))));
+        assert!(matches!(maps[0].apply_mor(pos), Some(Path::Seq(_))));
     }
 
     /// The [simple path](crate::one::graph_algorithms::simple_paths) should
@@ -665,7 +657,6 @@ mod tests {
         walking.add_ob(a, ustr("Object"));
         walking.add_ob(b, ustr("Object"));
         walking.add_mor(ustr("f"), a, b, Path::Id(ustr("Object")));
-        let w = Path::single(ustr("f"));
 
         //     y         Graph with lots of cyclic paths.
         //   ↗  ↘
@@ -688,7 +679,7 @@ mod tests {
                     .initialize_ob(ustr("B"), j)
                     .find_all()
                     .into_iter()
-                    .map(|f| f.apply_mor(&w).unwrap())
+                    .map(|f| f.apply_mor_generator(ustr("f")).unwrap())
                     .collect();
                 let spaths: HashSet<_> = simple_paths(model.generating_graph(), &i, &j).collect();
                 assert_eq!(maps, spaths);
@@ -707,7 +698,7 @@ mod tests {
             .max_path_len(2)
             .find_all();
         assert_eq!(maps.len(), 2);
-        let obs: Vec<_> = maps.iter().map(|mor| mor.apply_ob(&base_pt)).collect();
+        let obs: Vec<_> = maps.iter().map(|mor| mor.apply_ob(base_pt)).collect();
         assert!(obs.contains(&Some(ustr("x"))));
         assert!(obs.contains(&Some(ustr("y"))));
 
@@ -728,20 +719,20 @@ mod tests {
         let negloop = negative_loop(theory.clone());
         let posfeed = positive_feedback(theory.clone());
 
-        let f = DiscreteDblModelMapping {
-            ob_map: HashMap::from([(ustr("x"), ustr("x"))]).into(),
-            mor_map: HashMap::from([(ustr(""), Path::Id(ustr("negative")))]).into(),
-        };
+        let f = DiscreteDblModelMapping::new(
+            [(ustr("x"), ustr("x"))].into(),
+            [(ustr(""), Path::Id(ustr("negative")))].into(),
+        );
         let dmm = DblModelMorphism(&f, &negloop, &negloop);
         assert!(dmm.validate().is_err());
 
         // A bad map from h to itself that is wrong for the ob (it is in the map
         // but sent to something that doesn't exist) and for the hom generator
         // (not in the map)
-        let f = DiscreteDblModelMapping {
-            ob_map: HashMap::from([(ustr("x"), ustr("y"))]).into(),
-            mor_map: HashMap::from([(ustr("y"), Path::Id(ustr("y")))]).into(),
-        };
+        let f = DiscreteDblModelMapping::new(
+            [(ustr("x"), ustr("y"))].into(),
+            [(ustr("y"), Path::Id(ustr("y")))].into(),
+        );
         let dmm = DblModelMorphism(&f, &negloop, &negloop);
         let errs: Vec<_> = dmm.validate().unwrap_err().into();
         assert!(
@@ -752,10 +743,10 @@ mod tests {
         );
 
         // A bad map that doesn't preserve dom
-        let f = DiscreteDblModelMapping {
-            ob_map: HashMap::from([(ustr("x"), ustr("x"))]).into(),
-            mor_map: HashMap::from([(ustr("loop"), Path::single(ustr("positive1")))]).into(),
-        };
+        let f = DiscreteDblModelMapping::new(
+            [(ustr("x"), ustr("x"))].into(),
+            [(ustr("loop"), Path::single(ustr("positive1")))].into(),
+        );
         let dmm = DblModelMorphism(&f, &negloop, &posfeed);
         let errs: Vec<_> = dmm.validate().unwrap_err().into();
         assert!(
@@ -766,10 +757,10 @@ mod tests {
         );
 
         // A bad map that doesn't preserve codom
-        let f = DiscreteDblModelMapping {
-            ob_map: HashMap::from([(ustr("x"), ustr("x"))]).into(),
-            mor_map: HashMap::from([(ustr("loop"), Path::single(ustr("positive2")))]).into(),
-        };
+        let f = DiscreteDblModelMapping::new(
+            [(ustr("x"), ustr("x"))].into(),
+            [(ustr("loop"), Path::single(ustr("positive2")))].into(),
+        );
         let dmm = DblModelMorphism(&f, &negloop, &posfeed);
         let errs: Vec<_> = dmm.validate().unwrap_err().into();
         assert!(
@@ -786,19 +777,19 @@ mod tests {
         let negloop = positive_loop(theory.clone());
 
         // Identity map
-        let f = DiscreteDblModelMapping {
-            ob_map: HashMap::from([(ustr("x"), ustr("x"))]).into(),
-            mor_map: HashMap::from([(ustr("loop"), Path::single(ustr("loop")))]).into(),
-        };
+        let f = DiscreteDblModelMapping::new(
+            [(ustr("x"), ustr("x"))].into(),
+            [(ustr("loop"), Path::single(ustr("loop")))].into(),
+        );
         let dmm = DblModelMorphism(&f, &negloop, &negloop);
         assert!(dmm.validate().is_ok());
         assert!(dmm.is_free_simple_monic());
 
         // Send generator to identity
-        let f = DiscreteDblModelMapping {
-            ob_map: HashMap::from([(ustr("x"), ustr("x"))]).into(),
-            mor_map: HashMap::from([(ustr("loop"), Path::Id(ustr("x")))]).into(),
-        };
+        let f = DiscreteDblModelMapping::new(
+            [(ustr("x"), ustr("x"))].into(),
+            [(ustr("loop"), Path::Id(ustr("x")))].into(),
+        );
         let dmm = DblModelMorphism(&f, &negloop, &negloop);
         assert!(dmm.validate().is_ok());
         assert!(!dmm.is_free_simple_monic());

--- a/packages/catlog/src/dbl/model_morphism.rs
+++ b/packages/catlog/src/dbl/model_morphism.rs
@@ -34,7 +34,7 @@ use tsify::Tsify;
 use crate::one::graph_algorithms::{bounded_simple_paths, simple_paths, spec_order};
 use crate::one::*;
 use crate::validate::{self, Validate};
-use crate::zero::{Column, HashColumn, Mapping, MutMapping};
+use crate::zero::{Column, HashColumn, MutMapping};
 
 use super::model::*;
 
@@ -94,7 +94,7 @@ where
 {
     /// Applies the mapping at a basic morphism in the domain model.
     pub fn apply_basic_mor(&self, e: &DomId) -> Option<Path<CodId, CodId>> {
-        self.mor_map.apply(e)
+        self.mor_map.get(e).cloned()
     }
 
     /// Is the mapping defined at a basic morphism?
@@ -193,7 +193,7 @@ where
     type CodMor = Path<CodId, CodId>;
 
     fn apply_ob(&self, x: &Self::DomOb) -> Option<Self::CodOb> {
-        self.ob_map.apply(x)
+        self.ob_map.get(x).cloned()
     }
 
     fn apply_mor(&self, m: &Self::DomMor) -> Option<Self::CodMor> {
@@ -543,7 +543,7 @@ where
         match var.clone() {
             GraphElem::Vertex(x) => {
                 if self.ob_init.is_set(&x) {
-                    let y = self.ob_init.apply(&x).unwrap();
+                    let y = self.ob_init.get(&x).cloned().unwrap();
                     let can_assign = self.assign_ob(x.clone(), y.clone());
                     if can_assign {
                         self.search(depth + 1);
@@ -561,7 +561,7 @@ where
             }
             GraphElem::Edge(m) => {
                 if self.mor_init.is_set(&m) {
-                    let path = self.mor_init.apply(&m).unwrap();
+                    let path = self.mor_init.get(&m).cloned().unwrap();
                     self.map.assign_basic_mor(m, path);
                     self.search(depth + 1);
                 } else {

--- a/packages/catlog/src/dbl/theory.rs
+++ b/packages/catlog/src/dbl/theory.rs
@@ -625,7 +625,7 @@ where
     fn src(&self, m: &Self::Pro) -> Self::Ob {
         match m {
             TabMorType::Basic(e) => {
-                self.src.apply(e).expect("Source of morphism type should be defined")
+                self.src.get(e).cloned().expect("Source of morphism type should be defined")
             }
             TabMorType::Hom(x) => (**x).clone(),
         }
@@ -633,7 +633,7 @@ where
     fn tgt(&self, m: &Self::Pro) -> Self::Ob {
         match m {
             TabMorType::Basic(e) => {
-                self.tgt.apply(e).expect("Target of morphism type should be defined")
+                self.tgt.get(e).cloned().expect("Target of morphism type should be defined")
             }
             TabMorType::Hom(x) => (**x).clone(),
         }
@@ -689,7 +689,7 @@ where
             (m, TabMorType::Hom(y)) if self.tgt(&m) == *y => m,
             (TabMorType::Hom(x), n) if self.src(&n) == *x => n,
             (TabMorType::Basic(d), TabMorType::Basic(e)) => {
-                self.compose_map.apply(&(d, e)).expect("Composition should be defined")
+                self.compose_map.apply((d, e)).expect("Composition should be defined")
             }
             _ => panic!("Ill-typed composite of morphism types in discrete tabulator theory"),
         };

--- a/packages/catlog/src/dbl/theory.rs
+++ b/packages/catlog/src/dbl/theory.rs
@@ -528,19 +528,19 @@ where
         }
     }
 
-    /// Adds a basic object type to the theory.
+    /// Adds a generating object type to the theory.
     pub fn add_ob_type(&mut self, v: V) -> bool {
         self.ob_types.insert(v)
     }
 
-    /// Adds a basic morphism type to the theory.
+    /// Adds a generating morphism type to the theory.
     pub fn add_mor_type(&mut self, e: E, src: TabObType<V, E>, tgt: TabObType<V, E>) -> bool {
         self.src.set(e.clone(), src);
         self.tgt.set(e.clone(), tgt);
         self.make_mor_type(e)
     }
 
-    /// Adds a basic morphim type without initializing its source or target.
+    /// Adds a generating morphim type without initializing its source/target.
     pub fn make_mor_type(&mut self, e: E) -> bool {
         self.mor_types.insert(e)
     }

--- a/packages/catlog/src/one/category.rs
+++ b/packages/catlog/src/one/category.rs
@@ -1,5 +1,4 @@
-/*! Categories: interfaces and basic constructions.
- */
+//! Categories: interfaces and basic constructions.
 
 use derive_more::From;
 use ref_cast::RefCast;

--- a/packages/catlog/src/one/fp_category.rs
+++ b/packages/catlog/src/one/fp_category.rs
@@ -660,6 +660,49 @@ impl Default for CategorySymbols {
 }
 
 #[cfg(test)]
+use ustr::ustr;
+
+/// The schema for graphs, an f.p. category.
+#[cfg(test)]
+pub fn sch_graph() -> UstrFpCategory {
+    let mut cat = UstrFpCategory::new();
+    let (v, e) = (ustr("V"), ustr("E"));
+    cat.add_ob_generators([v, e]);
+    cat.add_mor_generator(ustr("src"), e, v);
+    cat.add_mor_generator(ustr("tgt"), e, v);
+    cat
+}
+
+/// The schema for symmetric graphs, an f.p. category.
+#[cfg(test)]
+pub fn sch_sgraph() -> UstrFpCategory {
+    let mut cat = UstrFpCategory::new();
+    let (v, e) = (ustr("V"), ustr("E"));
+    let (s, t, i) = (ustr("src"), ustr("tgt"), ustr("inv"));
+    cat.add_ob_generators([v, e]);
+    cat.add_mor_generator(s, e, v);
+    cat.add_mor_generator(t, e, v);
+    cat.add_mor_generator(i, e, e);
+    cat.equate(Path::pair(i, i), Path::empty(e));
+    cat.equate(Path::pair(i, s), Path::single(t));
+    cat.equate(Path::pair(i, t), Path::single(s));
+    cat
+}
+
+/// The schema for half-edge graphs, an f.p. category.
+#[cfg(test)]
+pub fn sch_hgraph() -> UstrFpCategory {
+    let mut cat = UstrFpCategory::new();
+    let (v, h) = (ustr("V"), ustr("H"));
+    let (vert, inv) = (ustr("vert"), ustr("inv"));
+    cat.add_ob_generators([v, h]);
+    cat.add_mor_generator(vert, h, v);
+    cat.add_mor_generator(inv, h, h);
+    cat.equate(Path::pair(inv, inv), Path::empty(h));
+    cat
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use expect_test::expect;
@@ -667,23 +710,14 @@ mod tests {
     use ustr::ustr;
 
     #[test]
-    fn sch_sgraph() {
-        let mut sch_sgraph = UstrFpCategory::new();
-        let (v, e) = (ustr("V"), ustr("E"));
-        let (s, t, i) = (ustr("src"), ustr("tgt"), ustr("inv"));
-        sch_sgraph.add_ob_generators([v, e]);
-        sch_sgraph.add_mor_generator(s, e, v);
-        sch_sgraph.add_mor_generator(t, e, v);
-        sch_sgraph.add_mor_generator(i, e, e);
-        assert!(sch_sgraph.is_free());
-        sch_sgraph.equate(Path::pair(i, i), Path::empty(e));
-        sch_sgraph.equate(Path::pair(i, s), Path::single(t));
-        sch_sgraph.equate(Path::pair(i, t), Path::single(s));
+    fn sch_sgraph_equations() {
+        let sch_sgraph = sch_sgraph();
         assert!(!sch_sgraph.is_free());
         assert!(sch_sgraph.validate().is_ok());
 
+        let (s, t, i) = (ustr("src"), ustr("tgt"), ustr("inv"));
         assert!(!sch_sgraph.morphisms_are_equal(Path::single(s), Path::single(t)));
-        assert!(sch_sgraph.morphisms_are_equal(Path::pair(i, i), Path::empty(e)));
+        assert!(sch_sgraph.morphisms_are_equal(Path::pair(i, i), Path::empty(ustr("E"))));
         assert!(sch_sgraph.morphisms_are_equal(Path::Seq(nonempty![i, i, i, s]), Path::single(t)));
     }
 

--- a/packages/catlog/src/one/functor.rs
+++ b/packages/catlog/src/one/functor.rs
@@ -224,12 +224,12 @@ where
                     InvalidGraphMorphism::Src(e) => InvalidFpFunctor::Dom(e),
                     InvalidGraphMorphism::Tgt(e) => InvalidFpFunctor::Cod(e),
                 });
-        let equation_errors = dom.equations().enumerate().filter_map(|(i, eq)| {
+        let equation_errors = dom.equations().enumerate().filter_map(|(id, eq)| {
             if let (Some(lhs), Some(rhs)) =
                 (self.apply_mor(eq.lhs.clone()), self.apply_mor(eq.rhs.clone()))
                 && !self.cod.morphisms_are_equal(lhs, rhs)
             {
-                Some(InvalidFpFunctor::Eq(i))
+                Some(InvalidFpFunctor::Eq(id))
             } else {
                 None
             }
@@ -241,19 +241,19 @@ where
 /// A failure of a map out of an f.p. category to be functorial.
 #[derive(Debug, Error)]
 pub enum InvalidFpFunctor<V, E> {
-    /// A generating object not mapped to an object in the codomain category.
+    /// An object generator not mapped to an object in the codomain category.
     #[error("Object generator `{0}` is not mapped to an object in the codomain")]
     ObGen(V),
 
-    /// A generating morphism not mapped to a morphism in the codomain category.
+    /// A morphism generator not mapped to a morphism in the codomain category.
     #[error("Morphism generator `{0}` is not mapped to a morphism in the codomain")]
     MorGen(E),
 
-    /// A generating morphism whose domain is not preserved.
+    /// A morphism generator whose domain is not preserved.
     #[error("Domain of morphism generator `{0}` is not preserved")]
     Dom(E),
 
-    /// A generating morphism whose codomain is not preserved.
+    /// A morphism generator whose codomain is not preserved.
     #[error("Codomain of morphism generator `{0}` is not preserved")]
     Cod(E),
 

--- a/packages/catlog/src/one/functor.rs
+++ b/packages/catlog/src/one/functor.rs
@@ -1,0 +1,96 @@
+//! Functors between categories.
+
+use crate::zero::{Column, Mapping};
+
+/** A mapping between categories.
+
+Analogous to a [`Mapping`] between sets, this a functor that does not yet know
+its domain or codomain.
+ */
+pub trait CategoryMap {
+    /// Type of objects in domain category.
+    type DomOb: Eq + Clone;
+
+    /// Type of morphisms in domain category.
+    type DomMor: Eq + Clone;
+
+    /// Type of objects in codomain category.
+    type CodOb: Eq + Clone;
+
+    /// Type of morphisms in codomain category.
+    type CodMor: Eq + Clone;
+
+    /// Type of underlying mapping on objects.
+    type ObMap: Mapping<Dom = Self::DomOb, Cod = Self::CodOb>;
+
+    /// Type of underlying mapping on morphisms.
+    type MorMap: Mapping<Dom = Self::DomMor, Cod = Self::CodMor>;
+
+    /// Gets the underlying mapping on objects.
+    fn ob_map(&self) -> &Self::ObMap;
+
+    /// Gets the underlying mapping on morphisms.
+    fn mor_map(&self) -> &Self::MorMap;
+
+    /// Applies the mapping to an object.
+    fn apply_ob(&self, x: Self::DomOb) -> Option<Self::CodOb> {
+        self.ob_map().apply(x)
+    }
+
+    /// Applies the mapping to a morphism.
+    fn apply_mor(&self, m: Self::DomMor) -> Option<Self::CodMor> {
+        self.mor_map().apply(m)
+    }
+
+    /// Is the mapping defined at an object?
+    fn is_ob_assigned(&self, x: &Self::DomOb) -> bool {
+        self.ob_map().is_set(x)
+    }
+
+    /// Is the mapping defined at a morphism?
+    fn is_mor_assigned(&self, m: &Self::DomMor) -> bool {
+        self.mor_map().is_set(m)
+    }
+}
+
+/** A mapping out of a finitely generated category.
+
+Such a mapping is determined by its action on generating objects and morphisms.
+The codomain category is arbitrary.
+ */
+pub trait FgCategoryMap: CategoryMap {
+    /// Type of object generators in domain category.
+    type ObGen: Eq + Clone;
+
+    /// Type of morphism generators in domain category.
+    type MorGen: Eq + Clone;
+
+    /// Type of underlying mapping from object generators to objects.
+    type ObGenMap: Column<Dom = Self::ObGen, Cod = Self::CodOb>;
+
+    /// Type of underlying mapping from morphism generators to morphisms.
+    type MorGenMap: Column<Dom = Self::MorGen, Cod = Self::CodMor>;
+
+    /// Gets the underlying mapping from object generators to objects.
+    fn ob_generator_map(&self) -> &Self::ObGenMap;
+
+    /// Gets the underlying mapping from morphism generators to morphisms.
+    fn mor_generator_map(&self) -> &Self::MorGenMap;
+
+    /// Applies the mapping at a generating object.
+    fn apply_ob_generator(&self, x: Self::ObGen) -> Option<Self::CodOb> {
+        self.ob_generator_map().apply(x)
+    }
+
+    /// Applies the mapping at a generating morphism.
+    fn apply_mor_generator(&self, m: Self::MorGen) -> Option<Self::CodMor> {
+        self.mor_generator_map().apply(m)
+    }
+}
+
+/** A functor defined by a [category mapping](CategoryMap).
+
+Analogous to a [`Function`](crate::zero::Function) between sets, this struct
+exists to validate that a mapping between categories defines a valid functor.
+ */
+pub struct Functor<'a, Map, Dom, Cod>(pub &'a Map, pub &'a Dom, pub &'a Cod);

--- a/packages/catlog/src/one/functor.rs
+++ b/packages/catlog/src/one/functor.rs
@@ -13,8 +13,9 @@ use crate::zero::{Column, Mapping};
 
 /** A mapping between categories.
 
-Analogous to a [`Mapping`] between sets, this a functor that does not
-necessarily have a specified domain or codomain.
+Analogous to a mapping between [sets](crate::zero::Mapping) or
+[graphs](crate::one::GraphMapping), a category mapping is a functor without
+specified domain or codomain categories.
  */
 pub trait CategoryMap {
     /// Type of objects in domain category.
@@ -130,7 +131,7 @@ where
         self.map.vertex_map()
     }
     fn mor_map(&self) -> &Self::MorMap {
-        FpFunctorMorMap::ref_cast(self)
+        RefCast::ref_cast(self)
     }
 }
 

--- a/packages/catlog/src/one/graph.rs
+++ b/packages/catlog/src/one/graph.rs
@@ -644,7 +644,7 @@ pub struct ColumnarGraphMapping<VMap, EMap> {
 }
 
 impl<VMap, EMap> ColumnarGraphMapping<VMap, EMap> {
-    /// Constructs a new graph mapping from existing columns.
+    /// Constructs a graph mapping from given vertex and edge mappings.
     pub fn new(vertex_map: VMap, edge_map: EMap) -> Self {
         Self {
             vertex_map,
@@ -670,6 +670,16 @@ where
     }
     fn edge_map(&self) -> &Self::EdgeMap {
         &self.edge_map
+    }
+}
+
+/// A graph mapping between skeletal finite graphs, backed by vectors.
+pub type SkelGraphMapping = ColumnarGraphMapping<VecColumn<usize>, VecColumn<usize>>;
+
+impl SkelGraphMapping {
+    /// Constructs a graph mapping from a pair of vectors.
+    pub fn from_vec(vertex_map: Vec<usize>, edge_map: Vec<usize>) -> Self {
+        Self::new(VecColumn::new(vertex_map), VecColumn::new(edge_map))
     }
 }
 
@@ -733,12 +743,10 @@ mod tests {
     fn validate_graph_morphism() {
         let g = SkelGraph::path(3);
         let h = SkelGraph::path(4);
-        let f =
-            ColumnarGraphMapping::new(VecColumn::new(vec![1, 2, 3]), VecColumn::new(vec![1, 2]));
+        let f = SkelGraphMapping::from_vec(vec![1, 2, 3], vec![1, 2]);
         assert!(GraphMorphism(&f, &g, &h).validate().is_ok());
 
-        let f =
-            ColumnarGraphMapping::new(VecColumn::new(vec![1, 2, 3]), VecColumn::new(vec![2, 1])); // Not a homomorphism.
+        let f = SkelGraphMapping::from_vec(vec![1, 2, 3], vec![2, 1]); // Not a homomorphism.
         assert!(GraphMorphism(&f, &g, &h).validate().is_err());
     }
 }

--- a/packages/catlog/src/one/graph.rs
+++ b/packages/catlog/src/one/graph.rs
@@ -641,10 +641,10 @@ where
     type CodE = ColE::Cod;
 
     fn apply_vertex(&self, v: &Self::DomV) -> Option<Self::CodV> {
-        self.vertex_map.apply(v)
+        self.vertex_map.get(v).cloned()
     }
     fn apply_edge(&self, e: &Self::DomE) -> Option<Self::CodE> {
-        self.edge_map.apply(e)
+        self.edge_map.get(e).cloned()
     }
     fn is_vertex_assigned(&self, v: &Self::DomV) -> bool {
         self.vertex_map.is_set(v)

--- a/packages/catlog/src/one/graph.rs
+++ b/packages/catlog/src/one/graph.rs
@@ -638,14 +638,14 @@ That is, the data of the graph mapping is defined by two columns. The mapping
 can be between arbitrary graphs with compatible vertex and edge types.
 */
 #[derive(Clone, Default)]
-pub struct ColumnarGraphMapping<ColV, ColE> {
-    vertex_map: ColV,
-    edge_map: ColE,
+pub struct ColumnarGraphMapping<VMap, EMap> {
+    vertex_map: VMap,
+    edge_map: EMap,
 }
 
-impl<ColV, ColE> ColumnarGraphMapping<ColV, ColE> {
+impl<VMap, EMap> ColumnarGraphMapping<VMap, EMap> {
     /// Constructs a new graph mapping from existing columns.
-    pub fn new(vertex_map: ColV, edge_map: ColE) -> Self {
+    pub fn new(vertex_map: VMap, edge_map: EMap) -> Self {
         Self {
             vertex_map,
             edge_map,
@@ -653,17 +653,17 @@ impl<ColV, ColE> ColumnarGraphMapping<ColV, ColE> {
     }
 }
 
-impl<ColV, ColE> GraphMapping for ColumnarGraphMapping<ColV, ColE>
+impl<VMap, EMap> GraphMapping for ColumnarGraphMapping<VMap, EMap>
 where
-    ColV: Mapping,
-    ColE: Mapping,
+    VMap: Mapping,
+    EMap: Mapping,
 {
-    type DomV = ColV::Dom;
-    type DomE = ColE::Dom;
-    type CodV = ColV::Cod;
-    type CodE = ColE::Cod;
-    type VertexMap = ColV;
-    type EdgeMap = ColE;
+    type DomV = VMap::Dom;
+    type DomE = EMap::Dom;
+    type CodV = VMap::Cod;
+    type CodE = EMap::Cod;
+    type VertexMap = VMap;
+    type EdgeMap = EMap;
 
     fn vertex_map(&self) -> &Self::VertexMap {
         &self.vertex_map

--- a/packages/catlog/src/one/graph.rs
+++ b/packages/catlog/src/one/graph.rs
@@ -637,7 +637,7 @@ pub enum InvalidGraphMorphism<V, E> {
 That is, the data of the graph mapping is defined by two columns. The mapping
 can be between arbitrary graphs with compatible vertex and edge types.
 */
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ColumnarGraphMapping<VMap, EMap> {
     vertex_map: VMap,
     edge_map: EMap,
@@ -650,6 +650,16 @@ impl<VMap, EMap> ColumnarGraphMapping<VMap, EMap> {
             vertex_map,
             edge_map,
         }
+    }
+
+    /// Gets a mutable reference to the vertex mapping.
+    pub fn vertex_map_mut(&mut self) -> &mut VMap {
+        &mut self.vertex_map
+    }
+
+    /// Gets a mutable reference to the edge mapping.
+    pub fn edge_map_mut(&mut self) -> &mut EMap {
+        &mut self.edge_map
     }
 }
 

--- a/packages/catlog/src/one/mod.rs
+++ b/packages/catlog/src/one/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod category;
 pub mod fp_category;
+pub mod functor;
 pub mod graph;
 pub mod graph_algorithms;
 pub mod path;
@@ -9,5 +10,6 @@ pub mod tree;
 pub mod tree_algorithms;
 
 pub use self::category::*;
+pub use self::functor::*;
 pub use self::graph::*;
 pub use self::path::*;

--- a/packages/catlog/src/one/mod.rs
+++ b/packages/catlog/src/one/mod.rs
@@ -10,6 +10,7 @@ pub mod tree;
 pub mod tree_algorithms;
 
 pub use self::category::*;
+pub use self::fp_category::*;
 pub use self::functor::*;
 pub use self::graph::*;
 pub use self::path::*;

--- a/packages/catlog/src/refs.rs
+++ b/packages/catlog/src/refs.rs
@@ -31,13 +31,21 @@ Evan Patterson, 2024: Products in double categories, revisited.
  */
 pub const DblProducts: () = ();
 
+/** Reference: Yoneda theory for double categories.
+
+Paré, 2011: Yoneda theory for double categories.
+
+- [TAC](http://www.tac.mta.ca/tac/volumes/25/17/25-17abs.html)
+ */
+pub const DblYonedaTheory: () = ();
+
 /** Reference: A unified framework for generalized multicategories.
 
 G.S.H. Cruttwell & Michael Shulman, 2010: A unified framework for generalized
 multicategories.
 
 - [arXiv:0907.2460](https://arxiv.org/abs/0907.2460)
-- [TAC](http://www.tac.mta.ca/tac/volumes/24/21/24-21.pdf)
+- [TAC](http://www.tac.mta.ca/tac/volumes/24/21/24-21abs.html)
  */
 pub const GeneralizedMulticategories: () = ();
 

--- a/packages/catlog/src/zero/column.rs
+++ b/packages/catlog/src/zero/column.rs
@@ -32,6 +32,9 @@ pub trait Mapping {
 
     /// Applies the mapping at a point possibly in the domain.
     fn apply(&self, x: Self::Dom) -> Option<Self::Cod>;
+
+    /// Is the mapping defined at a point?
+    fn is_set(&self, x: &Self::Dom) -> bool;
 }
 
 /** A mutable [mapping](Mapping).
@@ -68,11 +71,6 @@ pub trait MutMapping: Mapping {
             Some(y) => self.set(x, y),
             None => self.unset(&x),
         }
-    }
-
-    /// Is the mapping defined at a point?
-    fn is_set(&self, x: &Self::Dom) -> bool {
-        self.get(x).is_some()
     }
 }
 
@@ -192,6 +190,10 @@ impl<T: Eq + Clone> Mapping for VecColumn<T> {
     fn apply(&self, i: usize) -> Option<T> {
         self.0.get(i).cloned().flatten()
     }
+
+    fn is_set(&self, i: &usize) -> bool {
+        *i < self.0.len() && self.0[*i].is_some()
+    }
 }
 
 impl<T: Eq + Clone> MutMapping for VecColumn<T> {
@@ -216,10 +218,6 @@ impl<T: Eq + Clone> MutMapping for VecColumn<T> {
         } else {
             None
         }
-    }
-
-    fn is_set(&self, i: &usize) -> bool {
-        *i < self.0.len() && self.0[*i].is_some()
     }
 }
 
@@ -261,6 +259,9 @@ where
     fn apply(&self, x: K) -> Option<V> {
         self.0.get(&x).cloned()
     }
+    fn is_set(&self, x: &K) -> bool {
+        self.0.contains_key(x)
+    }
 }
 
 impl<K, V, S> MutMapping for HashColumn<K, V, S>
@@ -277,9 +278,6 @@ where
     }
     fn unset(&mut self, x: &K) -> Option<V> {
         self.0.remove(x)
-    }
-    fn is_set(&self, x: &K) -> bool {
-        self.0.contains_key(x)
     }
 }
 
@@ -441,6 +439,9 @@ where
     fn apply(&self, x: Dom) -> Option<Cod> {
         self.mapping.apply(x)
     }
+    fn is_set(&self, x: &Dom) -> bool {
+        self.mapping.is_set(x)
+    }
 }
 
 impl<Dom, Cod, Col, Ind> MutMapping for IndexedColumn<Dom, Cod, Col, Ind>
@@ -467,10 +468,6 @@ where
             self.index.remove(x, y);
         }
         old
-    }
-
-    fn is_set(&self, x: &Dom) -> bool {
-        self.mapping.is_set(x)
     }
 }
 
@@ -521,6 +518,9 @@ impl Mapping for SkelIndexedColumn {
     fn apply(&self, x: usize) -> Option<usize> {
         self.0.apply(x)
     }
+    fn is_set(&self, x: &usize) -> bool {
+        self.0.is_set(x)
+    }
 }
 
 impl MutMapping for SkelIndexedColumn {
@@ -532,9 +532,6 @@ impl MutMapping for SkelIndexedColumn {
     }
     fn unset(&mut self, x: &usize) -> Option<usize> {
         self.0.unset(x)
-    }
-    fn is_set(&self, x: &usize) -> bool {
-        self.0.is_set(x)
     }
 }
 
@@ -579,6 +576,9 @@ impl<T: Eq + Hash + Clone> Mapping for IndexedVecColumn<T> {
     fn apply(&self, x: usize) -> Option<T> {
         self.0.apply(x)
     }
+    fn is_set(&self, x: &usize) -> bool {
+        self.0.is_set(x)
+    }
 }
 
 impl<T: Eq + Hash + Clone> MutMapping for IndexedVecColumn<T> {
@@ -590,9 +590,6 @@ impl<T: Eq + Hash + Clone> MutMapping for IndexedVecColumn<T> {
     }
     fn unset(&mut self, x: &usize) -> Option<T> {
         self.0.unset(x)
-    }
-    fn is_set(&self, x: &usize) -> bool {
-        self.0.is_set(x)
     }
 }
 
@@ -636,6 +633,9 @@ where
     fn apply(&self, x: K) -> Option<V> {
         self.0.apply(x)
     }
+    fn is_set(&self, x: &K) -> bool {
+        self.0.is_set(x)
+    }
 }
 
 impl<K, V, S> MutMapping for IndexedHashColumn<K, V, S>
@@ -652,9 +652,6 @@ where
     }
     fn unset(&mut self, x: &K) -> Option<V> {
         self.0.unset(x)
-    }
-    fn is_set(&self, x: &K) -> bool {
-        self.0.is_set(x)
     }
 }
 

--- a/packages/catlog/src/zero/column.rs
+++ b/packages/catlog/src/zero/column.rs
@@ -247,6 +247,13 @@ pub struct HashColumn<K, V, S = RandomState>(HashMap<K, V, S>);
 /// An unindexed column with keys of type `Ustr`.
 pub type UstrColumn<V> = HashColumn<Ustr, V, BuildHasherDefault<IdentityHasher>>;
 
+impl<K, V, S> HashColumn<K, V, S> {
+    /// Creates a new hash column from an existing hash map.
+    pub fn new(map: HashMap<K, V, S>) -> Self {
+        Self(map)
+    }
+}
+
 impl<K, V, S> Mapping for HashColumn<K, V, S>
 where
     K: Eq + Hash + Clone,


### PR DESCRIPTION
First steps toward model migration for discrete double theories in the core:

- Traits for mappings between categories and out of f.g. categories ("functors without (co)domains")
- Data structure for functors out of f.p. categories with validation
- Re-use of f.p. functor validation for morphisms b/w models of discrete double theories

The tests show that when validating functorality, we take advantage of egglog to check path equations.