### PR TITLE
Pushforward migration of models of discrete double theories

### DIFF
--- a/packages/catlog-wasm/src/model_diagram.rs
+++ b/packages/catlog-wasm/src/model_diagram.rs
@@ -10,7 +10,7 @@ use wasm_bindgen::prelude::*;
 
 use catlog::dbl::model::{FgDblModel, MutDblModel};
 use catlog::dbl::model_diagram as diagram;
-use catlog::one::{FgCategory, FgCategoryMap};
+use catlog::one::FgCategory;
 use catlog::zero::MutMapping;
 use notebook_types::current::*;
 
@@ -142,7 +142,7 @@ impl DblModelDiagram {
                         name: "".into(),
                         id: x,
                         ob_type: Quoter.quote(&model.ob_generator_type(&x)),
-                        over: mapping.ob_generator_map().get(&x).map(|ob| Quoter.quote(ob))
+                        over: mapping.0.ob_generator_map().get(&x).map(|ob| Quoter.quote(ob))
                     }
                 });
                 decls.collect()
@@ -161,7 +161,7 @@ impl DblModelDiagram {
                         name: "".into(),
                         id: f,
                         mor_type: Quoter.quote(&model.mor_generator_type(&f)),
-                        over: mapping.mor_generator_map().get(&f).map(|mor| Quoter.quote(mor)),
+                        over: mapping.0.mor_generator_map().get(&f).map(|mor| Quoter.quote(mor)),
                         dom: model.get_dom(&f).cloned().map(|ob| Quoter.quote(&ob)),
                         cod: model.get_cod(&f).cloned().map(|ob| Quoter.quote(&ob)),
                     }

--- a/packages/catlog-wasm/src/model_diagram.rs
+++ b/packages/catlog-wasm/src/model_diagram.rs
@@ -142,7 +142,7 @@ impl DblModelDiagram {
                         name: "".into(),
                         id: x,
                         ob_type: Quoter.quote(&model.ob_generator_type(&x)),
-                        over: mapping.0.ob_generator_map().get(&x).map(|ob| Quoter.quote(ob))
+                        over: mapping.0.ob_generator_map.get(&x).map(|ob| Quoter.quote(ob))
                     }
                 });
                 decls.collect()
@@ -161,7 +161,7 @@ impl DblModelDiagram {
                         name: "".into(),
                         id: f,
                         mor_type: Quoter.quote(&model.mor_generator_type(&f)),
-                        over: mapping.0.mor_generator_map().get(&f).map(|mor| Quoter.quote(mor)),
+                        over: mapping.0.mor_generator_map.get(&f).map(|mor| Quoter.quote(mor)),
                         dom: model.get_dom(&f).cloned().map(|ob| Quoter.quote(&ob)),
                         cod: model.get_cod(&f).cloned().map(|ob| Quoter.quote(&ob)),
                     }

--- a/packages/catlog/src/dbl/model.rs
+++ b/packages/catlog/src/dbl/model.rs
@@ -395,10 +395,10 @@ where
     Cat::Mor: Hash,
 {
     fn ob_generator_type(&self, ob: &Self::ObGen) -> Self::ObType {
-        self.ob_types.get(ob).cloned().expect("Object should have type")
+        self.ob_types.apply_to_ref(ob).expect("Object should have type")
     }
     fn mor_generator_type(&self, mor: &Self::MorGen) -> Self::MorType {
-        self.mor_types.get(mor).cloned().expect("Morphism should have type")
+        self.mor_types.apply_to_ref(mor).expect("Morphism should have type")
     }
 
     fn ob_generators_with_type(&self, typ: &Self::ObType) -> impl Iterator<Item = Self::ObGen> {
@@ -638,7 +638,7 @@ where
     fn src(&self, edge: &Self::E) -> Self::V {
         match edge {
             TabEdge::Basic(e) => {
-                self.dom.get(e).cloned().expect("Domain of morphism should be defined")
+                self.dom.apply_to_ref(e).expect("Domain of morphism should be defined")
             }
             TabEdge::Square { dom, .. } => TabOb::Tabulated(dom.clone()),
         }
@@ -647,7 +647,7 @@ where
     fn tgt(&self, edge: &Self::E) -> Self::V {
         match edge {
             TabEdge::Basic(e) => {
-                self.cod.get(e).cloned().expect("Codomain of morphism should be defined")
+                self.cod.apply_to_ref(e).expect("Codomain of morphism should be defined")
             }
             TabEdge::Square { cod, .. } => TabOb::Tabulated(cod.clone()),
         }
@@ -781,10 +781,10 @@ where
     }
 
     fn mor_generator_dom(&self, f: &Self::MorGen) -> Self::Ob {
-        self.generators.dom.get(f).cloned().expect("Domain should be defined")
+        self.generators.dom.apply_to_ref(f).expect("Domain should be defined")
     }
     fn mor_generator_cod(&self, f: &Self::MorGen) -> Self::Ob {
-        self.generators.cod.get(f).cloned().expect("Codomain should be defined")
+        self.generators.cod.apply_to_ref(f).expect("Codomain should be defined")
     }
 }
 
@@ -841,10 +841,10 @@ where
     S: BuildHasher,
 {
     fn ob_generator_type(&self, ob: &Self::ObGen) -> Self::ObType {
-        self.ob_types.get(ob).cloned().expect("Object should have type")
+        self.ob_types.apply_to_ref(ob).expect("Object should have type")
     }
     fn mor_generator_type(&self, mor: &Self::MorGen) -> Self::MorType {
-        self.mor_types.get(mor).cloned().expect("Morphism should have type")
+        self.mor_types.apply_to_ref(mor).expect("Morphism should have type")
     }
 
     fn ob_generators_with_type(&self, obtype: &Self::ObType) -> impl Iterator<Item = Self::ObGen> {

--- a/packages/catlog/src/dbl/model_diagram.rs
+++ b/packages/catlog/src/dbl/model_diagram.rs
@@ -27,6 +27,7 @@ use tsify::{Tsify, declare};
 use super::{model::*, model_morphism::*};
 use crate::one::{Category, FgCategory, GraphMapping};
 use crate::validate;
+use crate::zero::Mapping;
 
 /** A diagram in a model of a double theory.
 
@@ -101,7 +102,7 @@ where
         let (mapping, domain) = self.into();
         domain.infer_missing();
         for e in domain.mor_generators() {
-            let Some(g) = mapping.0.apply_edge(e.clone()) else {
+            let Some(g) = mapping.0.edge_map().apply_to_ref(&e) else {
                 continue;
             };
             if !model.has_mor(&g) {

--- a/packages/catlog/src/dbl/model_morphism.rs
+++ b/packages/catlog/src/dbl/model_morphism.rs
@@ -26,7 +26,6 @@ use std::rc::Rc;
 
 use derivative::Derivative;
 use nonempty::NonEmpty;
-use ref_cast::RefCast;
 use thiserror::Error;
 
 #[cfg(feature = "serde")]
@@ -50,74 +49,8 @@ axioms for a model morphism are also trivial.
 #[derivative(Default(bound = ""))]
 #[derivative(PartialEq(bound = "DomId: Eq + Hash, CodId: PartialEq"))]
 pub struct DiscreteDblModelMapping<DomId, CodId>(
-    FpFunctorData<HashColumn<DomId, CodId>, HashColumn<DomId, Path<CodId, CodId>>>,
+    pub FpFunctorData<HashColumn<DomId, CodId>, HashColumn<DomId, Path<CodId, CodId>>>,
 );
-
-/// Auxiliary struct for morphism map of [`DiscreteDblModelMapping`].
-#[derive(RefCast)]
-#[repr(transparent)]
-pub struct DiscreteDblModelMorMap<DomId, CodId>(DiscreteDblModelMapping<DomId, CodId>);
-
-impl<DomId, CodId> Mapping for DiscreteDblModelMorMap<DomId, CodId>
-where
-    DomId: Clone + Eq + Hash,
-    CodId: Clone + Eq + Hash,
-{
-    type Dom = Path<DomId, DomId>;
-    type Cod = Path<CodId, CodId>;
-
-    fn apply(&self, mor: Self::Dom) -> Option<Self::Cod> {
-        let graph_map = &self.0.0;
-        mor.partial_map(|v| graph_map.apply_vertex(v), |e| graph_map.apply_edge(e))
-            .map(|path| path.flatten())
-    }
-
-    fn is_set(&self, mor: &Self::Dom) -> bool {
-        let graph_map = &self.0.0;
-        match mor {
-            Path::Id(v) => graph_map.is_vertex_assigned(v),
-            Path::Seq(edges) => edges.iter().all(|e| graph_map.is_edge_assigned(e)),
-        }
-    }
-}
-
-impl<DomId, CodId> CategoryMap for DiscreteDblModelMapping<DomId, CodId>
-where
-    DomId: Clone + Eq + Hash,
-    CodId: Clone + Eq + Hash,
-{
-    type DomOb = DomId;
-    type DomMor = Path<DomId, DomId>;
-    type CodOb = CodId;
-    type CodMor = Path<CodId, CodId>;
-    type ObMap = HashColumn<DomId, CodId>;
-    type MorMap = DiscreteDblModelMorMap<DomId, CodId>;
-
-    fn ob_map(&self) -> &Self::ObMap {
-        self.0.ob_generator_map()
-    }
-    fn mor_map(&self) -> &Self::MorMap {
-        RefCast::ref_cast(self)
-    }
-}
-
-impl<DomId, CodId> FgCategoryMap for DiscreteDblModelMapping<DomId, CodId>
-where
-    DomId: Clone + Eq + Hash,
-    CodId: Clone + Eq + Hash,
-{
-    type ObGen = DomId;
-    type MorGen = DomId;
-    type ObGenMap = HashColumn<DomId, CodId>;
-    type MorGenMap = HashColumn<DomId, Path<CodId, CodId>>;
-
-    fn ob_generator_map(&self) -> &Self::ObGenMap {
-        self.0.ob_generator_map()
-    }
-    fn mor_generator_map(&self) -> &Self::MorGenMap {
-        self.0.mor_generator_map()
-    }
-}
 
 impl<DomId, CodId> DiscreteDblModelMapping<DomId, CodId>
 where
@@ -149,6 +82,21 @@ where
         self.0.mor_generator_map_mut().unset(e)
     }
 
+    /// Interprets the data as a functor into the given model.
+    pub fn functor_into<'a, Cat: FgCategory>(
+        &'a self,
+        cod: &'a DiscreteDblModel<CodId, Cat>,
+    ) -> impl FgCategoryMap<
+        DomOb = DomId,
+        DomMor = Path<DomId, DomId>,
+        CodOb = CodId,
+        CodMor = Path<CodId, CodId>,
+        ObGen = DomId,
+        MorGen = DomId,
+    > {
+        self.0.functor_into(&cod.category)
+    }
+
     /** Basic objects and morphisms in the image of the model morphism.
 
     Note this method does not compute the set-theoretic image of the model
@@ -159,12 +107,11 @@ where
     comprising all *basic* objects and morphisms appearing in the image of the
     model morphism, possibly inside composites.
      */
-    pub fn syntactic_image<Cat>(
+    pub fn syntactic_image<Cat: FgCategory>(
         &self,
         cod: &DiscreteDblModel<CodId, Cat>,
     ) -> DiscreteDblModel<CodId, Cat>
     where
-        Cat: FgCategory,
         Cat::Ob: Hash,
         Cat::Mor: Hash,
     {
@@ -173,10 +120,10 @@ where
         assert!(cod.is_free(), "Codomain model should be free");
 
         let mut im = DiscreteDblModel::new(cod.theory_rc());
-        for x in self.ob_generator_map().values() {
+        for x in self.0.ob_generator_map().values() {
             im.add_ob(x.clone(), cod.ob_type(x));
         }
-        for path in self.mor_generator_map().values() {
+        for path in self.0.mor_generator_map().values() {
             for e in path.iter() {
                 let (x, y) = (cod.mor_generator_dom(e), cod.mor_generator_cod(e));
                 if !im.has_ob(&x) {
@@ -192,12 +139,11 @@ where
     }
 
     /// Finder of morphisms between two models of a discrete double theory.
-    pub fn morphisms<'a, Cat>(
+    pub fn morphisms<'a, Cat: FgCategory>(
         dom: &'a DiscreteDblModel<DomId, Cat>,
         cod: &'a DiscreteDblModel<CodId, Cat>,
     ) -> DiscreteDblModelMorphismFinder<'a, DomId, CodId, Cat>
     where
-        Cat: FgCategory,
         Cat::Ob: Hash,
         Cat::Mor: Hash,
     {
@@ -234,8 +180,9 @@ where
         &self,
     ) -> impl Iterator<Item = InvalidDblModelMorphism<DomId, DomId>> + 'a + use<'a, DomId, CodId, Cat>
     {
-        let DblModelMorphism(mapping, dom, cod) = *self;
-        let category_errors: Vec<_> = FpFunctor::new(&mapping.0, &cod.category)
+        let DblModelMorphism(DiscreteDblModelMapping(mapping), dom, cod) = *self;
+        let category_errors: Vec<_> = mapping
+            .functor_into(&cod.category)
             .iter_invalid_on(&dom.category)
             .map(|err| match err {
                 InvalidFpFunctor::ObGen(x) => InvalidDblModelMorphism::Ob(x),
@@ -272,17 +219,17 @@ where
     /// Are morphism generators sent to simple composites of morphisms in the
     /// codomain?
     fn is_simple(&self) -> bool {
-        let DblModelMorphism(mapping, dom, _) = *self;
+        let DblModelMorphism(DiscreteDblModelMapping(mapping), dom, _) = *self;
         dom.mor_generators()
-            .all(|e| mapping.apply_mor_generator(e).map(|p| p.is_simple()).unwrap_or(true))
+            .all(|e| mapping.apply_edge(e).map(|p| p.is_simple()).unwrap_or(true))
     }
 
     /// Is the model morphism injective on objects?
     pub fn is_injective_objects(&self) -> bool {
-        let DblModelMorphism(mapping, dom, _) = *self;
+        let DblModelMorphism(DiscreteDblModelMapping(mapping), dom, _) = *self;
         let mut seen_obs: HashSet<_> = HashSet::new();
         for x in dom.ob_generators() {
-            if let Some(f_x) = mapping.apply_ob_generator(x) {
+            if let Some(f_x) = mapping.apply_vertex(x) {
                 if seen_obs.contains(&f_x) {
                     return false; // not monic
                 } else {
@@ -302,17 +249,18 @@ where
     assumptions are violated, the function will panic.
      */
     pub fn is_free_simple_faithful(&self) -> bool {
-        let DblModelMorphism(mapping, dom, cod) = *self;
+        let DblModelMorphism(DiscreteDblModelMapping(mapping), dom, cod) = *self;
 
         assert!(dom.is_free(), "Domain model should be free");
         assert!(cod.is_free(), "Codomain model should be free");
         assert!(self.is_simple(), "Morphism assignments should be simple");
 
+        let functor = mapping.functor_into(&cod.category);
         for x in dom.ob_generators() {
             for y in dom.ob_generators() {
                 let mut seen: HashSet<_> = HashSet::new();
                 for path in simple_paths(dom.generating_graph(), &x, &y) {
-                    if let Some(f_path) = mapping.apply_mor(path) {
+                    if let Some(f_path) = functor.apply_mor(path) {
                         if seen.contains(&f_path) {
                             return false; // not faithful
                         } else {
@@ -535,13 +483,12 @@ where
                     self.map.assign_mor(m, path);
                     self.search(depth + 1);
                 } else {
+                    let functor = self.map.0.functor_into(&self.cod.category);
                     let mor_type = self.dom.mor_generator_type(&m);
-                    let w = self
-                        .map
+                    let w = functor
                         .apply_ob(self.dom.mor_generator_dom(&m))
                         .expect("Domain should already be assigned");
-                    let z = self
-                        .map
+                    let z = functor
                         .apply_ob(self.dom.mor_generator_cod(&m))
                         .expect("Codomain should already be assigned");
 
@@ -591,19 +538,6 @@ mod tests {
     use crate::validate::Validate;
 
     #[test]
-    fn discrete_model_mapping() {
-        let mut f: DiscreteDblModelMapping<_, _> = Default::default();
-        f.assign_ob('a', 'x');
-        f.assign_ob('b', 'y');
-        assert!(f.is_ob_assigned(&'a'));
-        assert_eq!(f.apply_ob('b'), Some('y'));
-        f.assign_mor('f', Path::pair('p', 'q'));
-        f.assign_mor('g', Path::pair('r', 's'));
-        assert!(f.is_mor_assigned(&Path::single('f')));
-        assert_eq!(f.apply_mor(Path::pair('f', 'g')), Path::from_vec(vec!['p', 'q', 'r', 's']));
-    }
-
-    #[test]
     fn find_positive_loops() {
         let th = Rc::new(th_signed_category());
         let positive_loop = positive_loop(th.clone());
@@ -611,7 +545,10 @@ mod tests {
 
         let maps = DiscreteDblModelMapping::morphisms(&positive_loop, &positive_loop).find_all();
         assert_eq!(maps.len(), 2);
-        let mors: Vec<_> = maps.into_iter().map(|mor| mor.apply_mor(pos.clone())).collect();
+        let mors: Vec<_> = maps
+            .into_iter()
+            .map(|map| map.functor_into(&positive_loop).apply_mor(pos.clone()))
+            .collect();
         assert!(mors.iter().any(|mor| matches!(mor, Some(Path::Id(_)))));
         assert!(mors.iter().any(|mor| matches!(mor, Some(Path::Seq(_)))));
 
@@ -619,7 +556,10 @@ mod tests {
             .monic()
             .find_all();
         assert_eq!(maps.len(), 1);
-        assert!(matches!(maps[0].apply_mor(pos), Some(Path::Seq(_))));
+        assert!(matches!(
+            maps[0].functor_into(&positive_loop).apply_mor(pos),
+            Some(Path::Seq(_))
+        ));
     }
 
     /// The [simple path](crate::one::graph_algorithms::simple_paths) should
@@ -656,7 +596,7 @@ mod tests {
                     .initialize_ob(ustr("B"), j)
                     .find_all()
                     .into_iter()
-                    .map(|f| f.apply_mor_generator(ustr("f")).unwrap())
+                    .map(|map| map.functor_into(&model).apply_mor_generator(ustr("f")).unwrap())
                     .collect();
                 let spaths: HashSet<_> = simple_paths(model.generating_graph(), &i, &j).collect();
                 assert_eq!(maps, spaths);
@@ -675,7 +615,10 @@ mod tests {
             .max_path_len(2)
             .find_all();
         assert_eq!(maps.len(), 2);
-        let obs: Vec<_> = maps.iter().map(|mor| mor.apply_ob(base_pt)).collect();
+        let obs: Vec<_> = maps
+            .iter()
+            .map(|map| map.functor_into(&negative_feedback).apply_ob(base_pt))
+            .collect();
         assert!(obs.contains(&Some(ustr("x"))));
         assert!(obs.contains(&Some(ustr("y"))));
 

--- a/packages/catlog/src/dbl/model_morphism.rs
+++ b/packages/catlog/src/dbl/model_morphism.rs
@@ -50,7 +50,7 @@ axioms for a model morphism are also trivial.
 #[derivative(Default(bound = ""))]
 #[derivative(PartialEq(bound = "DomId: Eq + Hash, CodId: PartialEq"))]
 pub struct DiscreteDblModelMapping<DomId, CodId>(
-    ColumnarGraphMapping<HashColumn<DomId, CodId>, HashColumn<DomId, Path<CodId, CodId>>>,
+    FpFunctorData<HashColumn<DomId, CodId>, HashColumn<DomId, Path<CodId, CodId>>>,
 );
 
 /// Auxiliary struct for morphism map of [`DiscreteDblModelMapping`].
@@ -94,7 +94,7 @@ where
     type MorMap = DiscreteDblModelMorMap<DomId, CodId>;
 
     fn ob_map(&self) -> &Self::ObMap {
-        self.0.vertex_map()
+        self.0.ob_generator_map()
     }
     fn mor_map(&self) -> &Self::MorMap {
         RefCast::ref_cast(self)
@@ -112,10 +112,10 @@ where
     type MorGenMap = HashColumn<DomId, Path<CodId, CodId>>;
 
     fn ob_generator_map(&self) -> &Self::ObGenMap {
-        self.0.vertex_map()
+        self.0.ob_generator_map()
     }
     fn mor_generator_map(&self) -> &Self::MorGenMap {
-        self.0.edge_map()
+        self.0.mor_generator_map()
     }
 }
 
@@ -126,27 +126,27 @@ where
 {
     /// Constructs a model mapping from a pair of hash maps.
     pub fn new(ob_map: HashMap<DomId, CodId>, mor_map: HashMap<DomId, Path<CodId, CodId>>) -> Self {
-        Self(ColumnarGraphMapping::new(HashColumn::new(ob_map), HashColumn::new(mor_map)))
+        Self(FpFunctorData::new(HashColumn::new(ob_map), HashColumn::new(mor_map)))
     }
 
     /// Assigns an object generator, returning the previous assignment.
     pub fn assign_ob(&mut self, x: DomId, y: CodId) -> Option<CodId> {
-        self.0.vertex_map_mut().set(x, y)
+        self.0.ob_generator_map_mut().set(x, y)
     }
 
     /// Assigns a morphism generator, returning the previous assignment.
     pub fn assign_mor(&mut self, e: DomId, n: Path<CodId, CodId>) -> Option<Path<CodId, CodId>> {
-        self.0.edge_map_mut().set(e, n)
+        self.0.mor_generator_map_mut().set(e, n)
     }
 
     /// Unassigns an object generator, returning the previous assignment.
     pub fn unassign_ob(&mut self, x: &DomId) -> Option<CodId> {
-        self.0.vertex_map_mut().unset(x)
+        self.0.ob_generator_map_mut().unset(x)
     }
 
     /// Unassigns a morphism generator, returning the previous assignment.
     pub fn unassign_mor(&mut self, e: &DomId) -> Option<Path<CodId, CodId>> {
-        self.0.edge_map_mut().unset(e)
+        self.0.mor_generator_map_mut().unset(e)
     }
 
     /** Basic objects and morphisms in the image of the model morphism.

--- a/packages/catlog/src/dbl/model_morphism.rs
+++ b/packages/catlog/src/dbl/model_morphism.rs
@@ -460,8 +460,7 @@ where
         let var = &self.var_order[depth];
         match var.clone() {
             GraphElem::Vertex(x) => {
-                if self.ob_init.is_set(&x) {
-                    let y = self.ob_init.get(&x).cloned().unwrap();
+                if let Some(y) = self.ob_init.apply_to_ref(&x) {
                     let can_assign = self.assign_ob(x.clone(), y.clone());
                     if can_assign {
                         self.search(depth + 1);
@@ -478,8 +477,7 @@ where
                 }
             }
             GraphElem::Edge(m) => {
-                if self.mor_init.is_set(&m) {
-                    let path = self.mor_init.get(&m).cloned().unwrap();
+                if let Some(path) = self.mor_init.apply_to_ref(&m) {
                     self.map.assign_mor(m, path);
                     self.search(depth + 1);
                 } else {
@@ -541,13 +539,13 @@ mod tests {
     fn find_positive_loops() {
         let th = Rc::new(th_signed_category());
         let positive_loop = positive_loop(th.clone());
-        let pos: Path<_, _> = positive_loop.mor_generators().next().unwrap().into();
+        let pos = positive_loop.mor_generators().next().unwrap().into();
 
         let maps = DiscreteDblModelMapping::morphisms(&positive_loop, &positive_loop).find_all();
         assert_eq!(maps.len(), 2);
         let mors: Vec<_> = maps
             .into_iter()
-            .map(|map| map.functor_into(&positive_loop).apply_mor(pos.clone()))
+            .map(|map| map.functor_into(&positive_loop).mor_map().apply_to_ref(&pos))
             .collect();
         assert!(mors.iter().any(|mor| matches!(mor, Some(Path::Id(_)))));
         assert!(mors.iter().any(|mor| matches!(mor, Some(Path::Seq(_)))));

--- a/packages/catlog/src/dbl/theory.rs
+++ b/packages/catlog/src/dbl/theory.rs
@@ -625,7 +625,7 @@ where
     fn src(&self, m: &Self::Pro) -> Self::Ob {
         match m {
             TabMorType::Basic(e) => {
-                self.src.get(e).cloned().expect("Source of morphism type should be defined")
+                self.src.apply_to_ref(e).expect("Source of morphism type should be defined")
             }
             TabMorType::Hom(x) => (**x).clone(),
         }
@@ -633,7 +633,7 @@ where
     fn tgt(&self, m: &Self::Pro) -> Self::Ob {
         match m {
             TabMorType::Basic(e) => {
-                self.tgt.get(e).cloned().expect("Target of morphism type should be defined")
+                self.tgt.apply_to_ref(e).expect("Target of morphism type should be defined")
             }
             TabMorType::Hom(x) => (**x).clone(),
         }

--- a/packages/catlog/src/one/functor.rs
+++ b/packages/catlog/src/one/functor.rs
@@ -100,8 +100,8 @@ pub trait FgCategoryMap: CategoryMap {
 
 /** The data of a functor out of a finitely presented (f.p.) category.
 
-The data comprises a pair of mappings out of the object and morphism generators
-of the domain category, assumed to be finitely presented. These should form a
+This struct consists of a pair of mappings on the object and morphism generators
+of the domain category, assumed to be finitely presented. This data defines a
 [graph mapping](GraphMapping) from the domain category's generating graph to the
 codomain category's underlying graph.
 
@@ -110,37 +110,20 @@ functor](Self::functor_into) into a specific category.
  */
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct FpFunctorData<ObGenMap, MorGenMap> {
-    ob_gen_map: ObGenMap,
-    mor_gen_map: MorGenMap,
+    /// Mapping on object generators.
+    pub ob_generator_map: ObGenMap,
+
+    /// Mapping on morphism generators.
+    pub mor_generator_map: MorGenMap,
 }
 
 impl<ObGenMap, MorGenMap> FpFunctorData<ObGenMap, MorGenMap> {
     /// Constructs from given mappings on object and morphism generators.
-    pub fn new(ob_gen_map: ObGenMap, mor_gen_map: MorGenMap) -> Self {
+    pub fn new(ob_generator_map: ObGenMap, mor_generator_map: MorGenMap) -> Self {
         Self {
-            ob_gen_map,
-            mor_gen_map,
+            ob_generator_map,
+            mor_generator_map,
         }
-    }
-
-    /// Gets a reference to the mapping on object generators.
-    pub fn ob_generator_map(&self) -> &ObGenMap {
-        &self.ob_gen_map
-    }
-
-    /// Gets a reference to the mapping on morphism generators.
-    pub fn mor_generator_map(&self) -> &MorGenMap {
-        &self.mor_gen_map
-    }
-
-    /// Gets a mutable reference to the mapping on object generators.
-    pub fn ob_generator_map_mut(&mut self) -> &mut ObGenMap {
-        &mut self.ob_gen_map
-    }
-
-    /// Gets a mutable reference to the mapping on morphism generators.
-    pub fn mor_generator_map_mut(&mut self) -> &mut MorGenMap {
-        &mut self.mor_gen_map
     }
 
     /// Interprets the data as a functor into the given category.
@@ -162,10 +145,10 @@ where
     type EdgeMap = MorGenMap;
 
     fn vertex_map(&self) -> &Self::VertexMap {
-        &self.ob_gen_map
+        &self.ob_generator_map
     }
     fn edge_map(&self) -> &Self::EdgeMap {
-        &self.mor_gen_map
+        &self.mor_generator_map
     }
 }
 

--- a/packages/catlog/src/one/functor.rs
+++ b/packages/catlog/src/one/functor.rs
@@ -1,4 +1,18 @@
-//! Functors between categories.
+/*! Functors between categories.
+
+Abstractly, a functor between categories is a just graph morphism between the
+underlying graphs that respects composition. In our applications, we are most
+interested in functors out of *finitely generated* categories, whose action on
+arbitrary morphisms is uniquely determined by that on the morphism generators.
+Thus, in contrast to mappings between [sets](crate::zero::Mapping) and
+[graphs](crate::one::GraphMapping), we generally cannot separate *evaluation*
+from *validation*: to evaluate a [map](FgCategoryMap) on a finitely generated
+category, we might need access to the domain category, in order to decompose
+general morphisms into composites of generators, and also to the codomain
+category, in order to compose images of generating morphisms. The upshot is that
+you must carry around (references to) more data to evaluate functors than to
+evaluate functions or graph morphisms.
+ */
 
 use std::hash::{BuildHasher, Hash};
 

--- a/packages/catlog/src/one/functor.rs
+++ b/packages/catlog/src/one/functor.rs
@@ -293,8 +293,8 @@ where
                     InvalidGraphMorphism::Tgt(e) => InvalidFpFunctor::Cod(e),
                 });
         let equation_errors = dom.equations().enumerate().filter_map(|(id, eq)| {
-            if let (Some(lhs), Some(rhs)) =
-                (self.apply_mor(eq.lhs.clone()), self.apply_mor(eq.rhs.clone()))
+            let map = self.mor_map();
+            if let (Some(lhs), Some(rhs)) = (map.apply_to_ref(&eq.lhs), map.apply_to_ref(&eq.rhs))
                 && !self.cod.morphisms_are_equal(lhs, rhs)
             {
                 Some(InvalidFpFunctor::Eq(id))

--- a/packages/catlog/src/one/functor.rs
+++ b/packages/catlog/src/one/functor.rs
@@ -172,8 +172,9 @@ where
 /** A functor out of a finitely presented (f.p.) category.
 
 Like a [`Function`](crate::zero::Function), this struct borrows its data. Unlike
-a function, the codomain is needed not just for validation but even to evaluate
-the functor on morphisms. The domain category is used only for validation.
+a [`Mapping`] between sets, a codomain is needed not just for validation but to
+even evaluate the functor on morphisms, hence is required as extra data. The
+domain category is needed only for validation.
  */
 pub struct FpFunctor<'a, Map, Cod> {
     map: &'a Map,

--- a/packages/catlog/src/one/graph.rs
+++ b/packages/catlog/src/one/graph.rs
@@ -570,7 +570,7 @@ where
     {
         let GraphMorphism(mapping, dom, cod) = *self;
         let vertex_errors = dom.vertices().filter_map(|v| {
-            if mapping.apply_vertex(v.clone()).is_some_and(|w| cod.has_vertex(&w)) {
+            if mapping.vertex_map().apply_to_ref(&v).is_some_and(|w| cod.has_vertex(&w)) {
                 None
             } else {
                 Some(InvalidGraphMorphism::Vertex(v))
@@ -578,7 +578,7 @@ where
         });
 
         let edge_errors = dom.edges().flat_map(|e| {
-            if let Some(f) = mapping.apply_edge(e.clone()) {
+            if let Some(f) = mapping.edge_map().apply_to_ref(&e) {
                 if cod.has_edge(&f) {
                     let mut errs = Vec::new();
                     if mapping.apply_vertex(dom.src(&e)).is_some_and(|v| v != cod.src(&f)) {

--- a/packages/catlog/src/one/graph.rs
+++ b/packages/catlog/src/one/graph.rs
@@ -651,16 +651,6 @@ impl<VMap, EMap> ColumnarGraphMapping<VMap, EMap> {
             edge_map,
         }
     }
-
-    /// Gets a mutable reference to the vertex mapping.
-    pub fn vertex_map_mut(&mut self) -> &mut VMap {
-        &mut self.vertex_map
-    }
-
-    /// Gets a mutable reference to the edge mapping.
-    pub fn edge_map_mut(&mut self) -> &mut EMap {
-        &mut self.edge_map
-    }
 }
 
 impl<VMap, EMap> GraphMapping for ColumnarGraphMapping<VMap, EMap>

--- a/packages/catlog/src/zero/column.rs
+++ b/packages/catlog/src/zero/column.rs
@@ -337,8 +337,7 @@ impl<T: Eq + Clone> Column for VecColumn<T> {
 
 impl<T: Eq + Clone> MutColumn for VecColumn<T> {}
 
-/** An unindexed column backed by a hash map.
- */
+/// An unindexed column backed by a hash map.
 #[derive(Clone, From, Debug, Derivative)]
 #[derivative(Default(bound = "S: Default"))]
 #[derivative(PartialEq(bound = "K: Eq + Hash, V: PartialEq, S: BuildHasher"))]
@@ -461,8 +460,7 @@ trait Index {
     fn remove(&mut self, x: &Self::Dom, y: &Self::Cod);
 }
 
-/** An index implemented as a vector of vectors.
- */
+/// An index implemented as a vector of vectors.
 #[derive(Clone, Debug, Derivative)]
 #[derivative(Default(bound = ""))]
 struct VecIndex<T>(Vec<Vec<T>>);
@@ -494,8 +492,7 @@ impl<T: Eq + Clone> Index for VecIndex<T> {
     }
 }
 
-/** An index implemented by a hash map into vectors.
- */
+/// An index implemented by a hash map into vectors.
 #[derive(Clone, Debug, Derivative)]
 #[derivative(Default(bound = "S: Default"))]
 struct HashIndex<X, Y, S = RandomState>(HashMap<Y, Vec<X>, S>);


### PR DESCRIPTION
Sequel to #551. The implementation is trivial after some initial work to support conversion to/from iterators of pairs for all the column types.

Also includes more refactoring of the interfaces for set mappings, which I hope is finally converging.

CC @tim-at-topos