### PR TITLE
Modal double theories in core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,18 +627,18 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "1.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "1.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/packages/catlog-wasm/Cargo.toml
+++ b/packages/catlog-wasm/Cargo.toml
@@ -14,7 +14,7 @@ default = ["console_error_panic_hook"]
 all-the-same = "1.1.0"
 catlog = { path = "../catlog", features = ["ode", "serde-wasm"] }
 console_error_panic_hook = { version = "0.1.7", optional = true }
-derive_more = { version = "1", features = ["from", "try_into"] }
+derive_more = { version = "2", features = ["from", "try_into"] }
 egglog = { version = "0.4", default-features = false, features = [
     "wasm-bindgen",
 ] }

--- a/packages/catlog/Cargo.toml
+++ b/packages/catlog/Cargo.toml
@@ -12,7 +12,7 @@ serde-wasm = ["serde", "dep:wasm-bindgen", "dep:tsify"]
 
 [dependencies]
 derivative = "2"
-derive_more = { version = "1", features = ["from", "into"] }
+derive_more = { version = "2", features = ["from", "into"] }
 duplicate = "2"
 egglog = { version = "0.4", default-features = false }
 ego-tree = "0.10"

--- a/packages/catlog/Cargo.toml
+++ b/packages/catlog/Cargo.toml
@@ -12,7 +12,7 @@ serde-wasm = ["serde", "dep:wasm-bindgen", "dep:tsify"]
 
 [dependencies]
 derivative = "2"
-derive_more = { version = "2", features = ["from", "into"] }
+derive_more = { version = "2", features = ["constructor", "from", "into"] }
 duplicate = "2"
 egglog = { version = "0.4", default-features = false }
 ego-tree = "0.10"

--- a/packages/catlog/src/dbl/category.rs
+++ b/packages/catlog/src/dbl/category.rs
@@ -30,9 +30,9 @@ to composition in a double category does not arise in VDCs.
 
 A [double theory](super::theory) is "just" a unital virtual double category, so
 any double theory in the standard library is an example of a VDC. For testing
-purposes, this module provides several minimal examples of VDCs implemented
-directly, namely ["walking"](https://ncatlab.org/nlab/show/walking+structure)
-categorical structures that can be interpreted in any VDC:
+purposes, this module directly implements several minimal examples of VDCs,
+namely ["walking"](https://ncatlab.org/nlab/show/walking+structure) categorical
+structures that can be interpreted in any VDC:
 
 - the [walking category](WalkingCategory)
 - the [walking functor](WalkingFunctor)

--- a/packages/catlog/src/dbl/category.rs
+++ b/packages/catlog/src/dbl/category.rs
@@ -49,7 +49,7 @@ use std::ops::Range;
 
 use super::graph::{EdgeGraph, VDblGraph};
 use super::tree::DblTree;
-use crate::one::path::Path;
+use crate::one::{Category, Path};
 
 /** A virtual double category (VDC).
 
@@ -233,10 +233,42 @@ pub trait VDCWithComposites: VDblCategory {
     }
 }
 
+/// The underlying category of objects and arrows in a VDC.
+#[derive(From, RefCast)]
+#[repr(transparent)]
+pub struct UnderlyingCategory<VDC>(pub VDC);
+
+impl<VDC: VDblCategory> Category for UnderlyingCategory<VDC> {
+    type Ob = VDC::Ob;
+    type Mor = VDC::Arr;
+
+    fn has_ob(&self, x: &Self::Ob) -> bool {
+        self.0.has_ob(x)
+    }
+    fn has_mor(&self, f: &Self::Mor) -> bool {
+        self.0.has_arrow(f)
+    }
+    fn dom(&self, f: &Self::Mor) -> Self::Ob {
+        self.0.dom(f)
+    }
+    fn cod(&self, f: &Self::Mor) -> Self::Ob {
+        self.0.cod(f)
+    }
+    fn compose(&self, path: Path<Self::Ob, Self::Mor>) -> Self::Mor {
+        self.0.compose(path)
+    }
+    fn compose2(&self, f: Self::Mor, g: Self::Mor) -> Self::Mor {
+        self.0.compose2(f, g)
+    }
+    fn id(&self, x: Self::Ob) -> Self::Mor {
+        self.0.id(x)
+    }
+}
+
 /// The underlying [virtual double graph](VDblGraph) of a VDC.
 #[derive(From, RefCast)]
 #[repr(transparent)]
-pub struct UnderlyingDblGraph<VDC: VDblCategory>(pub VDC);
+pub struct UnderlyingDblGraph<VDC>(pub VDC);
 
 impl<VDC: VDblCategory> VDblGraph for UnderlyingDblGraph<VDC> {
     type V = VDC::Ob;

--- a/packages/catlog/src/dbl/computad.rs
+++ b/packages/catlog/src/dbl/computad.rs
@@ -3,6 +3,7 @@
 use std::hash::{BuildHasher, Hash};
 
 use derivative::Derivative;
+use derive_more::Constructor;
 
 use super::graph::{InvalidVDblGraph, VDblGraph};
 use crate::one::{Graph, Path, ReflexiveGraph, ShortPath};
@@ -48,11 +49,12 @@ where
 }
 
 /// TODO
+#[derive(Constructor)]
 pub struct AVDCComputad<'a, Ob, Arr, Pro, ObSet, ArrGraph, ProGraph, Sq, S> {
-    pub objects: &'a ObSet,
-    pub arrows: &'a ArrGraph,
-    pub proarrows: &'a ProGraph,
-    pub computad: &'a AVDCComputadTop<Ob, Arr, Pro, Sq, S>,
+    objects: &'a ObSet,
+    arrows: &'a ArrGraph,
+    proarrows: &'a ProGraph,
+    computad: &'a AVDCComputadTop<Ob, Arr, Pro, Sq, S>,
 }
 
 impl<'a, Ob, Arr, Pro, ObSet, ArrGraph, ProGraph, Sq, S> VDblGraph

--- a/packages/catlog/src/dbl/computad.rs
+++ b/packages/catlog/src/dbl/computad.rs
@@ -1,6 +1,8 @@
 //! Computads for virtual double categories.
 
-use std::hash::{BuildHasher, Hash, RandomState};
+use std::hash::{BuildHasher, Hash};
+
+use derivative::Derivative;
 
 use super::graph::{InvalidVDblGraph, VDblGraph};
 use crate::one::{Graph, Path, ReflexiveGraph, ShortPath};
@@ -10,7 +12,9 @@ use crate::zero::*;
 
 Intended for use with [`AVDCComputad`].
  */
-pub struct AVDCComputadTop<Ob, Arr, Pro, Sq, S = RandomState> {
+#[derive(Debug, Derivative)]
+#[derivative(Default(bound = "S: Default"))]
+pub struct AVDCComputadTop<Ob, Arr, Pro, Sq, S> {
     squares: HashFinSet<Sq, S>,
     dom: HashColumn<Sq, Path<Ob, Pro>, S>,
     cod: HashColumn<Sq, ShortPath<Ob, Pro>, S>,
@@ -104,7 +108,7 @@ where
     Note that this method *assumes* that the graphs of objects and (pro)arrows
     are already valid. If that is in question, validate them first.
      */
-    pub fn iter_invalid(&self) -> impl Iterator<Item = InvalidVDblGraph<Arr, Pro, Sq>> {
+    pub fn iter_invalid<E, ProE>(&self) -> impl Iterator<Item = InvalidVDblGraph<E, ProE, Sq>> {
         let cptd = self.computad;
         cptd.squares.iter().flat_map(|sq| {
             let (dom, cod) = (cptd.dom.get(&sq), cptd.cod.get(&sq));

--- a/packages/catlog/src/dbl/computad.rs
+++ b/packages/catlog/src/dbl/computad.rs
@@ -1,0 +1,86 @@
+//! Computads for double categories and virtual double categories.
+
+use std::hash::{BuildHasher, Hash, RandomState};
+
+use super::graph::VDblGraph;
+use crate::one::{Graph, Path, ReflexiveGraph, ShortPath};
+use crate::zero::*;
+
+/// TODO
+pub struct AVDCComputadSquares<Ob, Arr, Pro, Sq, S = RandomState> {
+    pub squares: HashFinSet<Sq, S>,
+    pub dom: HashColumn<Sq, Path<Ob, Pro>, S>,
+    pub cod: HashColumn<Sq, ShortPath<Ob, Pro>, S>,
+    pub src: HashColumn<Sq, Arr, S>,
+    pub tgt: HashColumn<Sq, Arr, S>,
+}
+
+/// TODO
+pub struct AVDCComputad<'a, Ob, Arr, Pro, ObSet, ArrGraph, ProGraph, Sq, S> {
+    pub objects: &'a ObSet,
+    pub arrows: &'a ArrGraph,
+    pub proarrows: &'a ProGraph,
+    pub computad: &'a AVDCComputadSquares<Ob, Arr, Pro, Sq, S>,
+}
+
+impl<'a, Ob, Arr, Pro, ObSet, ArrGraph, ProGraph, Sq, S> VDblGraph
+    for AVDCComputad<'a, Ob, Arr, Pro, ObSet, ArrGraph, ProGraph, Sq, S>
+where
+    Ob: Eq + Clone,
+    Arr: Eq + Clone,
+    Pro: Eq + Clone,
+    Sq: Eq + Clone + Hash,
+    ObSet: Set<Elem = Ob>,
+    ArrGraph: Graph<V = Ob, E = Arr>,
+    ProGraph: ReflexiveGraph<V = Ob, E = Pro>,
+    S: BuildHasher,
+{
+    type V = Ob;
+    type E = Arr;
+    type ProE = Pro;
+    type Sq = Sq;
+
+    fn has_vertex(&self, v: &Self::V) -> bool {
+        self.objects.contains(v)
+    }
+    fn has_edge(&self, e: &Self::E) -> bool {
+        self.arrows.has_edge(e)
+    }
+    fn has_proedge(&self, p: &Self::ProE) -> bool {
+        self.proarrows.has_edge(p)
+    }
+    fn has_square(&self, sq: &Self::Sq) -> bool {
+        self.computad.squares.contains(sq)
+    }
+    fn dom(&self, e: &Self::E) -> Self::V {
+        self.arrows.src(e)
+    }
+    fn cod(&self, e: &Self::E) -> Self::V {
+        self.arrows.tgt(e)
+    }
+    fn src(&self, p: &Self::ProE) -> Self::V {
+        self.proarrows.src(p)
+    }
+    fn tgt(&self, p: &Self::ProE) -> Self::V {
+        self.proarrows.tgt(p)
+    }
+    fn square_dom(&self, sq: &Self::Sq) -> Path<Self::V, Self::ProE> {
+        self.computad.dom.apply_to_ref(sq).expect("Domain of square should be defined")
+    }
+    fn square_cod(&self, sq: &Self::Sq) -> Self::ProE {
+        self.computad
+            .cod
+            .apply_to_ref(sq)
+            .expect("Codomain of square should be defined")
+            .to_edge_in(self.proarrows)
+    }
+    fn square_src(&self, sq: &Self::Sq) -> Self::E {
+        self.computad.src.apply_to_ref(sq).expect("Source of square should be defined")
+    }
+    fn square_tgt(&self, sq: &Self::Sq) -> Self::E {
+        self.computad.src.apply_to_ref(sq).expect("Target of square should be defined")
+    }
+    fn arity(&self, sq: &Self::Sq) -> usize {
+        self.computad.dom.get(sq).expect("Domain of square should be defined").len()
+    }
+}

--- a/packages/catlog/src/dbl/computad.rs
+++ b/packages/catlog/src/dbl/computad.rs
@@ -22,6 +22,31 @@ pub struct AVDCComputadTop<Ob, Arr, Pro, Sq, S> {
     tgt: HashColumn<Sq, Arr, S>,
 }
 
+impl<Ob, Arr, Pro, Sq, S> AVDCComputadTop<Ob, Arr, Pro, Sq, S>
+where
+    Ob: Eq + Clone,
+    Arr: Eq + Clone,
+    Pro: Eq + Clone,
+    Sq: Eq + Clone + Hash,
+    S: BuildHasher,
+{
+    /// Adds a square to the double computad.
+    pub fn add_square(
+        &mut self,
+        sq: Sq,
+        dom: Path<Ob, Pro>,
+        cod: ShortPath<Ob, Pro>,
+        src: Arr,
+        tgt: Arr,
+    ) -> bool {
+        self.dom.set(sq.clone(), dom);
+        self.cod.set(sq.clone(), cod);
+        self.src.set(sq.clone(), src);
+        self.tgt.set(sq.clone(), tgt);
+        self.squares.insert(sq)
+    }
+}
+
 /// TODO
 pub struct AVDCComputad<'a, Ob, Arr, Pro, ObSet, ArrGraph, ProGraph, Sq, S> {
     pub objects: &'a ObSet,

--- a/packages/catlog/src/dbl/computad.rs
+++ b/packages/catlog/src/dbl/computad.rs
@@ -48,7 +48,17 @@ where
     }
 }
 
-/// TODO
+/** An augmented virtual double computad.
+
+The set of objects and the graphs of arrows and proarrows are assumed already
+constructed, possibly from other generating data, while the top-dimensional
+generating data is provided directly.
+
+We say "augmented" because the generating squares have co-arity zero or one,
+like the cells in an *augmented VDC* ([Koudenburg
+2020](crate::refs::AugmentedVDCs)), though we use such computads to generate
+*unital* VDCs.
+ */
 #[derive(Constructor)]
 pub struct AVDCComputad<'a, Ob, Arr, Pro, ObSet, ArrGraph, ProGraph, Sq, S> {
     objects: &'a ObSet,

--- a/packages/catlog/src/dbl/discrete/model.rs
+++ b/packages/catlog/src/dbl/discrete/model.rs
@@ -80,10 +80,7 @@ where
         let category_errors = self.category.iter_invalid().map(|err| match err {
             InvalidFpCategory::Dom(e) => Invalid::Dom(e),
             InvalidFpCategory::Cod(e) => Invalid::Cod(e),
-            InvalidFpCategory::EqLhs(eq) => Invalid::EqLhs(eq),
-            InvalidFpCategory::EqRhs(eq) => Invalid::EqRhs(eq),
-            InvalidFpCategory::EqSrc(eq) => Invalid::EqSrc(eq),
-            InvalidFpCategory::EqTgt(eq) => Invalid::EqTgt(eq),
+            InvalidFpCategory::Eq(eq, errs) => Invalid::Eq(eq, errs),
         });
         let ob_type_errors = self.category.ob_generators().filter_map(|x| {
             if self.theory.has_ob_type(&self.ob_type(&x)) {

--- a/packages/catlog/src/dbl/discrete/theory.rs
+++ b/packages/catlog/src/dbl/discrete/theory.rs
@@ -7,8 +7,7 @@ use derive_more::From;
 use ref_cast::RefCast;
 
 use crate::dbl::{category::*, theory::InvalidDblTheory, tree::DblTree};
-use crate::one::fp_category::{FpCategory, InvalidFpCategory, UstrFpCategory};
-use crate::one::{Path, category::*};
+use crate::one::{Path, category::*, fp_category::*};
 use crate::validate::{self, Validate};
 
 /** A discrete double theory.

--- a/packages/catlog/src/dbl/discrete/theory.rs
+++ b/packages/catlog/src/dbl/discrete/theory.rs
@@ -1,13 +1,15 @@
 //! Discrete double theories.
 
+use std::hash::{BuildHasher, Hash};
 use std::ops::Range;
 
 use derive_more::From;
 use ref_cast::RefCast;
 
-use crate::dbl::{category::*, tree::DblTree};
-use crate::one::{Path, category::*, fp_category::UstrFpCategory};
-use crate::validate::Validate;
+use crate::dbl::{category::*, theory::InvalidDblTheory, tree::DblTree};
+use crate::one::fp_category::{FpCategory, InvalidFpCategory, UstrFpCategory};
+use crate::one::{Path, category::*};
+use crate::validate::{self, Validate};
 
 /** A discrete double theory.
 
@@ -111,11 +113,19 @@ where
     }
 }
 
-impl<C: FgCategory + Validate> Validate for DiscreteDblTheory<C> {
-    type ValidationError = C::ValidationError;
+impl<Id, S> Validate for DiscreteDblTheory<FpCategory<Id, Id, S>>
+where
+    Id: Eq + Clone + Hash,
+    S: BuildHasher,
+{
+    type ValidationError = InvalidDblTheory<Id>;
 
     fn validate(&self) -> Result<(), nonempty::NonEmpty<Self::ValidationError>> {
-        self.0.validate()
+        validate::wrap_errors(self.0.iter_invalid().map(|err| match err {
+            InvalidFpCategory::Dom(id) => InvalidDblTheory::SrcType(id),
+            InvalidFpCategory::Cod(id) => InvalidDblTheory::TgtType(id),
+            InvalidFpCategory::Eq(eq, errs) => InvalidDblTheory::MorTypeEq(eq, errs),
+        }))
     }
 }
 

--- a/packages/catlog/src/dbl/graph.rs
+++ b/packages/catlog/src/dbl/graph.rs
@@ -11,8 +11,9 @@ except that the top boundary is a directed path of proedges rather than a single
 proedge.
  */
 
-use derive_more::derive::From;
+use derive_more::From;
 use ref_cast::RefCast;
+use thiserror::Error;
 
 use crate::one::{Graph, path::Path};
 
@@ -130,4 +131,44 @@ impl<VDG: VDblGraph> Graph for ProedgeGraph<VDG> {
     fn tgt(&self, e: &Self::E) -> Self::V {
         self.0.tgt(e)
     }
+}
+
+/// An invalid assignment in a virtual double graph.
+#[derive(Debug, Error)]
+pub enum InvalidVDblGraph<E, ProE, Sq> {
+    /// Edge with an invalid domain.
+    #[error("Domain of edge `{0}` is not a vertex in the double graph")]
+    Dom(E),
+
+    /// Edge with an invalid codomain.
+    #[error("Codomain of edge `{0}` is not a vertex in the double graph")]
+    Cod(E),
+
+    /// Proedge with an invalid source.
+    #[error("Source of proedge `{0}` is not a vertex in the double graph")]
+    Src(ProE),
+
+    /// Proedge with an invalid target.
+    #[error("Target of proedge `{0}` is not a vertex in the double graph")]
+    Tgt(ProE),
+
+    /// Square with an invalid domain.
+    #[error("Domain of square `{0}` is not a proedge in the double graph")]
+    SquareDom(Sq),
+
+    /// Square with an invalid codomain.
+    #[error("Codomain of square `{0}` is not a proedge in the double graph")]
+    SquareCod(Sq),
+
+    /// Square with an invalid source.
+    #[error("Source of square `{0}` is not an edge in the double graph")]
+    SquareSrc(Sq),
+
+    /// Square with an invalid target.
+    #[error("Target of cell `{0}` is not an edge in the double graph")]
+    SquareTgt(Sq),
+
+    /// Square with incompatible sides.
+    #[error("Square `{0}` has sides with incompatible endpoints")]
+    NotSquare(Sq),
 }

--- a/packages/catlog/src/dbl/mod.rs
+++ b/packages/catlog/src/dbl/mod.rs
@@ -42,10 +42,13 @@ double doctrines are currently implemented, named according to their theories:
   operations, and no further structure
 - [Discrete tabulator theories](discrete_tabulator): double theories with
   tabulators and only trivial operations
+- [Modal double theories](modal): double theories equipped with modalities, or
+  monads on the types
 
 */
 
 pub mod category;
+pub mod computad;
 pub mod graph;
 pub mod tree;
 
@@ -56,3 +59,8 @@ pub mod theory;
 
 pub mod discrete;
 pub mod discrete_tabulator;
+pub mod modal;
+
+pub use self::category::*;
+pub use self::graph::*;
+pub use self::tree::*;

--- a/packages/catlog/src/dbl/modal/mod.rs
+++ b/packages/catlog/src/dbl/modal/mod.rs
@@ -1,0 +1,3 @@
+//! Doctrine of modal double theories.
+
+pub mod theory;

--- a/packages/catlog/src/dbl/modal/theory.rs
+++ b/packages/catlog/src/dbl/modal/theory.rs
@@ -194,7 +194,7 @@ where
     S: BuildHasher,
 {
     fn computad(&self) -> Computad<'_, ModalObType<Id>, ModalSet<Id, S>, Id, S> {
-        Computad(ModalSet::ref_cast(&self.0.ob_generators), &self.0.pro_generators)
+        Computad::new(ModalSet::ref_cast(&self.0.ob_generators), &self.0.pro_generators)
     }
 }
 
@@ -268,7 +268,7 @@ where
     S: BuildHasher,
 {
     fn computad(&self) -> Computad<'_, ModalObType<Id>, ModalSet<Id, S>, Id, S> {
-        Computad(ModalSet::ref_cast(&self.0.ob_generators), &self.0.arr_generators)
+        Computad::new(ModalSet::ref_cast(&self.0.ob_generators), &self.0.arr_generators)
     }
 }
 
@@ -356,12 +356,12 @@ where
     S: BuildHasher,
 {
     fn computad(&self) -> ModalVDblComputad<'_, Id, S> {
-        AVDCComputad {
-            objects: ModalSet::ref_cast(&self.0.ob_generators),
-            arrows: UnderlyingGraph::ref_cast(ModalOneTheory::ref_cast(&self.0)),
-            proarrows: ModalMorTypeGraph::ref_cast(&self.0),
-            computad: &self.0.cell_generators,
-        }
+        AVDCComputad::new(
+            ModalSet::ref_cast(&self.0.ob_generators),
+            UnderlyingGraph::ref_cast(ModalOneTheory::ref_cast(&self.0)),
+            ModalMorTypeGraph::ref_cast(&self.0),
+            &self.0.cell_generators,
+        )
     }
 }
 

--- a/packages/catlog/src/dbl/modal/theory.rs
+++ b/packages/catlog/src/dbl/modal/theory.rs
@@ -1,0 +1,388 @@
+/*! Modal double theories.
+
+TODO: Explain implementation strategy.
+*/
+
+use std::hash::{BuildHasher, Hash, RandomState};
+
+use ref_cast::RefCast;
+
+use crate::dbl::computad::{AVDCComputad, AVDCComputadSquares};
+use crate::dbl::{DblTree, VDblCategory, VDblGraph};
+use crate::one::computad::{Computad, ComputadEdges};
+use crate::{one::*, zero::*};
+
+/** Modes/modalities available in a modal double theory.
+
+On the semantics side, each of these corresponds to a lax double monad on the
+double category of sets.
+ */
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    /// Lists of objects and morphisms (of same length).
+    List,
+
+    /// Lists of objects and morphisms with permutation of codomain list.
+    SymList,
+
+    /// Lists of objects and morphisms with reindexing of codomain list.
+    Fam,
+
+    /// Lists of objects and morphisms with reindexing of domain list..
+    ProdFam,
+
+    /// Lists of objects and morphisms with independent reindexing of both
+    /// domain and codomain lists.
+    BiprodFam,
+}
+
+/** Application of modes/modalities.
+
+Due to the simplicity of this logic, we can easily put terms in normal form:
+every term is a generator with a list (possibly empty) of modes applied to it.
+ */
+#[derive(Clone, PartialEq, Eq)]
+pub struct ModeApp<T> {
+    arg: T,
+    modes: Vec<Mode>,
+}
+
+impl<T> ModeApp<T> {
+    fn apply(mut self, modes: Vec<Mode>) -> Self {
+        self.modes.extend(modes);
+        self
+    }
+}
+
+/// An object type in a modal double theory.
+pub type ModalObType<Id> = ModeApp<Id>;
+
+/// A morphism type in a modal double theory.
+pub type ModalMorType<Id> = ShortPath<ModalObType<Id>, ModeApp<Id>>;
+
+impl<Id> ModalMorType<Id> {
+    fn apply_modes(self, modes: Vec<Mode>) -> Self {
+        match self {
+            ShortPath::Zero(x) => ShortPath::Zero(x.apply(modes)),
+            ShortPath::One(f) => ShortPath::One(f.apply(modes)),
+        }
+    }
+}
+
+/// An object operation in a modal double theory.
+type ModalObOp<Id> = Path<ModalObType<Id>, ModeApp<Id>>;
+
+impl<Id> ModalObOp<Id> {
+    fn apply_modes(self, modes: Vec<Mode>) -> Self {
+        match self {
+            Path::Id(x) => Path::Id(x.apply(modes)),
+            Path::Seq(edges) => Path::Seq(edges.map(|p| p.apply(modes.clone()))),
+        }
+    }
+}
+
+/// TODO
+#[derive(Clone, PartialEq, Eq)]
+pub enum Square<Id> {
+    /// Generating square.
+    Generator(Id),
+
+    /// Square witnessing a composite.
+    Composite(Path<ModalObType<Id>, ModalMorType<Id>>),
+}
+
+/// A morphism operation in a modal double theory.
+type ModalMorOp<Id> = DblTree<ModalObOp<Id>, ModalMorType<Id>, ModeApp<Square<Id>>>;
+
+/// A modal double theory.
+pub struct ModalDblTheory<Id, S = RandomState> {
+    ob_generators: HashFinSet<Id, S>,
+    arr_generators: ComputadEdges<ModalObType<Id>, Id, S>,
+    pro_generators: ComputadEdges<ModalObType<Id>, Id, S>,
+    cell_generators: AVDCComputadSquares<ModalObType<Id>, ModalObOp<Id>, ModalMorType<Id>, Id, S>,
+    // TODO: Arrow equations, cell equations, composites
+    //arr_equations: Vec<PathEq<ModalObType<Id>, ModeApp<Id>>>,
+}
+
+/// Set of object types in a modal double theory.
+#[derive(RefCast)]
+#[repr(transparent)]
+struct ModalSet<Id, S>(HashFinSet<Id, S>);
+
+impl<Id, S> Set for ModalSet<Id, S>
+where
+    Id: Eq + Clone + Hash,
+    S: BuildHasher,
+{
+    type Elem = ModeApp<Id>;
+
+    fn contains(&self, ob: &Self::Elem) -> bool {
+        self.0.contains(&ob.arg)
+    }
+}
+
+/// Graph of basic object operations or morphism types in a modal double theory.
+struct ModalGraph<'a, Id, S>(&'a HashFinSet<Id, S>, &'a ComputadEdges<ModeApp<Id>, Id, S>);
+
+impl<'a, Id, S> ModalGraph<'a, Id, S>
+where
+    Id: Eq + Clone + Hash,
+    S: BuildHasher,
+{
+    fn for_ob_ops(th: &'a ModalDblTheory<Id, S>) -> Self {
+        ModalGraph(&th.ob_generators, &th.arr_generators)
+    }
+    fn for_mor_types(th: &'a ModalDblTheory<Id, S>) -> Self {
+        ModalGraph(&th.ob_generators, &th.pro_generators)
+    }
+    fn computad(&self) -> impl ColumnarGraph<V = ModeApp<Id>, E = Id> {
+        Computad(ModalSet::ref_cast(self.0), self.1)
+    }
+}
+
+impl<'a, Id, S> Graph for ModalGraph<'a, Id, S>
+where
+    Id: Eq + Clone + Hash,
+    S: BuildHasher,
+{
+    type V = ModeApp<Id>;
+    type E = ModeApp<Id>;
+
+    fn has_vertex(&self, x: &Self::V) -> bool {
+        ModalSet::ref_cast(self.0).contains(x)
+    }
+    fn has_edge(&self, f: &Self::E) -> bool {
+        self.computad().has_edge(&f.arg)
+    }
+    fn src(&self, f: &Self::E) -> Self::V {
+        self.computad().src(&f.arg).apply(f.modes.clone())
+    }
+    fn tgt(&self, f: &Self::E) -> Self::V {
+        self.computad().tgt(&f.arg).apply(f.modes.clone())
+    }
+}
+
+/// Category of object types/operations in a modal double theory.
+#[derive(RefCast)]
+#[repr(transparent)]
+struct ModalOneTheory<Id, S>(ModalDblTheory<Id, S>);
+
+impl<Id, S> Category for ModalOneTheory<Id, S>
+where
+    Id: Eq + Clone + Hash,
+    S: BuildHasher,
+{
+    type Ob = ModalObType<Id>;
+    type Mor = ModalObOp<Id>;
+
+    fn has_ob(&self, x: &Self::Ob) -> bool {
+        ModalGraph::for_ob_ops(&self.0).has_vertex(x)
+    }
+    fn has_mor(&self, path: &Self::Mor) -> bool {
+        path.contained_in(&ModalGraph::for_ob_ops(&self.0))
+    }
+    fn dom(&self, path: &Self::Mor) -> Self::Ob {
+        path.src(&ModalGraph::for_ob_ops(&self.0))
+    }
+    fn cod(&self, path: &Self::Mor) -> Self::Ob {
+        path.tgt(&ModalGraph::for_ob_ops(&self.0))
+    }
+    fn compose(&self, path: Path<Self::Ob, Self::Mor>) -> Self::Mor {
+        path.flatten()
+    }
+}
+
+/// Graph of object/morphism types in a modal double theory.
+#[derive(RefCast)]
+#[repr(transparent)]
+struct ModalMorTypeGraph<Id, S>(ModalDblTheory<Id, S>);
+
+impl<Id, S> Graph for ModalMorTypeGraph<Id, S>
+where
+    Id: Eq + Clone + Hash,
+    S: BuildHasher,
+{
+    type V = ModalObType<Id>;
+    type E = ModalMorType<Id>;
+
+    fn has_vertex(&self, x: &Self::V) -> bool {
+        ModalGraph::for_mor_types(&self.0).has_vertex(x)
+    }
+    fn has_edge(&self, path: &Self::E) -> bool {
+        path.contained_in(&ModalGraph::for_mor_types(&self.0))
+    }
+    fn src(&self, path: &Self::E) -> Self::V {
+        path.src(&ModalGraph::for_mor_types(&self.0))
+    }
+    fn tgt(&self, path: &Self::E) -> Self::V {
+        path.tgt(&ModalGraph::for_mor_types(&self.0))
+    }
+}
+
+impl<Id, S> ReflexiveGraph for ModalMorTypeGraph<Id, S>
+where
+    Id: Eq + Clone + Hash,
+    S: BuildHasher,
+{
+    fn refl(&self, x: Self::V) -> Self::E {
+        ShortPath::Zero(x)
+    }
+}
+
+#[derive(RefCast)]
+#[repr(transparent)]
+struct ModalVDblGraph<Id, S>(ModalDblTheory<Id, S>);
+
+impl<Id, S> VDblGraph for ModalVDblGraph<Id, S>
+where
+    Id: Eq + Clone + Hash,
+    S: BuildHasher,
+{
+    type V = ModalObType<Id>;
+    type E = ModalObOp<Id>;
+    type ProE = ModalMorType<Id>;
+    type Sq = ModeApp<Square<Id>>;
+
+    fn has_vertex(&self, x: &Self::V) -> bool {
+        ModalSet::ref_cast(&self.0.ob_generators).contains(x)
+    }
+    fn has_edge(&self, path: &Self::E) -> bool {
+        ModalOneTheory::ref_cast(&self.0).has_mor(path)
+    }
+    fn has_proedge(&self, path: &Self::ProE) -> bool {
+        ModalMorTypeGraph::ref_cast(&self.0).has_edge(path)
+    }
+    fn has_square(&self, sq: &Self::Sq) -> bool {
+        match &sq.arg {
+            Square::Generator(sq) => self.0.cell_generators.squares.contains(sq),
+            // FIXME: Don't assume all composites exist.
+            Square::Composite(_) => true,
+        }
+    }
+
+    fn dom(&self, path: &Self::E) -> Self::V {
+        ModalOneTheory::ref_cast(&self.0).dom(path)
+    }
+    fn cod(&self, path: &Self::E) -> Self::V {
+        ModalOneTheory::ref_cast(&self.0).cod(path)
+    }
+    fn src(&self, path: &Self::ProE) -> Self::V {
+        ModalMorTypeGraph::ref_cast(&self.0).src(path)
+    }
+    fn tgt(&self, path: &Self::ProE) -> Self::V {
+        ModalMorTypeGraph::ref_cast(&self.0).tgt(path)
+    }
+
+    fn square_dom(&self, sq: &Self::Sq) -> Path<Self::V, Self::ProE> {
+        let dom = match &sq.arg {
+            Square::Generator(sq) => self.0.computad().square_dom(sq),
+            Square::Composite(path) => path.clone(),
+        };
+        dom.map(|x| x.apply(sq.modes.clone()), |p| p.apply_modes(sq.modes.clone()))
+    }
+    fn square_cod(&self, sq: &Self::Sq) -> Self::ProE {
+        let cod = match &sq.arg {
+            Square::Generator(sq) => self.0.computad().square_cod(sq),
+            Square::Composite(_) => panic!("Composites not implemented"),
+        };
+        cod.apply_modes(sq.modes.clone())
+    }
+    fn square_src(&self, sq: &Self::Sq) -> Self::E {
+        let src = match &sq.arg {
+            Square::Generator(sq) => self.0.computad().square_src(sq),
+            Square::Composite(path) => Path::empty(path.src(ModalMorTypeGraph::ref_cast(&self.0))),
+        };
+        src.apply_modes(sq.modes.clone())
+    }
+    fn square_tgt(&self, sq: &Self::Sq) -> Self::E {
+        let tgt = match &sq.arg {
+            Square::Generator(sq) => self.0.computad().square_tgt(sq),
+            Square::Composite(path) => Path::empty(path.tgt(ModalMorTypeGraph::ref_cast(&self.0))),
+        };
+        tgt.apply_modes(sq.modes.clone())
+    }
+    fn arity(&self, sq: &Self::Sq) -> usize {
+        match &sq.arg {
+            Square::Generator(sq) => self.0.computad().arity(sq),
+            Square::Composite(path) => path.len(),
+        }
+    }
+}
+
+impl<Id, S> ModalDblTheory<Id, S>
+where
+    Id: Eq + Clone + Hash,
+    S: BuildHasher,
+{
+    fn computad(
+        &self,
+    ) -> impl VDblGraph<V = ModalObType<Id>, E = ModalObOp<Id>, ProE = ModalMorType<Id>, Sq = Id>
+    {
+        AVDCComputad {
+            objects: ModalSet::ref_cast(&self.ob_generators),
+            arrows: UnderlyingGraph::ref_cast(ModalOneTheory::ref_cast(self)),
+            proarrows: ModalMorTypeGraph::ref_cast(self),
+            computad: &self.cell_generators,
+        }
+    }
+}
+
+impl<Id, S> VDblCategory for ModalDblTheory<Id, S>
+where
+    Id: Eq + Clone + Hash,
+    S: BuildHasher,
+{
+    type Ob = ModalObType<Id>;
+    type Arr = ModalObOp<Id>;
+    type Pro = ModalMorType<Id>;
+    type Cell = ModalMorOp<Id>;
+
+    fn has_ob(&self, x: &Self::Ob) -> bool {
+        ModalVDblGraph::ref_cast(self).has_vertex(x)
+    }
+    fn has_arrow(&self, f: &Self::Arr) -> bool {
+        ModalVDblGraph::ref_cast(self).has_edge(f)
+    }
+    fn has_proarrow(&self, m: &Self::Pro) -> bool {
+        ModalVDblGraph::ref_cast(self).has_proedge(m)
+    }
+    fn has_cell(&self, tree: &Self::Cell) -> bool {
+        tree.contained_in(ModalVDblGraph::ref_cast(self))
+    }
+
+    fn dom(&self, f: &Self::Arr) -> Self::Ob {
+        ModalVDblGraph::ref_cast(self).dom(f)
+    }
+    fn cod(&self, f: &Self::Arr) -> Self::Ob {
+        ModalVDblGraph::ref_cast(self).cod(f)
+    }
+    fn src(&self, m: &Self::Pro) -> Self::Ob {
+        ModalVDblGraph::ref_cast(self).src(m)
+    }
+    fn tgt(&self, m: &Self::Pro) -> Self::Ob {
+        ModalVDblGraph::ref_cast(self).tgt(m)
+    }
+
+    fn cell_dom(&self, tree: &Self::Cell) -> Path<Self::Ob, Self::Pro> {
+        tree.dom(ModalVDblGraph::ref_cast(self))
+    }
+    fn cell_cod(&self, tree: &Self::Cell) -> Self::Pro {
+        tree.cod(ModalVDblGraph::ref_cast(self))
+    }
+    fn cell_src(&self, tree: &Self::Cell) -> Self::Arr {
+        self.compose(tree.src(ModalVDblGraph::ref_cast(self)))
+    }
+    fn cell_tgt(&self, tree: &Self::Cell) -> Self::Arr {
+        self.compose(tree.tgt(ModalVDblGraph::ref_cast(self)))
+    }
+    fn arity(&self, tree: &Self::Cell) -> usize {
+        tree.arity(ModalVDblGraph::ref_cast(self))
+    }
+
+    fn compose(&self, path: Path<Self::Ob, Self::Arr>) -> Self::Arr {
+        ModalOneTheory::ref_cast(self).compose(path)
+    }
+    fn compose_cells(&self, tree: DblTree<Self::Arr, Self::Pro, Self::Cell>) -> Self::Cell {
+        tree.flatten()
+    }
+}

--- a/packages/catlog/src/dbl/modal/theory.rs
+++ b/packages/catlog/src/dbl/modal/theory.rs
@@ -4,7 +4,9 @@ TODO: Explain implementation strategy.
 */
 
 use std::hash::{BuildHasher, BuildHasherDefault, Hash, RandomState};
+use std::iter::repeat_n;
 
+use derive_more::From;
 use ref_cast::RefCast;
 use ustr::{IdentityHasher, Ustr};
 
@@ -58,6 +60,17 @@ impl<T> ModeApp<T> {
         }
     }
 
+    /** Converts from `&ModeApp<T>` to `ModeApp<&T>`.
+
+    Note that this requires cloning the list of applied modes.
+    */
+    pub fn as_ref(&self) -> ModeApp<&T> {
+        ModeApp {
+            arg: &self.arg,
+            modes: self.modes.clone(),
+        }
+    }
+
     /// Applies a mode.
     pub fn apply(mut self, mode: Mode) -> Self {
         self.modes.push(mode);
@@ -68,6 +81,18 @@ impl<T> ModeApp<T> {
     pub fn apply_all(mut self, modes: impl IntoIterator<Item = Mode>) -> Self {
         self.modes.extend(modes);
         self
+    }
+
+    /// Maps over the argument.
+    pub fn map<S, F: FnOnce(T) -> S>(self, f: F) -> ModeApp<S> {
+        let ModeApp { arg, modes } = self;
+        ModeApp { arg: f(arg), modes }
+    }
+
+    /// Maps over the argument, flattening nested applications.
+    pub fn flat_map<S, F: FnOnce(T) -> ModeApp<S>>(self, f: F) -> ModeApp<S> {
+        let ModeApp { arg, modes } = self;
+        f(arg).apply_all(modes)
     }
 }
 
@@ -86,8 +111,19 @@ impl<Id> ModalMorType<Id> {
     }
 }
 
+/// A basic object operation in a modal double theory.
+#[derive(Clone, Debug, PartialEq, Eq, From)]
+pub enum ModalEdge<Id> {
+    /// Generating operation.
+    #[from]
+    Generator(Id),
+
+    /// Component of monad multiplication at given object type.
+    Mul(Mode, usize, ModalObType<Id>),
+}
+
 /// An object operation in a modal double theory.
-type ModalObOp<Id> = Path<ModalObType<Id>, ModeApp<Id>>;
+type ModalObOp<Id> = Path<ModalObType<Id>, ModeApp<ModalEdge<Id>>>;
 
 impl<Id> ModalObOp<Id> {
     fn apply_all(self, modes: impl IntoIterator<Item = Mode> + Clone) -> Self {
@@ -98,18 +134,22 @@ impl<Id> ModalObOp<Id> {
     }
 }
 
-/// TODO
-#[derive(Clone, PartialEq, Eq)]
-pub enum Square<Id> {
-    /// Generating square.
+/// A basic morphism operation in a modal double theory.
+#[derive(Clone, PartialEq, Eq, From)]
+pub enum ModalSquare<Id> {
+    /// Generating operation.
+    #[from]
     Generator(Id),
+
+    /// Component of monad multiplication at given morphism type.
+    Mul(Mode, usize, ModeApp<Id>),
 
     /// Square witnessing a composite.
     Composite(Path<ModalObType<Id>, ModalMorType<Id>>),
 }
 
 /// A morphism operation in a modal double theory.
-type ModalMorOp<Id> = DblTree<ModalObOp<Id>, ModalMorType<Id>, ModeApp<Square<Id>>>;
+type ModalMorOp<Id> = DblTree<ModalObOp<Id>, ModalMorType<Id>, ModeApp<ModalSquare<Id>>>;
 
 /// A modal double theory.
 #[derive(Debug, Default)]
@@ -142,74 +182,40 @@ where
     }
 }
 
-/// Graph of basic object operations or morphism types in a modal double theory.
-struct ModalGraph<'a, Id, S>(&'a HashFinSet<Id, S>, &'a ComputadTop<ModeApp<Id>, Id, S>);
-
-impl<'a, Id, S> ModalGraph<'a, Id, S>
-where
-    Id: Eq + Clone + Hash,
-    S: BuildHasher,
-{
-    fn for_ob_ops(th: &'a ModalDblTheory<Id, S>) -> Self {
-        ModalGraph(&th.ob_generators, &th.arr_generators)
-    }
-    fn for_mor_types(th: &'a ModalDblTheory<Id, S>) -> Self {
-        ModalGraph(&th.ob_generators, &th.pro_generators)
-    }
-    fn computad(&self) -> Computad<'_, ModalObType<Id>, ModalSet<Id, S>, Id, S> {
-        Computad(ModalSet::ref_cast(self.0), self.1)
-    }
-}
-
-impl<'a, Id, S> Graph for ModalGraph<'a, Id, S>
-where
-    Id: Eq + Clone + Hash,
-    S: BuildHasher,
-{
-    type V = ModeApp<Id>;
-    type E = ModeApp<Id>;
-
-    fn has_vertex(&self, x: &Self::V) -> bool {
-        ModalSet::ref_cast(self.0).contains(x)
-    }
-    fn has_edge(&self, f: &Self::E) -> bool {
-        self.computad().has_edge(&f.arg)
-    }
-    fn src(&self, f: &Self::E) -> Self::V {
-        self.computad().src(&f.arg).apply_all(f.modes.clone())
-    }
-    fn tgt(&self, f: &Self::E) -> Self::V {
-        self.computad().tgt(&f.arg).apply_all(f.modes.clone())
-    }
-}
-
-/// Category of object types/operations in a modal double theory.
+/// Graph of object types and *basic* morphism types in a modal double theory.
 #[derive(RefCast)]
 #[repr(transparent)]
-struct ModalOneTheory<Id, S>(ModalDblTheory<Id, S>);
+struct ModalProedgeGraph<Id, S>(ModalDblTheory<Id, S>);
 
-impl<Id, S> Category for ModalOneTheory<Id, S>
+impl<Id, S> ModalProedgeGraph<Id, S>
 where
     Id: Eq + Clone + Hash,
     S: BuildHasher,
 {
-    type Ob = ModalObType<Id>;
-    type Mor = ModalObOp<Id>;
+    fn computad(&self) -> Computad<'_, ModalObType<Id>, ModalSet<Id, S>, Id, S> {
+        Computad(ModalSet::ref_cast(&self.0.ob_generators), &self.0.pro_generators)
+    }
+}
 
-    fn has_ob(&self, x: &Self::Ob) -> bool {
-        ModalGraph::for_ob_ops(&self.0).has_vertex(x)
+impl<Id, S> Graph for ModalProedgeGraph<Id, S>
+where
+    Id: Eq + Clone + Hash,
+    S: BuildHasher,
+{
+    type V = ModalObType<Id>;
+    type E = ModeApp<Id>;
+
+    fn has_vertex(&self, ob: &Self::V) -> bool {
+        self.computad().has_vertex(ob)
     }
-    fn has_mor(&self, path: &Self::Mor) -> bool {
-        path.contained_in(&ModalGraph::for_ob_ops(&self.0))
+    fn has_edge(&self, proedge: &Self::E) -> bool {
+        self.computad().has_edge(&proedge.arg)
     }
-    fn dom(&self, path: &Self::Mor) -> Self::Ob {
-        path.src(&ModalGraph::for_ob_ops(&self.0))
+    fn src(&self, proedge: &Self::E) -> Self::V {
+        proedge.as_ref().flat_map(|e| self.computad().src(e))
     }
-    fn cod(&self, path: &Self::Mor) -> Self::Ob {
-        path.tgt(&ModalGraph::for_ob_ops(&self.0))
-    }
-    fn compose(&self, path: Path<Self::Ob, Self::Mor>) -> Self::Mor {
-        path.flatten()
+    fn tgt(&self, proedge: &Self::E) -> Self::V {
+        proedge.as_ref().flat_map(|e| self.computad().tgt(e))
     }
 }
 
@@ -227,16 +233,16 @@ where
     type E = ModalMorType<Id>;
 
     fn has_vertex(&self, x: &Self::V) -> bool {
-        ModalGraph::for_mor_types(&self.0).has_vertex(x)
+        ModalProedgeGraph::ref_cast(&self.0).has_vertex(x)
     }
     fn has_edge(&self, path: &Self::E) -> bool {
-        path.contained_in(&ModalGraph::for_mor_types(&self.0))
+        path.contained_in(ModalProedgeGraph::ref_cast(&self.0))
     }
     fn src(&self, path: &Self::E) -> Self::V {
-        path.src(&ModalGraph::for_mor_types(&self.0))
+        path.src(ModalProedgeGraph::ref_cast(&self.0))
     }
     fn tgt(&self, path: &Self::E) -> Self::V {
-        path.tgt(&ModalGraph::for_mor_types(&self.0))
+        path.tgt(ModalProedgeGraph::ref_cast(&self.0))
     }
 }
 
@@ -247,6 +253,82 @@ where
 {
     fn refl(&self, x: Self::V) -> Self::E {
         ShortPath::Zero(x)
+    }
+}
+
+/// Graph of object types and *basic* object operations in a modal theory.
+#[derive(RefCast)]
+#[repr(transparent)]
+struct ModalEdgeGraph<Id, S>(ModalDblTheory<Id, S>);
+
+impl<Id, S> ModalEdgeGraph<Id, S>
+where
+    Id: Eq + Clone + Hash,
+    S: BuildHasher,
+{
+    fn computad(&self) -> Computad<'_, ModalObType<Id>, ModalSet<Id, S>, Id, S> {
+        Computad(ModalSet::ref_cast(&self.0.ob_generators), &self.0.arr_generators)
+    }
+}
+
+impl<Id, S> Graph for ModalEdgeGraph<Id, S>
+where
+    Id: Eq + Clone + Hash,
+    S: BuildHasher,
+{
+    type V = ModalObType<Id>;
+    type E = ModeApp<ModalEdge<Id>>;
+
+    fn has_vertex(&self, ob: &Self::V) -> bool {
+        self.computad().has_vertex(ob)
+    }
+    fn has_edge(&self, edge: &Self::E) -> bool {
+        match &edge.arg {
+            ModalEdge::Generator(e) => self.computad().has_edge(e),
+            ModalEdge::Mul(_, _, ob) => self.computad().has_vertex(ob),
+        }
+    }
+    fn src(&self, edge: &Self::E) -> Self::V {
+        edge.as_ref().flat_map(|arg| match arg {
+            ModalEdge::Generator(e) => self.computad().src(e),
+            ModalEdge::Mul(mode, n, ob) => ob.clone().apply_all(repeat_n(*mode, *n)),
+        })
+    }
+    fn tgt(&self, edge: &Self::E) -> Self::V {
+        edge.as_ref().flat_map(|arg| match arg {
+            ModalEdge::Generator(e) => self.computad().tgt(e),
+            ModalEdge::Mul(mode, _, ob) => ob.clone().apply(*mode),
+        })
+    }
+}
+
+/// Category of object types/operations in a modal double theory.
+#[derive(RefCast)]
+#[repr(transparent)]
+struct ModalOneTheory<Id, S>(ModalDblTheory<Id, S>);
+
+impl<Id, S> Category for ModalOneTheory<Id, S>
+where
+    Id: Eq + Clone + Hash,
+    S: BuildHasher,
+{
+    type Ob = ModalObType<Id>;
+    type Mor = ModalObOp<Id>;
+
+    fn has_ob(&self, x: &Self::Ob) -> bool {
+        ModalEdgeGraph::ref_cast(&self.0).has_vertex(x)
+    }
+    fn has_mor(&self, path: &Self::Mor) -> bool {
+        path.contained_in(ModalEdgeGraph::ref_cast(&self.0))
+    }
+    fn dom(&self, path: &Self::Mor) -> Self::Ob {
+        path.src(ModalEdgeGraph::ref_cast(&self.0))
+    }
+    fn cod(&self, path: &Self::Mor) -> Self::Ob {
+        path.tgt(ModalEdgeGraph::ref_cast(&self.0))
+    }
+    fn compose(&self, path: Path<Self::Ob, Self::Mor>) -> Self::Mor {
+        path.flatten()
     }
 }
 
@@ -290,14 +372,14 @@ where
     type ValidationError = InvalidVDblGraph<Id, Id, Id>;
 
     fn validate(&self) -> Result<(), nonempty::NonEmpty<Self::ValidationError>> {
-        let ob_op_graph = ModalGraph::for_ob_ops(&self.0);
-        let edge_cptd = ob_op_graph.computad();
+        let edge_graph = ModalEdgeGraph::ref_cast(&self.0);
+        let edge_cptd = edge_graph.computad();
         let edge_errors = edge_cptd.iter_invalid().map(|err| match err {
             InvalidGraph::Src(e) => InvalidVDblGraph::Dom(e),
             InvalidGraph::Tgt(e) => InvalidVDblGraph::Cod(e),
         });
-        let mor_type_graph = ModalGraph::for_mor_types(&self.0);
-        let proedge_cptd = mor_type_graph.computad();
+        let proedge_graph = ModalProedgeGraph::ref_cast(&self.0);
+        let proedge_cptd = proedge_graph.computad();
         let proedge_errors = proedge_cptd.iter_invalid().map(|err| match err {
             InvalidGraph::Src(p) => InvalidVDblGraph::Src(p),
             InvalidGraph::Tgt(p) => InvalidVDblGraph::Tgt(p),
@@ -317,7 +399,7 @@ where
     type V = ModalObType<Id>;
     type E = ModalObOp<Id>;
     type ProE = ModalMorType<Id>;
-    type Sq = ModeApp<Square<Id>>;
+    type Sq = ModeApp<ModalSquare<Id>>;
 
     fn has_vertex(&self, x: &Self::V) -> bool {
         ModalSet::ref_cast(&self.0.ob_generators).contains(x)
@@ -330,9 +412,10 @@ where
     }
     fn has_square(&self, sq: &Self::Sq) -> bool {
         match &sq.arg {
-            Square::Generator(sq) => self.computad().has_square(sq),
+            ModalSquare::Generator(sq) => self.computad().has_square(sq),
+            ModalSquare::Mul(_, _, p) => ModalProedgeGraph::ref_cast(&self.0).has_edge(p),
             // FIXME: Don't assume all composites exist.
-            Square::Composite(_) => true,
+            ModalSquare::Composite(_) => true,
         }
     }
 
@@ -351,36 +434,53 @@ where
 
     fn square_dom(&self, sq: &Self::Sq) -> Path<Self::V, Self::ProE> {
         let dom = match &sq.arg {
-            Square::Generator(sq) => self.computad().square_dom(sq),
-            Square::Composite(path) => path.clone(),
+            ModalSquare::Generator(sq) => self.computad().square_dom(sq),
+            ModalSquare::Mul(mode, n, p) => {
+                ShortPath::One(p.clone().apply_all(repeat_n(*mode, *n))).into()
+            }
+            ModalSquare::Composite(path) => path.clone(),
         };
         dom.map(|x| x.apply_all(sq.modes.clone()), |p| p.apply_all(sq.modes.clone()))
     }
     fn square_cod(&self, sq: &Self::Sq) -> Self::ProE {
         let cod = match &sq.arg {
-            Square::Generator(sq) => self.computad().square_cod(sq),
-            Square::Composite(_) => panic!("Composites not implemented"),
+            ModalSquare::Generator(sq) => self.computad().square_cod(sq),
+            ModalSquare::Mul(mode, _, p) => p.clone().apply(*mode).into(),
+            ModalSquare::Composite(_) => panic!("Composites not implemented"),
         };
         cod.apply_all(sq.modes.clone())
     }
     fn square_src(&self, sq: &Self::Sq) -> Self::E {
         let src = match &sq.arg {
-            Square::Generator(sq) => self.computad().square_src(sq),
-            Square::Composite(path) => Path::empty(path.src(ModalMorTypeGraph::ref_cast(&self.0))),
+            ModalSquare::Generator(sq) => self.computad().square_src(sq),
+            ModalSquare::Mul(mode, n, p) => {
+                let graph = ModalProedgeGraph::ref_cast(&self.0);
+                ModeApp::new(ModalEdge::Mul(*mode, *n, graph.src(p))).into()
+            }
+            ModalSquare::Composite(path) => {
+                Path::empty(path.src(ModalMorTypeGraph::ref_cast(&self.0)))
+            }
         };
         src.apply_all(sq.modes.clone())
     }
     fn square_tgt(&self, sq: &Self::Sq) -> Self::E {
         let tgt = match &sq.arg {
-            Square::Generator(sq) => self.computad().square_tgt(sq),
-            Square::Composite(path) => Path::empty(path.tgt(ModalMorTypeGraph::ref_cast(&self.0))),
+            ModalSquare::Generator(sq) => self.computad().square_tgt(sq),
+            ModalSquare::Mul(mode, n, p) => {
+                let graph = ModalProedgeGraph::ref_cast(&self.0);
+                ModeApp::new(ModalEdge::Mul(*mode, *n, graph.tgt(p))).into()
+            }
+            ModalSquare::Composite(path) => {
+                Path::empty(path.tgt(ModalMorTypeGraph::ref_cast(&self.0)))
+            }
         };
         tgt.apply_all(sq.modes.clone())
     }
     fn arity(&self, sq: &Self::Sq) -> usize {
         match &sq.arg {
-            Square::Generator(sq) => self.computad().arity(sq),
-            Square::Composite(path) => path.len(),
+            ModalSquare::Generator(sq) => self.computad().arity(sq),
+            ModalSquare::Mul(_, _, _) => 1,
+            ModalSquare::Composite(path) => path.len(),
         }
     }
 }
@@ -476,5 +576,24 @@ where
     /// Adds a generating object operation to the theory.
     pub fn add_ob_op(&mut self, id: Id, dom: ModalObType<Id>, cod: ModalObType<Id>) {
         self.arr_generators.add_edge(id, dom, cod);
+    }
+
+    /// Adds a generating morphism operation to the theory.
+    pub fn add_mor_op(
+        &mut self,
+        id: Id,
+        dom: Path<ModalObType<Id>, ModalMorType<Id>>,
+        cod: ModalMorType<Id>,
+        src: ModalObOp<Id>,
+        tgt: ModalObOp<Id>,
+    ) {
+        self.cell_generators.add_square(id, dom, cod.into(), src, tgt);
+    }
+
+    /// Adds a morphism operation with nullary domain and unit codomain.
+    pub fn add_special_mor_op(&mut self, id: Id, src: ModalObOp<Id>, tgt: ModalObOp<Id>) {
+        let dom = self.dom(&src); // == self.dom(&tgt)
+        let cod = self.cod(&src); // == self.cod(&tgt)
+        self.add_mor_op(id, Path::empty(dom), ShortPath::Zero(cod), src, tgt);
     }
 }

--- a/packages/catlog/src/dbl/modal/theory.rs
+++ b/packages/catlog/src/dbl/modal/theory.rs
@@ -7,9 +7,9 @@ use std::hash::{BuildHasher, Hash, RandomState};
 
 use ref_cast::RefCast;
 
-use crate::dbl::computad::{AVDCComputad, AVDCComputadSquares};
+use crate::dbl::computad::{AVDCComputad, AVDCComputadTop};
 use crate::dbl::{DblTree, VDblCategory, VDblGraph};
-use crate::one::computad::{Computad, ComputadEdges};
+use crate::one::computad::{Computad, ComputadTop};
 use crate::{one::*, zero::*};
 
 /** Modes/modalities available in a modal double theory.
@@ -97,9 +97,9 @@ type ModalMorOp<Id> = DblTree<ModalObOp<Id>, ModalMorType<Id>, ModeApp<Square<Id
 /// A modal double theory.
 pub struct ModalDblTheory<Id, S = RandomState> {
     ob_generators: HashFinSet<Id, S>,
-    arr_generators: ComputadEdges<ModalObType<Id>, Id, S>,
-    pro_generators: ComputadEdges<ModalObType<Id>, Id, S>,
-    cell_generators: AVDCComputadSquares<ModalObType<Id>, ModalObOp<Id>, ModalMorType<Id>, Id, S>,
+    arr_generators: ComputadTop<ModalObType<Id>, Id, S>,
+    pro_generators: ComputadTop<ModalObType<Id>, Id, S>,
+    cell_generators: AVDCComputadTop<ModalObType<Id>, ModalObOp<Id>, ModalMorType<Id>, Id, S>,
     // TODO: Arrow equations, cell equations, composites
     //arr_equations: Vec<PathEq<ModalObType<Id>, ModeApp<Id>>>,
 }
@@ -122,7 +122,7 @@ where
 }
 
 /// Graph of basic object operations or morphism types in a modal double theory.
-struct ModalGraph<'a, Id, S>(&'a HashFinSet<Id, S>, &'a ComputadEdges<ModeApp<Id>, Id, S>);
+struct ModalGraph<'a, Id, S>(&'a HashFinSet<Id, S>, &'a ComputadTop<ModeApp<Id>, Id, S>);
 
 impl<'a, Id, S> ModalGraph<'a, Id, S>
 where
@@ -254,7 +254,7 @@ where
     }
     fn has_square(&self, sq: &Self::Sq) -> bool {
         match &sq.arg {
-            Square::Generator(sq) => self.0.cell_generators.squares.contains(sq),
+            Square::Generator(sq) => self.0.computad().has_square(sq),
             // FIXME: Don't assume all composites exist.
             Square::Composite(_) => true,
         }

--- a/packages/catlog/src/dbl/model.rs
+++ b/packages/catlog/src/dbl/model.rs
@@ -33,13 +33,15 @@ In addition, a model has the following operations:
   whose type is the composite of the corresponding morphism types.
  */
 
+use nonempty::NonEmpty;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "serde-wasm")]
 use tsify::Tsify;
 
 use super::theory::DblTheory;
-use crate::one::{Category, FgCategory};
+use crate::one::{Category, FgCategory, InvalidPathEq};
 
 pub use super::discrete::model::*;
 pub use super::discrete_tabulator::model::*;
@@ -200,15 +202,6 @@ pub enum InvalidDblModel<Id> {
     /// Codomain of morphism generator has type incompatible with morphism type.
     CodType(Id),
 
-    /// Equation has left hand side that is not a well defined path.
-    EqLhs(usize),
-
-    /// Equation has right hand side that is not a well defined path.
-    EqRhs(usize),
-
-    /// Equation has different sources on left and right hand sides.
-    EqSrc(usize),
-
-    /// Equation has different sources on left and right hand sides.
-    EqTgt(usize),
+    /// Equation between object operations has one or more errors.
+    Eq(usize, NonEmpty<InvalidPathEq>),
 }

--- a/packages/catlog/src/dbl/model.rs
+++ b/packages/catlog/src/dbl/model.rs
@@ -172,9 +172,6 @@ pub trait MutDblModel: FgDblModel {
 
 /** A failure of a model of a double theory to be well defined.
 
-We currently are encompassing error variants for all kinds of double theories in
-a single enum. That will likely become unviable but it's convenient for now.
-
 TODO: We are missing the case that an equation has different composite morphism
 types on left and right hand sides.
 */
@@ -202,6 +199,6 @@ pub enum InvalidDblModel<Id> {
     /// Codomain of morphism generator has type incompatible with morphism type.
     CodType(Id),
 
-    /// Equation between object operations has one or more errors.
+    /// Equation between morphisms has one or more errors.
     Eq(usize, NonEmpty<InvalidPathEq>),
 }

--- a/packages/catlog/src/dbl/theory.rs
+++ b/packages/catlog/src/dbl/theory.rs
@@ -73,6 +73,7 @@ use crate::one::{Path, tree::OpenTree};
 
 pub use super::discrete::theory::*;
 pub use super::discrete_tabulator::theory::*;
+pub use super::modal::theory::*;
 
 /** A double theory.
 

--- a/packages/catlog/src/dbl/theory.rs
+++ b/packages/catlog/src/dbl/theory.rs
@@ -68,8 +68,10 @@ composed:
   Section 10: Finite-product double theories
 */
 
-use super::{category::*, tree::*};
-use crate::one::{Path, tree::OpenTree};
+use nonempty::NonEmpty;
+
+use super::{category::*, graph::InvalidVDblGraph, tree::*};
+use crate::one::{InvalidPathEq, Path, tree::OpenTree};
 
 pub use super::discrete::theory::*;
 pub use super::discrete_tabulator::theory::*;
@@ -269,5 +271,58 @@ impl<VDC: VDCWithComposites> DblTheory for VDC {
     }
     fn id_mor_op(&self, m: Self::MorType) -> Self::MorOp {
         self.id_cell(m)
+    }
+}
+
+/// A failure of a double theory to be well defined.
+#[derive(Debug)]
+pub enum InvalidDblTheory<Id> {
+    /// Morphism type with an invalid source type.
+    SrcType(Id),
+
+    /// Morphism type with an invalid target type.
+    TgtType(Id),
+
+    /// Object operation with an invalid domain.
+    ObOpDom(Id),
+
+    /// Object operation with an invalid codomain.
+    ObOpCod(Id),
+
+    /// Morphism operation with an invalid domain.
+    MorOpDom(Id),
+
+    /// Morphism operation with an invalid codomain.
+    MorOpCod(Id),
+
+    /// Morphism operation with an invalid source operation.
+    SrcOp(Id),
+
+    /// Morphism operation with an invalid target operation.
+    TgtOp(Id),
+
+    /// Morphism operation having a boundary with incompatible corners.
+    MorOpBoundary(Id),
+
+    /// Equation between morphism types with one or more errors.
+    MorTypeEq(usize, NonEmpty<InvalidPathEq>),
+
+    /// Equation between object operations with one or more errors.
+    ObOpEq(usize, NonEmpty<InvalidPathEq>),
+}
+
+impl<Id> From<InvalidVDblGraph<Id, Id, Id>> for InvalidDblTheory<Id> {
+    fn from(err: InvalidVDblGraph<Id, Id, Id>) -> Self {
+        match err {
+            InvalidVDblGraph::Dom(id) => InvalidDblTheory::ObOpDom(id),
+            InvalidVDblGraph::Cod(id) => InvalidDblTheory::ObOpCod(id),
+            InvalidVDblGraph::Src(id) => InvalidDblTheory::SrcType(id),
+            InvalidVDblGraph::Tgt(id) => InvalidDblTheory::TgtType(id),
+            InvalidVDblGraph::SquareDom(id) => InvalidDblTheory::MorOpDom(id),
+            InvalidVDblGraph::SquareCod(id) => InvalidDblTheory::MorOpCod(id),
+            InvalidVDblGraph::SquareSrc(id) => InvalidDblTheory::SrcOp(id),
+            InvalidVDblGraph::SquareTgt(id) => InvalidDblTheory::TgtOp(id),
+            InvalidVDblGraph::NotSquare(id) => InvalidDblTheory::MorOpBoundary(id),
+        }
     }
 }

--- a/packages/catlog/src/dbl/tree.rs
+++ b/packages/catlog/src/dbl/tree.rs
@@ -371,6 +371,17 @@ impl<V, E, ProE, Sq> DblTree<Path<V, E>, ProE, DblTree<E, ProE, Sq>> {
     }
 }
 
+impl<Arr, ProE, Sq> DblTree<Arr, ProE, DblTree<Arr, ProE, Sq>> {
+    /// Flattens a double tree of double trees into a single double tree.
+    pub fn flatten(self) -> DblTree<Arr, ProE, Sq> {
+        let tree = self.0.map(|dn| match dn {
+            DblNode::Cell(tree) => tree.0,
+            DblNode::Spine(f) => OpenTree::single(DblNode::Spine(f), 1),
+        });
+        tree.flatten().into()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use ego_tree::tree;

--- a/packages/catlog/src/dbl/tree.rs
+++ b/packages/catlog/src/dbl/tree.rs
@@ -13,19 +13,19 @@ Yet another way to say this is that double trees are the cells of [free
 VDCs](super::category::FreeVDblCategory), generalizing how trees are the
 morphisms of free multicategories. Turning this around, we use our data
 structure for trees, specifically [open trees](crate::one::tree), to implement
-double trees, the idea being that a double tree is an open tree whose types are
+double trees. A double tree is thus implemented as an open tree whose types are
 proarrows and operations are cells, subject to additional typing constraints on
 the sources and targets.
 
 The only hitch in this plan is that composition in a VDC includes the degenerate
 case of composing a cell with a zero-length path of cells, which is just a
-single arrow. To accomodate the degenerate case, the [nodes](DblNode) in a
+single arrow. To accomodate nullary cell composition, the [nodes](DblNode) in a
 double tree contain either cells *or* arrows. This complicates the code in a few
 places, since it is now possible for a nullary operation (cell) to have a child
 node, and it gives the data structure something of the spirit of *augmented*
-virtual double categories ([Koudenburg 2020](crate::refs::AugmentedVDCs)). We do
-not however implement pasting diagrams in augmented VDCs, which would introduce
-further complications.
+virtual double categories ([Koudenburg 2020](crate::refs::AugmentedVDCs)).
+Double trees are *not* however data structures for pasting diagrams in augmented
+VDCs, which would introduce further complications.
  */
 
 use derive_more::From;

--- a/packages/catlog/src/one/category.rs
+++ b/packages/catlog/src/one/category.rs
@@ -64,7 +64,7 @@ pub trait Category {
 /// The set of objects of a category.
 #[derive(From, RefCast)]
 #[repr(transparent)]
-pub struct ObSet<Cat: Category>(Cat);
+pub struct ObSet<Cat>(Cat);
 
 impl<Cat: Category> Set for ObSet<Cat> {
     type Elem = Cat::Ob;
@@ -81,7 +81,7 @@ are the identities, which can thus be identified with the objects.
  */
 #[derive(From, RefCast)]
 #[repr(transparent)]
-pub struct DiscreteCategory<S: Set>(S);
+pub struct DiscreteCategory<S>(S);
 
 impl<S: Set> Category for DiscreteCategory<S> {
     type Ob = S::Elem;

--- a/packages/catlog/src/one/category.rs
+++ b/packages/catlog/src/one/category.rs
@@ -3,7 +3,7 @@
 use derive_more::From;
 use ref_cast::RefCast;
 
-use super::graph::{FinGraph, Graph};
+use super::graph::{FinGraph, Graph, ReflexiveGraph};
 use super::path::Path;
 use crate::zero::{FinSet, Set};
 
@@ -139,6 +139,12 @@ impl<Cat: Category> Graph for UnderlyingGraph<Cat> {
     }
     fn tgt(&self, f: &Self::E) -> Self::V {
         self.0.cod(f)
+    }
+}
+
+impl<Cat: Category> ReflexiveGraph for UnderlyingGraph<Cat> {
+    fn refl(&self, x: Self::V) -> Self::E {
+        self.0.id(x)
     }
 }
 

--- a/packages/catlog/src/one/computad.rs
+++ b/packages/catlog/src/one/computad.rs
@@ -1,6 +1,8 @@
 //! Computads in dimension one.
 
-use std::hash::{BuildHasher, Hash, RandomState};
+use std::hash::{BuildHasher, Hash};
+
+use derivative::Derivative;
 
 use super::graph::ColumnarGraph;
 use crate::zero::*;
@@ -9,10 +11,26 @@ use crate::zero::*;
 
 Intended for use with [`Computad`].
  */
-pub struct ComputadTop<Ob, E, S = RandomState> {
+#[derive(Debug, Derivative)]
+#[derivative(Default(bound = "S: Default"))]
+pub struct ComputadTop<Ob, E, S> {
     edges: HashFinSet<E, S>,
     src: HashColumn<E, Ob, S>,
     tgt: HashColumn<E, Ob, S>,
+}
+
+impl<Ob, E, S> ComputadTop<Ob, E, S>
+where
+    Ob: Eq + Clone,
+    E: Eq + Clone + Hash,
+    S: BuildHasher,
+{
+    /// Adds an edge to the computad.
+    pub fn add_edge(&mut self, e: E, src: Ob, tgt: Ob) -> bool {
+        self.src.set(e.clone(), src);
+        self.tgt.set(e.clone(), tgt);
+        self.edges.insert(e)
+    }
 }
 
 /// TODO

--- a/packages/catlog/src/one/computad.rs
+++ b/packages/catlog/src/one/computad.rs
@@ -1,0 +1,44 @@
+//! Computads in dimension one.
+
+use std::hash::{BuildHasher, Hash, RandomState};
+
+use super::graph::ColumnarGraph;
+use crate::zero::*;
+
+/// TODO
+pub struct ComputadEdges<Ob, E, S = RandomState> {
+    edges: HashFinSet<E, S>,
+    src: HashColumn<E, Ob, S>,
+    tgt: HashColumn<E, Ob, S>,
+}
+
+/// TODO
+pub struct Computad<'a, Ob, ObSet, E, S>(pub &'a ObSet, pub &'a ComputadEdges<Ob, E, S>);
+
+impl<'a, Ob, ObSet, E, S> ColumnarGraph for Computad<'a, Ob, ObSet, E, S>
+where
+    Ob: Eq + Clone,
+    ObSet: Set<Elem = Ob>,
+    E: Eq + Clone + Hash,
+    S: BuildHasher,
+{
+    type V = Ob;
+    type E = E;
+    type Vertices = ObSet;
+    type Edges = HashFinSet<E, S>;
+    type Src = HashColumn<E, Ob, S>;
+    type Tgt = HashColumn<E, Ob, S>;
+
+    fn vertex_set(&self) -> &Self::Vertices {
+        self.0
+    }
+    fn edge_set(&self) -> &Self::Edges {
+        &self.1.edges
+    }
+    fn src_map(&self) -> &Self::Src {
+        &self.1.src
+    }
+    fn tgt_map(&self) -> &Self::Tgt {
+        &self.1.tgt
+    }
+}

--- a/packages/catlog/src/one/computad.rs
+++ b/packages/catlog/src/one/computad.rs
@@ -1,4 +1,11 @@
-//! Computads in dimension one.
+/*! Computads in dimension one.
+
+A 1-computad, in the strictest sense of the term, is the generating data for a
+free category, which is just a [graph](super::graph). This module provides
+simple data structures to aid in defining computads for categories with extra
+structure. For example, a computad for monoidal categories is called a "tensor
+scheme" by Joyal and Street and a "pre-net" in the Petri net literature.
+ */
 
 use std::hash::{BuildHasher, Hash};
 
@@ -34,7 +41,11 @@ where
     }
 }
 
-/// TODO
+/** A 1-computad.
+
+The set of objects is assumed already constructed, possibly from other
+generating data, while the top-dimensional generating data is provided directly.
+ */
 #[derive(Constructor)]
 pub struct Computad<'a, Ob, ObSet, E, S> {
     objects: &'a ObSet,

--- a/packages/catlog/src/one/computad.rs
+++ b/packages/catlog/src/one/computad.rs
@@ -3,6 +3,7 @@
 use std::hash::{BuildHasher, Hash};
 
 use derivative::Derivative;
+use derive_more::Constructor;
 
 use super::graph::ColumnarGraph;
 use crate::zero::*;
@@ -34,7 +35,11 @@ where
 }
 
 /// TODO
-pub struct Computad<'a, Ob, ObSet, E, S>(pub &'a ObSet, pub &'a ComputadTop<Ob, E, S>);
+#[derive(Constructor)]
+pub struct Computad<'a, Ob, ObSet, E, S> {
+    objects: &'a ObSet,
+    computad: &'a ComputadTop<Ob, E, S>,
+}
 
 impl<'a, Ob, ObSet, E, S> ColumnarGraph for Computad<'a, Ob, ObSet, E, S>
 where
@@ -51,15 +56,15 @@ where
     type Tgt = HashColumn<E, Ob, S>;
 
     fn vertex_set(&self) -> &Self::Vertices {
-        self.0
+        self.objects
     }
     fn edge_set(&self) -> &Self::Edges {
-        &self.1.edges
+        &self.computad.edges
     }
     fn src_map(&self) -> &Self::Src {
-        &self.1.src
+        &self.computad.src
     }
     fn tgt_map(&self) -> &Self::Tgt {
-        &self.1.tgt
+        &self.computad.tgt
     }
 }

--- a/packages/catlog/src/one/computad.rs
+++ b/packages/catlog/src/one/computad.rs
@@ -5,15 +5,18 @@ use std::hash::{BuildHasher, Hash, RandomState};
 use super::graph::ColumnarGraph;
 use crate::zero::*;
 
-/// TODO
-pub struct ComputadEdges<Ob, E, S = RandomState> {
+/** Top-dimensional data of a 1-computad.
+
+Intended for use with [`Computad`].
+ */
+pub struct ComputadTop<Ob, E, S = RandomState> {
     edges: HashFinSet<E, S>,
     src: HashColumn<E, Ob, S>,
     tgt: HashColumn<E, Ob, S>,
 }
 
 /// TODO
-pub struct Computad<'a, Ob, ObSet, E, S>(pub &'a ObSet, pub &'a ComputadEdges<Ob, E, S>);
+pub struct Computad<'a, Ob, ObSet, E, S>(pub &'a ObSet, pub &'a ComputadTop<Ob, E, S>);
 
 impl<'a, Ob, ObSet, E, S> ColumnarGraph for Computad<'a, Ob, ObSet, E, S>
 where

--- a/packages/catlog/src/one/fp_category.rs
+++ b/packages/catlog/src/one/fp_category.rs
@@ -176,8 +176,8 @@ where
     /// Iterates over failures to be a well-defined presentation of a category.
     pub fn iter_invalid(&self) -> impl Iterator<Item = InvalidFpCategory<E>> + '_ {
         let generator_errors = self.generators.iter_invalid().map(|err| match err {
-            InvalidGraphData::Src(e) => InvalidFpCategory::Dom(e),
-            InvalidGraphData::Tgt(e) => InvalidFpCategory::Cod(e),
+            InvalidGraph::Src(e) => InvalidFpCategory::Dom(e),
+            InvalidGraph::Tgt(e) => InvalidFpCategory::Cod(e),
         });
         let equation_errors = self.equations.iter().enumerate().flat_map(|(i, eq)| {
             eq.iter_invalid_in(&self.generators).map(move |err| match err {

--- a/packages/catlog/src/one/functor.rs
+++ b/packages/catlog/src/one/functor.rs
@@ -16,6 +16,7 @@ evaluate functions or graph morphisms.
 
 use std::hash::{BuildHasher, Hash};
 
+use derive_more::Constructor;
 use nonempty::NonEmpty;
 use ref_cast::RefCast;
 use thiserror::Error;
@@ -122,7 +123,7 @@ codomain category's underlying graph.
 You can't do much with this data until it is [interpreted as a
 functor](Self::functor_into) into a specific category.
  */
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Constructor)]
 pub struct FpFunctorData<ObGenMap, MorGenMap> {
     /// Mapping on object generators.
     pub ob_generator_map: ObGenMap,
@@ -132,14 +133,6 @@ pub struct FpFunctorData<ObGenMap, MorGenMap> {
 }
 
 impl<ObGenMap, MorGenMap> FpFunctorData<ObGenMap, MorGenMap> {
-    /// Constructs from given mappings on object and morphism generators.
-    pub fn new(ob_generator_map: ObGenMap, mor_generator_map: MorGenMap) -> Self {
-        Self {
-            ob_generator_map,
-            mor_generator_map,
-        }
-    }
-
     /// Interprets the data as a functor into the given category.
     pub fn functor_into<'a, Cod>(&'a self, cod: &'a Cod) -> FpFunctor<'a, Self, Cod> {
         FpFunctor::new(self, cod)
@@ -173,6 +166,7 @@ a [`Mapping`] between sets, a codomain is needed not just for validation but to
 even evaluate the functor on morphisms, hence is required as extra data. The
 domain category is needed only for validation.
  */
+#[derive(Constructor)]
 pub struct FpFunctor<'a, Map, Cod> {
     map: &'a Map,
     cod: &'a Cod,
@@ -248,13 +242,6 @@ where
             Path::Id(v) => self.0.map.is_vertex_assigned(v),
             Path::Seq(edges) => edges.iter().all(|e| self.0.map.is_edge_assigned(e)),
         }
-    }
-}
-
-impl<'a, Map, Cod> FpFunctor<'a, Map, Cod> {
-    /// Constructs a new functor out of an f.p. category.
-    pub fn new(map: &'a Map, cod: &'a Cod) -> Self {
-        Self { map, cod }
     }
 }
 

--- a/packages/catlog/src/one/graph.rs
+++ b/packages/catlog/src/one/graph.rs
@@ -8,6 +8,7 @@ theory.
 
 use std::hash::{BuildHasher, BuildHasherDefault, Hash, RandomState};
 
+use derive_more::From;
 use derivative::Derivative;
 use nonempty::NonEmpty;
 use ref_cast::RefCast;
@@ -96,6 +97,28 @@ pub trait FinGraph: Graph {
      */
     fn degree(&self, v: &Self::V) -> usize {
         self.in_degree(v) + self.out_degree(v)
+    }
+}
+
+/// The set of vertices of a graph.
+#[derive(From, RefCast)]
+#[repr(transparent)]
+pub struct VertexSet<G>(G);
+
+impl<G: Graph> Set for VertexSet<G> {
+    type Elem = G::V;
+
+    fn contains(&self, v: &Self::Elem) -> bool {
+        self.0.has_vertex(v)
+    }
+}
+
+impl<G: FinGraph> FinSet for VertexSet<G> {
+    fn iter(&self) -> impl Iterator<Item = Self::Elem> {
+        self.0.vertices()
+    }
+    fn len(&self) -> usize {
+        self.0.vertex_count()
     }
 }
 
@@ -727,6 +750,13 @@ mod tests {
         g.set_tgt("fg", 'z');
         assert_eq!(g.src(&"fg"), 'x');
         assert_eq!(g.tgt(&"fg"), 'z');
+    }
+
+    #[test]
+    fn vertex_set() {
+        let set: VertexSet<_> = SkelGraph::triangle().into();
+        assert!(set.contains(&2));
+        assert_eq!(set.len(), 3);
     }
 
     #[test]

--- a/packages/catlog/src/one/graph.rs
+++ b/packages/catlog/src/one/graph.rs
@@ -169,6 +169,21 @@ pub trait ColumnarGraph {
 
     /// Gets the mapping assignment a target vertex to each edge.
     fn tgt_map(&self) -> &Self::Tgt;
+
+    /// Iterates over failures to be a valid graph.
+    fn iter_invalid(&self) -> impl Iterator<Item = InvalidGraph<Self::E>>
+    where
+        Self::Edges: FinSet<Elem = Self::E>,
+    {
+        let (dom, cod) = (self.edge_set(), self.vertex_set());
+        let srcs = Function(self.src_map(), dom, cod)
+            .iter_invalid()
+            .map(|e| InvalidGraph::Src(e.take()));
+        let tgts = Function(self.tgt_map(), dom, cod)
+            .iter_invalid()
+            .map(|e| InvalidGraph::Tgt(e.take()));
+        srcs.chain(tgts)
+    }
 }
 
 /** A finite graph backed by columns.
@@ -185,17 +200,6 @@ pub trait ColumnarFinGraph:
         Tgt: Column<Dom = Self::E, Cod = Self::V>,
     >
 {
-    /// Iterates over failures to be a valid graph.
-    fn iter_invalid(&self) -> impl Iterator<Item = InvalidGraph<Self::E>> {
-        let (dom, cod) = (self.edge_set(), self.vertex_set());
-        let srcs = Function(self.src_map(), dom, cod)
-            .iter_invalid()
-            .map(|e| InvalidGraph::Src(e.take()));
-        let tgts = Function(self.tgt_map(), dom, cod)
-            .iter_invalid()
-            .map(|e| InvalidGraph::Tgt(e.take()));
-        srcs.chain(tgts)
-    }
 }
 
 /// A columnar graph with mutable columns.

--- a/packages/catlog/src/one/graph.rs
+++ b/packages/catlog/src/one/graph.rs
@@ -8,8 +8,8 @@ theory.
 
 use std::hash::{BuildHasher, BuildHasherDefault, Hash, RandomState};
 
-use derive_more::From;
 use derivative::Derivative;
+use derive_more::From;
 use nonempty::NonEmpty;
 use ref_cast::RefCast;
 use thiserror::Error;
@@ -44,8 +44,7 @@ pub trait Graph {
     fn tgt(&self, e: &Self::E) -> Self::V;
 }
 
-/** A graph with finitely many vertices and edges.
- */
+/// A graph with finitely many vertices and edges.
 pub trait FinGraph: Graph {
     /// Iterates over the vertices in the graph.
     fn vertices(&self) -> impl Iterator<Item = Self::V>;
@@ -98,6 +97,15 @@ pub trait FinGraph: Graph {
     fn degree(&self, v: &Self::V) -> usize {
         self.in_degree(v) + self.out_degree(v)
     }
+}
+
+/** A reflexive graph.
+
+A **reflexive graph** is a graph equipped with a distinguished self-loop on each vertex.
+ */
+pub trait ReflexiveGraph: Graph {
+    /// Gets the reflexive loop at a vertex.
+    fn refl(&self, v: Self::V) -> Self::E;
 }
 
 /// The set of vertices of a graph.

--- a/packages/catlog/src/one/graph.rs
+++ b/packages/catlog/src/one/graph.rs
@@ -186,14 +186,14 @@ pub trait ColumnarFinGraph:
     >
 {
     /// Iterates over failures to be a valid graph.
-    fn iter_invalid(&self) -> impl Iterator<Item = InvalidGraphData<Self::E>> {
+    fn iter_invalid(&self) -> impl Iterator<Item = InvalidGraph<Self::E>> {
         let (dom, cod) = (self.edge_set(), self.vertex_set());
         let srcs = Function(self.src_map(), dom, cod)
             .iter_invalid()
-            .map(|e| InvalidGraphData::Src(e.take()));
+            .map(|e| InvalidGraph::Src(e.take()));
         let tgts = Function(self.tgt_map(), dom, cod)
             .iter_invalid()
-            .map(|e| InvalidGraphData::Tgt(e.take()));
+            .map(|e| InvalidGraph::Tgt(e.take()));
         srcs.chain(tgts)
     }
 }
@@ -273,13 +273,13 @@ impl<G: ColumnarFinGraph> FinGraph for G {
     }
 }
 
-/** An invalid assignment in a graph defined explicitly by data.
+/** An invalid assignment in a graph.
 
-For [columnar graphs](ColumnarGraph) and other such graphs, it is possible that
-the data is incomplete or inconsistent.
+For [columnar graphs](ColumnarGraph) and other graphs defined explicitly by
+data, it is possible that the data is incomplete or inconsistent.
 */
 #[derive(Debug, Error)]
-pub enum InvalidGraphData<E> {
+pub enum InvalidGraph<E> {
     /// Edge assigned a source that is not a vertex contained in the graph.
     #[error("Source of edge `{0}` is not a vertex in the graph")]
     Src(E),
@@ -399,7 +399,7 @@ impl SkelGraph {
 }
 
 impl Validate for SkelGraph {
-    type ValidationError = InvalidGraphData<usize>;
+    type ValidationError = InvalidGraph<usize>;
 
     fn validate(&self) -> Result<(), NonEmpty<Self::ValidationError>> {
         validate::wrap_errors(self.iter_invalid())
@@ -516,7 +516,7 @@ where
     E: Eq + Hash + Clone,
     S: BuildHasher,
 {
-    type ValidationError = InvalidGraphData<E>;
+    type ValidationError = InvalidGraph<E>;
 
     fn validate(&self) -> Result<(), NonEmpty<Self::ValidationError>> {
         validate::wrap_errors(self.iter_invalid())

--- a/packages/catlog/src/one/graph.rs
+++ b/packages/catlog/src/one/graph.rs
@@ -9,7 +9,7 @@ theory.
 use std::hash::{BuildHasher, BuildHasherDefault, Hash, RandomState};
 
 use derivative::Derivative;
-use derive_more::From;
+use derive_more::{Constructor, From};
 use nonempty::NonEmpty;
 use ref_cast::RefCast;
 use thiserror::Error;
@@ -672,20 +672,10 @@ pub enum InvalidGraphMorphism<V, E> {
 That is, the data of the graph mapping is defined by two columns. The mapping
 can be between arbitrary graphs with compatible vertex and edge types.
 */
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Constructor)]
 pub struct ColumnarGraphMapping<VMap, EMap> {
     vertex_map: VMap,
     edge_map: EMap,
-}
-
-impl<VMap, EMap> ColumnarGraphMapping<VMap, EMap> {
-    /// Constructs a graph mapping from given vertex and edge mappings.
-    pub fn new(vertex_map: VMap, edge_map: EMap) -> Self {
-        Self {
-            vertex_map,
-            edge_map,
-        }
-    }
 }
 
 impl<VMap, EMap> GraphMapping for ColumnarGraphMapping<VMap, EMap>

--- a/packages/catlog/src/one/mod.rs
+++ b/packages/catlog/src/one/mod.rs
@@ -1,6 +1,7 @@
 //! Category theory in dimension one, plus a little graph theory.
 
 pub mod category;
+pub mod computad;
 pub mod fp_category;
 pub mod functor;
 pub mod graph;

--- a/packages/catlog/src/one/path.rs
+++ b/packages/catlog/src/one/path.rs
@@ -514,6 +514,28 @@ impl<V, E> ShortPath<V, E> {
         }
     }
 
+    /// Source of the path in the given graph.
+    pub fn src(&self, graph: &impl Graph<V = V, E = E>) -> V
+    where
+        V: Clone,
+    {
+        match self {
+            ShortPath::Zero(v) => v.clone(),
+            ShortPath::One(e) => graph.src(e),
+        }
+    }
+
+    /// Target of the path in the given graph.
+    pub fn tgt(&self, graph: &impl Graph<V = V, E = E>) -> V
+    where
+        V: Clone,
+    {
+        match self {
+            ShortPath::Zero(v) => v.clone(),
+            ShortPath::One(e) => graph.tgt(e),
+        }
+    }
+
     /// Converts the short path into an edge in the given *reflexive* graph.
     pub fn to_edge_in(self, graph: &impl ReflexiveGraph<V = V, E = E>) -> E {
         match self {

--- a/packages/catlog/src/one/path.rs
+++ b/packages/catlog/src/one/path.rs
@@ -485,6 +485,16 @@ pub enum ShortPath<V, E> {
     One(E),
 }
 
+/// A short path in a graph with skeletal vertex and edge sets.
+pub type SkelShortPath = ShortPath<usize, usize>;
+
+/// Converts an edge into a short path of length one.
+impl<V, E> From<E> for ShortPath<V, E> {
+    fn from(e: E) -> Self {
+        ShortPath::One(e)
+    }
+}
+
 impl<V, E> From<ShortPath<V, E>> for Path<V, E> {
     fn from(path: ShortPath<V, E>) -> Self {
         match path {
@@ -664,7 +674,7 @@ mod tests {
     fn short_paths() {
         let (v, e) = (1, 1);
         let path: SkelPath = ShortPath::Zero(v).into();
-        assert_eq!(path.try_into(), Ok(ShortPath::Zero(v)));
+        assert_eq!(path.try_into(), Ok(SkelShortPath::Zero(v)));
         let path: SkelPath = ShortPath::One(e).into();
         assert_eq!(path.clone().only(), Some(e));
         assert_eq!(path.try_into(), Ok(ShortPath::One(e)));

--- a/packages/catlog/src/one/path.rs
+++ b/packages/catlog/src/one/path.rs
@@ -8,7 +8,7 @@ addition, this module provides data types for ["short paths"](`ShortPath`) and
 use std::ops::Range;
 use std::{collections::HashSet, hash::Hash};
 
-use derive_more::From;
+use derive_more::{Constructor, From};
 use itertools::{Either, Itertools};
 use nonempty::{NonEmpty, nonempty};
 
@@ -552,7 +552,7 @@ impl<V, E> ShortPath<V, E> {
 }
 
 /// Assertion of an equation between the composites of two paths in a category.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Constructor)]
 pub struct PathEq<V, E> {
     /// Left hand side of equation.
     pub lhs: Path<V, E>,
@@ -562,11 +562,6 @@ pub struct PathEq<V, E> {
 }
 
 impl<V, E> PathEq<V, E> {
-    /// Constructs a path equation with the given left- and right-hand sides.
-    pub fn new(lhs: Path<V, E>, rhs: Path<V, E>) -> PathEq<V, E> {
-        PathEq { lhs, rhs }
-    }
-
     /** Source of the path equation in the given graph.
 
     Panics if the two sides of the path equation have different sources.

--- a/packages/catlog/src/stdlib/theories.rs
+++ b/packages/catlog/src/stdlib/theories.rs
@@ -160,7 +160,14 @@ fn th_monad_algebra(mode: Mode) -> UstrModalDblTheory {
     let (x, a) = (ustr("Object"), ustr("Mul"));
     th.add_ob_type(x);
     th.add_ob_op(a, ModeApp::new(x).apply(mode), ModeApp::new(x));
-    // TODO: Monad algebra equations
+    th.equate_ob_ops(
+        Path::pair(ModeApp::new(a.into()).apply(mode), ModeApp::new(a.into())),
+        Path::pair(ModeApp::new(ModalEdge::Mul(mode, 2, ModeApp::new(x))), ModeApp::new(a.into())),
+    );
+    th.equate_ob_ops(
+        Path::empty(ModeApp::new(x)),
+        Path::pair(ModeApp::new(ModalEdge::Mul(mode, 0, ModeApp::new(x))), ModeApp::new(a.into())),
+    );
     th
 }
 

--- a/packages/catlog/src/stdlib/theories.rs
+++ b/packages/catlog/src/stdlib/theories.rs
@@ -2,7 +2,6 @@
 
 use ustr::ustr;
 
-use crate::dbl::modal::theory::{ModalObType, Mode, UstrModalDblTheory};
 use crate::dbl::theory::*;
 use crate::one::{Path, fp_category::UstrFpCategory};
 
@@ -142,6 +141,11 @@ pub fn th_monoidal_category() -> UstrModalDblTheory {
     th_monad_algebra(Mode::List)
 }
 
+/// The theory of lax monoidal categories.
+pub fn th_lax_monoidal_category() -> UstrModalDblTheory {
+    th_monad_lax_algebra(Mode::List)
+}
+
 /// The theory of strict symmetric monoidal categories.
 pub fn th_sym_monoidal_category() -> UstrModalDblTheory {
     th_monad_algebra(Mode::SymList)
@@ -150,14 +154,33 @@ pub fn th_sym_monoidal_category() -> UstrModalDblTheory {
 /** The theory of a strict monad algebra.
 
 This is a modal double theory, parametric over the monad used.
-
-TODO: Monad algebra equations
  */
 fn th_monad_algebra(mode: Mode) -> UstrModalDblTheory {
     let mut th: UstrModalDblTheory = Default::default();
     let (x, a) = (ustr("Object"), ustr("Mul"));
     th.add_ob_type(x);
-    th.add_ob_op(a, ModalObType::new(x).apply(mode), ModalObType::new(x));
+    th.add_ob_op(a, ModeApp::new(x).apply(mode), ModeApp::new(x));
+    // TODO: Monad algebra equations
+    th
+}
+
+/// The theory of a lax monad algebra.
+fn th_monad_lax_algebra(mode: Mode) -> UstrModalDblTheory {
+    let mut th: UstrModalDblTheory = Default::default();
+    let (x, a) = (ustr("Object"), ustr("Mul"));
+    th.add_ob_type(x);
+    th.add_ob_op(a, ModeApp::new(x).apply(mode), ModeApp::new(x));
+    th.add_special_mor_op(
+        ustr("Associator"),
+        Path::pair(ModeApp::new(a.into()).apply(mode), ModeApp::new(a.into())),
+        Path::pair(ModeApp::new(ModalEdge::Mul(mode, 2, ModeApp::new(x))), ModeApp::new(a.into())),
+    );
+    th.add_special_mor_op(
+        ustr("Unitor"),
+        Path::empty(ModeApp::new(x)),
+        Path::pair(ModeApp::new(ModalEdge::Mul(mode, 0, ModeApp::new(x))), ModeApp::new(a.into())),
+    );
+    // TODO: Coherence equations
     th
 }
 
@@ -187,6 +210,7 @@ mod tests {
     #[test]
     fn validate_modal_theories() {
         assert!(th_monoidal_category().validate().is_ok());
+        assert!(th_lax_monoidal_category().validate().is_ok());
     }
 
     #[test]

--- a/packages/catlog/src/stdlib/theories.rs
+++ b/packages/catlog/src/stdlib/theories.rs
@@ -2,6 +2,7 @@
 
 use ustr::ustr;
 
+use crate::dbl::modal::theory::{ModalObType, Mode, UstrModalDblTheory};
 use crate::dbl::theory::*;
 use crate::one::{Path, fp_category::UstrFpCategory};
 
@@ -136,6 +137,30 @@ pub fn th_category_links() -> UstrDiscreteTabTheory {
     th
 }
 
+/// The theory of strict monoidal categories.
+pub fn th_monoidal_category() -> UstrModalDblTheory {
+    th_monad_algebra(Mode::List)
+}
+
+/// The theory of strict symmetric monoidal categories.
+pub fn th_sym_monoidal_category() -> UstrModalDblTheory {
+    th_monad_algebra(Mode::SymList)
+}
+
+/** The theory of a strict monad algebra.
+
+This is a modal double theory, parametric over the monad used.
+
+TODO: Monad algebra equations
+ */
+fn th_monad_algebra(mode: Mode) -> UstrModalDblTheory {
+    let mut th: UstrModalDblTheory = Default::default();
+    let (x, a) = (ustr("Object"), ustr("Mul"));
+    th.add_ob_type(x);
+    th.add_ob_op(a, ModalObType::new(x).apply(mode), ModalObType::new(x));
+    th
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -143,7 +168,7 @@ mod tests {
     use nonempty::nonempty;
 
     #[test]
-    fn validate_theories() {
+    fn validate_discrete_theories() {
         assert!(th_empty().validate().is_ok());
         assert!(th_category().validate().is_ok());
         assert!(th_schema().validate().is_ok());
@@ -151,8 +176,17 @@ mod tests {
         assert!(th_delayable_signed_category().validate().is_ok());
         assert!(th_nullable_signed_category().validate().is_ok());
         assert!(th_category_with_scalars().validate().is_ok());
-        // TODO: Validate discrete tabulator theories.
+    }
+
+    #[test]
+    fn validate_discrete_tabulator_theories() {
+        // TODO: Implementation validation for discrete tabulator theories.
         th_category_links();
+    }
+
+    #[test]
+    fn validate_modal_theories() {
+        assert!(th_monoidal_category().validate().is_ok());
     }
 
     #[test]

--- a/packages/catlog/src/zero/column.rs
+++ b/packages/catlog/src/zero/column.rs
@@ -5,7 +5,7 @@ use std::hash::{BuildHasher, BuildHasherDefault, Hash, RandomState};
 use std::marker::PhantomData;
 
 use derivative::Derivative;
-use derive_more::From;
+use derive_more::{Constructor, From};
 use nonempty::NonEmpty;
 use thiserror::Error;
 use ustr::{IdentityHasher, Ustr};
@@ -338,7 +338,7 @@ impl<T: Eq + Clone> Column for VecColumn<T> {
 impl<T: Eq + Clone> MutColumn for VecColumn<T> {}
 
 /// An unindexed column backed by a hash map.
-#[derive(Clone, From, Debug, Derivative)]
+#[derive(Clone, Debug, Derivative, Constructor, From)]
 #[derivative(Default(bound = "S: Default"))]
 #[derivative(PartialEq(bound = "K: Eq + Hash, V: PartialEq, S: BuildHasher"))]
 #[derivative(Eq(bound = "K: Eq + Hash, V: Eq, S: BuildHasher"))]
@@ -346,13 +346,6 @@ pub struct HashColumn<K, V, S = RandomState>(HashMap<K, V, S>);
 
 /// An unindexed column with keys of type `Ustr`.
 pub type UstrColumn<V> = HashColumn<Ustr, V, BuildHasherDefault<IdentityHasher>>;
-
-impl<K, V, S> HashColumn<K, V, S> {
-    /// Creates a new hash column from an existing hash map.
-    pub fn new(map: HashMap<K, V, S>) -> Self {
-        Self(map)
-    }
-}
 
 impl<K, V, S> IntoIterator for HashColumn<K, V, S> {
     type Item = (K, V);


### PR DESCRIPTION
This PR implements the first non-discrete double theories, what I'm currently calling "modal double theories." In the representable case, these would be strict double categories equipped with strict double monads. Though some features are missing, this enough to define double theories for strict monoidal categories and also (minus the coherence equations) for pseudo/lax double categories.

Along the way, this PR also:

- Adds simple data structures for 1-computads and virtual double computads (double categories were first attempted in #9 and later removed in #428)
- Adds a helper data structure `ShortPath` for paths of length at most one
- Create a unified validation error type for double theories

Wasm binding and frontend integration will follow, as will models of such theories.