### PR TITLE
Push forward models along theory inclusions in frontend

### DIFF
--- a/packages/frontend/src/model/model_editor.tsx
+++ b/packages/frontend/src/model/model_editor.tsx
@@ -81,10 +81,17 @@ export function ModelDocumentEditor(props: {
 export function ModelPane(props: {
     liveModel: LiveModelDocument;
 }) {
-    const theories = useContext(TheoryLibraryContext);
-    invariant(theories, "Library of theories should be provided as context");
-
     const liveDoc = () => props.liveModel.liveDoc;
+
+    const selectableTheories = () => {
+        console.log(props.liveModel.theory().inclusions);
+        if (liveDoc().doc.notebook.cells.some((cell) => cell.tag === "formal")) {
+            return props.liveModel.theory().inclusions;
+        } else {
+            // If the model has no formal cells, allow any theory to be selected.
+            return undefined;
+        }
+    };
 
     return (
         <div class="notebook-container">
@@ -107,8 +114,7 @@ export function ModelPane(props: {
                             model.theory = id;
                         });
                     }}
-                    theories={theories}
-                    disabled={liveDoc().doc.notebook.cells.some((cell) => cell.tag === "formal")}
+                    theories={selectableTheories()}
                 />
             </div>
             <ModelNotebookEditor liveModel={props.liveModel} />

--- a/packages/frontend/src/model/theory_selector.css
+++ b/packages/frontend/src/model/theory_selector.css
@@ -7,7 +7,6 @@
     text-align: left;
     border-top: transparent;
     border-left: transparent;
-    min-height: 30vh;
 
     & input[type="radio"] {
         position: absolute;

--- a/packages/frontend/src/model/theory_selector.tsx
+++ b/packages/frontend/src/model/theory_selector.tsx
@@ -1,21 +1,18 @@
 import Dialog from "@corvu/dialog";
-import { For, createMemo, createSignal } from "solid-js";
+import { For, createMemo, createSignal, useContext } from "solid-js";
+import invariant from "tiny-invariant";
 
-import type { TheoryLibrary, TheoryMeta } from "../stdlib";
+import { TheoryLibraryContext, type TheoryMeta } from "../stdlib";
 
 import "./theory_selector.css";
 
 type TheorySelectorProps = {
     theory: TheoryMeta;
     setTheory: (theoryId: string) => void;
-    theories: TheoryLibrary;
+    theories?: string[];
 };
 
-export function TheorySelectorDialog(
-    props: {
-        disabled?: boolean;
-    } & TheorySelectorProps,
-) {
+export function TheorySelectorDialog(props: TheorySelectorProps) {
     const [theorySelectorOpen, setTheorySelectorOpen] = createSignal(false);
 
     return (
@@ -23,7 +20,7 @@ export function TheorySelectorDialog(
             <Dialog.Trigger
                 as="a"
                 class="theory-selector-trigger"
-                data-disabled={props.disabled ? true : undefined}
+                data-disabled={props.theories?.length === 0 ? true : undefined}
             >
                 {props.theory.name}
             </Dialog.Trigger>
@@ -45,8 +42,11 @@ export function TheorySelectorDialog(
 }
 
 export function TheorySelector(props: TheorySelectorProps) {
+    const theories = useContext(TheoryLibraryContext);
+    invariant(theories, "Library of theories should be provided as context");
+
     const groupedTheories = createMemo(() =>
-        Array.from(props.theories.groupedMetadata().entries()),
+        Array.from(theories.groupedMetadata(props.theories).entries()),
     );
 
     return (

--- a/packages/frontend/src/stdlib/theories.tsx
+++ b/packages/frontend/src/stdlib/theories.tsx
@@ -224,6 +224,7 @@ stdTheories.add(
         return new Theory({
             ...meta,
             theory: thSignedCategory.theory(),
+            inclusions: ["causal-loop", "causal-loop-delays", "indeterminate-causal-loop"],
             onlyFreeModels: true,
             modelTypes: [
                 {
@@ -303,6 +304,7 @@ stdTheories.add(
         return new Theory({
             ...meta,
             theory: thSignedCategory.theory(),
+            inclusions: ["reg-net", "causal-loop-delays", "indeterminate-causal-loop"],
             onlyFreeModels: true,
             modelTypes: [
                 {

--- a/packages/frontend/src/stdlib/types.ts
+++ b/packages/frontend/src/stdlib/types.ts
@@ -100,15 +100,25 @@ export class TheoryLibrary {
         return this.get(this.defaultTheoryId);
     }
 
-    /** Iterator over metadata for available theories. */
-    metadata(): IterableIterator<TheoryMeta> {
+    /** Gets metadata for a theory by ID. */
+    getMetadata(id: string): TheoryMeta {
+        const meta = this.metaMap.get(id);
+        if (meta === undefined) {
+            throw new Error(`No theory with ID ${id}`);
+        }
+        return meta;
+    }
+
+    /** Gets metadata for all available theories. */
+    allMetadata(): IterableIterator<TheoryMeta> {
         return this.metaMap.values();
     }
 
-    /** Metadata for available theories, clustered by group. */
-    groupedMetadata(): Map<string, TheoryMeta[]> {
+    /** Gets metadata for theories clustered by group. */
+    groupedMetadata(ids?: string[]): Map<string, TheoryMeta[]> {
+        const theories = ids?.map((id) => this.getMetadata(id)) ?? this.allMetadata();
         const grouped = new Map<string, TheoryMeta[]>();
-        for (const theory of this.metadata()) {
+        for (const theory of theories) {
             const groupName = theory.group ?? "Other";
             const group = grouped.get(groupName) || [];
             group.push(theory);

--- a/packages/frontend/src/theory/types.ts
+++ b/packages/frontend/src/theory/types.ts
@@ -34,6 +34,12 @@ export class Theory {
      */
     readonly description: string;
 
+    /** List of IDs of theories that this theory includes into.
+
+    Migrations along such inclusions are trivial.
+     */
+    readonly inclusions: string[];
+
     /** Whether models of the double theory are constrained to be free. */
     readonly onlyFreeModels!: boolean;
 
@@ -46,10 +52,10 @@ export class Theory {
     private readonly modelTypeMeta: TypeMetadata<ModelObTypeMeta, ModelMorTypeMeta>;
     private readonly instanceTypeMeta: TypeMetadata<InstanceObTypeMeta, InstanceMorTypeMeta>;
 
-    /** Map from theory ID to model analysis metadata. */
+    /** Map from IDs of model analyses to their metadata. */
     private readonly modelAnalysisMap: Map<string, ModelAnalysisMeta>;
 
-    /** Map from theory ID to diagram analysis metadata. */
+    /** Map from IDs of diagram analyses to their metadata. */
     private readonly diagramAnalysisMap: Map<string, DiagramAnalysisMeta>;
 
     constructor(props: {
@@ -58,6 +64,7 @@ export class Theory {
         help?: string;
         name: string;
         description: string;
+        inclusions?: string[];
         modelTypes?: ModelTypeMeta[];
         modelAnalyses?: ModelAnalysisMeta[];
         onlyFreeModels?: boolean;
@@ -69,6 +76,7 @@ export class Theory {
         this.id = props.id;
         this.theory = props.theory;
         this.help = props.help;
+        this.inclusions = props.inclusions ?? [];
 
         // Models.
         this.name = props.name;


### PR DESCRIPTION
Support in the frontend for the simplest form of pushforward model migration, which does not require changing the underlying data, only the theory tag.