### PR TITLE
Add email, zulip, invitation to gh issues on help page

### DIFF
--- a/packages/frontend/src/help/index.mdx
+++ b/packages/frontend/src/help/index.mdx
@@ -19,6 +19,13 @@ to preserve the integrity of your data but you should not store anything
 critical or sensitive.
 </Warning>
 
+## Contact us
+
+- You can reach us via email [here](mailto:catcolab@topos.institute)
+with any questions, comments, or suggestions.
+- You can also join our [Zulip chat](https://catcolab.zulipchat.com/join/ma57lx2yclmkfgen4eft4ias/) to discuss CatColab with the community and the developers. This is our preferred venue for discussions of technical details.
+- All community members are welcome to post new issues on our [GitHub](https://github.com/ToposInstitute/CatColab).
+
 ## Concepts
 
 While CatColab has a notebook-style interface inspired by computational


### PR DESCRIPTION
The `catcolab@topos.institute` box hasn't been publicized yet (and I forgot about it till today.) @quffaro is about to finish the splash page and we agreed the email doesn't need to go there, so I've stuck it on the help page, along with suggestions to ask questions on Zulip or GitHub instead. This will cause a little merge conflict with @tim-at-topos's more substantial docs changes if we merge it first, so Tim should probably confirm whether he's already subsuming this change.