### PR TITLE
Fix URLs for dev docs sections

### DIFF
--- a/dev-docs/trees/dev-0001.tree
+++ b/dev-docs/trees/dev-0001.tree
@@ -1,7 +1,7 @@
 \title{CatColab: Developer Documentation}
 \import{macros}
 
-\subtree{
+\subtree[api]{
 \title{API Documentation}
 
 \ul{
@@ -10,7 +10,7 @@
 }
 }
 
-\subtree{
+\subtree[mathematics]{
 \title{Mathematics}
 
 \p{Doctrines whose free objects have a systems interpretation:}
@@ -35,7 +35,7 @@
 }
 }
 
-\subtree{
+\subtree[technology]{
 \title{Technology}
 
 \ul{


### PR DESCRIPTION
I think this should mean that the following three URLs now work:

- https://next.catcolab.org/dev/api.xml
- https://next.catcolab.org/dev/mathematics.xml
- https://next.catcolab.org/dev/technologyxml

which would be helpful for making nice links to things (especially in https://github.com/ToposInstitute/CatColab/pull/553)

@olynch is this indeed the right way to make this happen?