### PR TITLE
FIX: Menu not working in some error states

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -17,7 +17,7 @@ import { helpRoutes } from "./help/routes";
 import { createModel } from "./model/document";
 import { PageContainer } from "./page/page_container";
 import { TheoryLibraryContext, stdTheories } from "./stdlib";
-import { ErrorBoundaryDialog } from "./util/errors";
+import { ErrorBoundaryMessage } from "./util/errors";
 
 const serverUrl = import.meta.env.VITE_SERVER_URL;
 const repoUrl = import.meta.env.VITE_AUTOMERGE_REPO_URL;
@@ -68,7 +68,7 @@ const Root = (props: RouteSectionProps<unknown>) => {
             ]}
         >
             <FirebaseProvider app={firebaseApp}>
-                <ErrorBoundary fallback={(err) => <ErrorBoundaryDialog error={err} />}>
+                <ErrorBoundary fallback={(err) => <ErrorBoundaryMessage error={err} />}>
                     <PageContainer>{props.children}</PageContainer>
                 </ErrorBoundary>
                 <Show when={isSessionInvalid()}>
@@ -104,7 +104,6 @@ export function SessionExpiredModal() {
 
 function CreateModel() {
     const api = useApi();
-
     const theoryId = stdTheories.getDefault().id;
     const [ref] = createResource<string>(() => createModel(api, theoryId));
 
@@ -166,7 +165,7 @@ function App() {
     // We need two "top-level" error boundaries in order to display the SessionExpiredModal even after an
     // error occurs, while also catching error created by the router or other providers
     return (
-        <ErrorBoundary fallback={(err) => <ErrorBoundaryDialog error={err} />}>
+        <ErrorBoundary fallback={(err) => <ErrorBoundaryMessage error={err} />}>
             <Router root={Root}>{routes}</Router>
         </ErrorBoundary>
     );

--- a/packages/frontend/src/model/model_editor.tsx
+++ b/packages/frontend/src/model/model_editor.tsx
@@ -38,6 +38,7 @@ import {
 import "./model_editor.css";
 
 export default function ModelPage() {
+    throw "an error";
     const api = useApi();
     const theories = useContext(TheoryLibraryContext);
     invariant(theories, "Must provide theory library as context to model page");

--- a/packages/frontend/src/page/page_container.tsx
+++ b/packages/frontend/src/page/page_container.tsx
@@ -1,9 +1,10 @@
-import { type JSX, createSignal } from "solid-js";
+import { ErrorBoundary, type JSX, createSignal } from "solid-js";
 
 import { Dialog } from "../components";
 import { Login } from "../user";
 import { type PageActions, PageActionsContext } from "./context";
 import { ImportDocument } from "./import_document";
+import { ErrorBoundaryPage } from "../util/errors";
 
 /** Container for any page in the application.
 
@@ -25,7 +26,9 @@ export function PageContainer(props: {
     return (
         <>
             <PageActionsContext.Provider value={actions}>
-                {props.children}
+                <ErrorBoundary fallback={(err) => <ErrorBoundaryPage error={err} />}>
+                    {props.children}
+                </ErrorBoundary>
             </PageActionsContext.Provider>
             <Dialog open={loginOpen()} onOpenChange={setLoginOpen} title="Log in">
                 <Login onComplete={() => setLoginOpen(false)} />

--- a/packages/frontend/src/util/errors.css
+++ b/packages/frontend/src/util/errors.css
@@ -1,5 +1,19 @@
-.error-dialog {
-    & h3 {
-        color: #dc2626;
+.error-boundary {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+    flex: 1;
+
+    div {
+        h3 {
+            color: #dc2626;
+        }
     }
+}
+
+.error-page {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
 }

--- a/packages/frontend/src/util/errors.tsx
+++ b/packages/frontend/src/util/errors.tsx
@@ -12,23 +12,21 @@ export class PermissionsError extends Error {
 export function ErrorBoundaryMessage(props: { error: Error }) {
     console.error(props.error);
 
-    let heading: string;
-    let message: string;
-
-    if (props.error instanceof PermissionsError) {
-        heading = "Permissions Error";
-        message = "You are not permitted to view this resource.";
-    } else {
-        heading = "Error";
-        message = "An unknown error occurred.";
-    }
-
-    return <ErrorMessage heading={heading} message={message} />;
+    return <ErrorMessage error={props.error} />;
 }
 
 export function ErrorBoundaryPage(props: { error: Error }) {
     console.error(props.error);
 
+    return (
+        <div class="error-page">
+            <DefaultToolbar />
+            <ErrorMessage error={props.error} />
+        </div>
+    );
+}
+
+export function ErrorMessage(props: { error: Error }) {
     let heading: string;
     let message: string;
 
@@ -41,19 +39,10 @@ export function ErrorBoundaryPage(props: { error: Error }) {
     }
 
     return (
-        <div class="error-page">
-            <DefaultToolbar />
-            <ErrorMessage heading={heading} message={message} />
-        </div>
-    );
-}
-
-export function ErrorMessage(props: { heading: string; message: string }) {
-    return (
         <div class="error-boundary">
             <div>
-                <h3>{props.heading}</h3>
-                <p>{props.message}</p>
+                <h3>{heading}</h3>
+                <p>{message}</p>
             </div>
         </div>
     );

--- a/packages/frontend/src/util/errors.tsx
+++ b/packages/frontend/src/util/errors.tsx
@@ -1,13 +1,4 @@
-import Dialog, { Content, Portal, Trigger } from "@corvu/dialog";
 import { DefaultToolbar } from "../page/toolbar";
-import { useContext } from "solid-js";
-import { useNavigate } from "@solidjs/router";
-import { IconButton } from "../components";
-import { createModel } from "../model/document";
-import { useApi } from "../api";
-import CircleArrowLeft from "lucide-solid/icons/circle-arrow-left";
-import { TheoryLibraryContext } from "../stdlib";
-import invariant from "tiny-invariant";
 
 import "./errors.css";
 
@@ -18,7 +9,7 @@ export class PermissionsError extends Error {
     }
 }
 
-export function ErrorBoundaryDialog(props: { error: Error }) {
+export function ErrorBoundaryMessage(props: { error: Error }) {
     console.error(props.error);
 
     let heading: string;
@@ -32,28 +23,38 @@ export function ErrorBoundaryDialog(props: { error: Error }) {
         message = "An unknown error occurred.";
     }
 
-	// probably delete
-	const api = useApi();
-	const navigate = useNavigate();
-	const theories = useContext(TheoryLibraryContext);
-	invariant(theories, "Theory library must be provided as context");
-	const onNewModel = async () => {
-	  const newRef = await createModel(api, theories.getDefault().id);
-	  navigate(`/model/${newRef}`);
-	};
-	//
+    return <ErrorMessage heading={heading} message={message} />;
+}
+
+export function ErrorBoundaryPage(props: { error: Error }) {
+    console.error(props.error);
+
+    let heading: string;
+    let message: string;
+
+    if (props.error instanceof PermissionsError) {
+        heading = "Permissions Error";
+        message = "You are not permitted to view this resource.";
+    } else {
+        heading = "Error";
+        message = "An unknown error occurred.";
+    }
 
     return (
-	  <div>
-		<DefaultToolbar />
-        <Dialog initialOpen={true} noOutsidePointerEvents={false}>
-            <Portal>
-                <Content class="popup error-dialog">
-                    <h3>{heading}</h3>
-                    <p>{message}</p>
-                </Content>
-            </Portal>
-        </Dialog>
-	  </div>
+        <div class="error-page">
+            <DefaultToolbar />
+            <ErrorMessage heading={heading} message={message} />
+        </div>
+    );
+}
+
+export function ErrorMessage(props: { heading: string; message: string }) {
+    return (
+        <div class="error-boundary">
+            <div>
+                <h3>{props.heading}</h3>
+                <p>{props.message}</p>
+            </div>
+        </div>
     );
 }


### PR DESCRIPTION
The problem was that the menu relies on the `PageActionsContext`, which is not provided at the root level of the app. We can put an `ErrorBoundary` in `PageContainer`, however that won't show the menu since the menu is part of the "page" that is being contained. We can overcome this by creating another fallback component `ErrorBoundaryPage` which assumes that it will take up the entire page and add it's own `DefaultToolbar`.

This is a bit hacky, ideally we would have a layout with a toolbar and some content element, then just wrap that content element in a error boundary, instead of having to recreate part of the page in an error component. This might be addressed by the notion style UI, and if it's not then we should address this hierarchy problem after it's merged.

Also there's no good reason for the error message to be a dialogue, I had thought that there might still be something visible in the error boundary that we would put a dialogue on top of (iirc this is what React does), but instead the area in the ErrorBoundary is just not rendered at all so there's no reason not to replace it.

Feel free to edit any of the error stuff I'm adding here.