### PR TITLE
Remove redundant type defs and complete notebook-types refactor

### DIFF
--- a/packages/catlog-wasm/src/lib.rs
+++ b/packages/catlog-wasm/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod notation;
 pub mod result;
 
 pub mod model;

--- a/packages/catlog-wasm/src/model.rs
+++ b/packages/catlog-wasm/src/model.rs
@@ -17,6 +17,7 @@ use catlog::one::{Category as _, FgCategory, Path, fp_category::UstrFpCategory};
 use catlog::validate::Validate;
 use notebook_types::current::{path as notebook_path, *};
 
+use super::notation::*;
 use super::result::JsResult;
 use super::theory::{DblTheory, DblTheoryBox};
 
@@ -38,16 +39,6 @@ pub enum DblModelBox {
 
 #[wasm_bindgen]
 pub struct DblModel(#[wasm_bindgen(skip)] pub DblModelBox);
-
-/** Elaboration is the process of transforming notation (as declared in
-notebook-types) into syntax and values. This can possibly fail. Eventually,
-this struct may have some role to play in accumulating errors, but for now it is
-a singleton. */
-pub struct Elaborator;
-
-pub trait CanElaborate<T, S> {
-    fn elab(&self, x: &T) -> Result<S, String>;
-}
 
 impl CanElaborate<ObType, Ustr> for Elaborator {
     fn elab(&self, x: &ObType) -> Result<Ustr, String> {
@@ -175,12 +166,6 @@ impl CanElaborate<Mor, TabEdge<Uuid, Uuid>> for Elaborator {
             _ => Err(format!("Cannot cast morphism for discrete tabulator theory: {mor:#?}")),
         }
     }
-}
-
-pub struct Quoter;
-
-pub trait CanQuote<T, S> {
-    fn quote(&self, x: &T) -> S;
 }
 
 impl CanQuote<Uuid, Ob> for Quoter {

--- a/packages/catlog-wasm/src/model_diagram.rs
+++ b/packages/catlog-wasm/src/model_diagram.rs
@@ -14,9 +14,9 @@ use catlog::one::FgCategory;
 use catlog::zero::MutMapping;
 use notebook_types::current::*;
 
-use super::notation::*;
 use super::model::{DblModel, DblModelBox, DiscreteDblModel};
 use super::model_morphism::DiscreteDblModelMapping;
+use super::notation::*;
 use super::result::JsResult;
 use super::theory::DblTheory;
 

--- a/packages/catlog-wasm/src/model_diagram.rs
+++ b/packages/catlog-wasm/src/model_diagram.rs
@@ -14,7 +14,7 @@ use catlog::one::FgCategory;
 use catlog::zero::MutMapping;
 use notebook_types::current::*;
 
-use super::model::{CanElaborate, CanQuote, Elaborator, Quoter};
+use super::notation::*;
 use super::model::{DblModel, DblModelBox, DiscreteDblModel};
 use super::model_morphism::DiscreteDblModelMapping;
 use super::result::JsResult;

--- a/packages/catlog-wasm/src/notation.rs
+++ b/packages/catlog-wasm/src/notation.rs
@@ -1,0 +1,27 @@
+//! Traits concerning quoting and elaboration.
+
+/** An elaborator.
+
+Elaboration is the process of transforming notation (as declared in
+notebook-types) into syntax and values. This can possibly fail. Eventually, this
+struct may have some role to play in accumulating errors, but for now it is a
+singleton.
+ */
+pub struct Elaborator;
+
+pub trait CanElaborate<T, S> {
+    /// Transform notation into syntax.
+    fn elab(&self, x: &T) -> Result<S, String>;
+}
+
+/** A quoter.
+
+Quotation is the process of transformation syntax or values into notation.
+Unlike elaboration, quotation is infallible.
+ */
+pub struct Quoter;
+
+pub trait CanQuote<T, S> {
+    /// Transform syntax or value into notation.
+    fn quote(&self, x: &T) -> S;
+}

--- a/packages/catlog-wasm/src/theories.rs
+++ b/packages/catlog-wasm/src/theories.rs
@@ -282,7 +282,7 @@ impl ThCategoryLinks {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::theory::*;
+    use notebook_types::current::theory::*;
     use ustr::ustr;
 
     #[test]

--- a/packages/catlog-wasm/src/theory.rs
+++ b/packages/catlog-wasm/src/theory.rs
@@ -1,143 +1,110 @@
 //! Wasm bindings for double theories.
 
 use std::collections::HashMap;
-use std::hash::Hash;
 use std::rc::Rc;
 
 use all_the_same::all_the_same;
 use derive_more::From;
 use ustr::Ustr;
 
-use serde::{Deserialize, Serialize};
-use tsify::Tsify;
 use wasm_bindgen::prelude::*;
 
 use catlog::dbl::theory;
 use catlog::dbl::theory::{DblTheory as _, TabMorType, TabObType};
 use catlog::one::Path;
+use notebook_types::current::theory::*;
 
-/// Object type in a double theory.
-#[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Tsify)]
-#[serde(tag = "tag", content = "content")]
-#[tsify(into_wasm_abi, from_wasm_abi)]
-pub enum ObType {
-    /// Basic or generating object type.
-    Basic(Ustr),
+use super::notation::*;
 
-    /// Tabulator of a morphism type.
-    Tabulator(Box<MorType>),
-}
-
-/// Morphism type in a double theory.
-#[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, Tsify)]
-#[serde(tag = "tag", content = "content")]
-#[tsify(into_wasm_abi, from_wasm_abi)]
-pub enum MorType {
-    /// Basic or generating morphism type.
-    Basic(Ustr),
-
-    /// Composite of morphism types.
-    Composite(Vec<MorType>),
-
-    /// Hom type on an object type.
-    Hom(Box<ObType>),
-}
-
-/// Convert from object type in a discrete double theory.
-impl From<Ustr> for ObType {
-    fn from(value: Ustr) -> Self {
-        ObType::Basic(value)
+/// Elaborates into object type in a discrete double theory.
+impl CanElaborate<ObType, Ustr> for Elaborator {
+    fn elab(&self, x: &ObType) -> Result<Ustr, String> {
+        match x {
+            ObType::Basic(name) => Ok(*name),
+            _ => Err(format!("Cannot cast object type for discrete double theory: {x:#?}")),
+        }
     }
 }
 
-/// Convert from morphism type in a discrete double theory.
-impl From<Path<Ustr, Ustr>> for MorType {
-    fn from(mor: Path<Ustr, Ustr>) -> Self {
-        match mor {
-            Path::Id(v) => MorType::Hom(Box::new(ObType::Basic(v))),
+/// Elaborates into morphism type in a discrete double theory.
+impl CanElaborate<MorType, Path<Ustr, Ustr>> for Elaborator {
+    fn elab(&self, x: &MorType) -> Result<Path<Ustr, Ustr>, String> {
+        match x {
+            MorType::Basic(ustr) => Ok(Path::single(*ustr)),
+            MorType::Composite(fs) => {
+                let fs: Result<Vec<_>, _> = fs.iter().map(|f| self.elab(f)).collect();
+                let path = Path::from_vec(fs?).ok_or("Composite should not be empty")?;
+                Ok(path.flatten())
+            }
+            MorType::Hom(ob_type) => Ok(Path::Id(self.elab(&**ob_type)?)),
+        }
+    }
+}
+
+/// Elaborates into object type in a discrete tabulator theory.
+impl CanElaborate<ObType, TabObType<Ustr, Ustr>> for Elaborator {
+    fn elab(&self, x: &ObType) -> Result<TabObType<Ustr, Ustr>, String> {
+        match x {
+            ObType::Basic(name) => Ok(TabObType::Basic(*name)),
+            ObType::Tabulator(mor_type) => {
+                Ok(TabObType::Tabulator(Box::new(self.elab(&**mor_type)?)))
+            }
+        }
+    }
+}
+
+/// Elaborates into morphism type in a discrete tabulator theory.
+impl CanElaborate<MorType, TabMorType<Ustr, Ustr>> for Elaborator {
+    fn elab(&self, x: &MorType) -> Result<TabMorType<Ustr, Ustr>, String> {
+        match x {
+            MorType::Basic(ustr) => Ok(TabMorType::Basic(*ustr)),
+            MorType::Composite(_) => {
+                Err("Composites not yet implemented for tabulator theories".into())
+            }
+            MorType::Hom(ob_type) => Ok(TabMorType::Hom(Box::new(self.elab(&**ob_type)?))),
+        }
+    }
+}
+
+/// Quotes an object type in a discrete double theory.
+impl CanQuote<Ustr, ObType> for Quoter {
+    fn quote(&self, id: &Ustr) -> ObType {
+        ObType::Basic(*id)
+    }
+}
+
+/// Quotes a morphism type in a discrete double theory.
+impl CanQuote<Path<Ustr, Ustr>, MorType> for Quoter {
+    fn quote(&self, path: &Path<Ustr, Ustr>) -> MorType {
+        match path {
+            Path::Id(v) => MorType::Hom(Box::new(ObType::Basic(*v))),
             Path::Seq(edges) => {
                 if edges.len() == 1 {
                     MorType::Basic(edges.head)
                 } else {
-                    MorType::Composite(edges.into_iter().map(MorType::Basic).collect())
+                    MorType::Composite(edges.iter().map(|e| MorType::Basic(*e)).collect())
                 }
             }
         }
     }
 }
 
-/// Convert into object type in a discrete double theory.
-impl TryFrom<ObType> for Ustr {
-    type Error = String;
-
-    fn try_from(ob_type: ObType) -> Result<Self, Self::Error> {
+/// Quotes an object type in a discrete tabulator theory.
+impl CanQuote<TabObType<Ustr, Ustr>, ObType> for Quoter {
+    fn quote(&self, ob_type: &TabObType<Ustr, Ustr>) -> ObType {
         match ob_type {
-            ObType::Basic(name) => Ok(name),
-            _ => Err(format!("Cannot cast object type for discrete double theory: {ob_type:#?}")),
+            TabObType::Basic(name) => ObType::Basic(*name),
+            TabObType::Tabulator(m) => ObType::Tabulator(Box::new(self.quote(&**m))),
         }
     }
 }
 
-/// Convert into morphism type in a discrete double theory.
-impl TryFrom<MorType> for Path<Ustr, Ustr> {
-    type Error = String;
-
-    fn try_from(mor_type: MorType) -> Result<Self, Self::Error> {
+/// Quotes a morphism type in a discrete tabulator theory.
+impl CanQuote<TabMorType<Ustr, Ustr>, MorType> for Quoter {
+    fn quote(&self, mor_type: &TabMorType<Ustr, Ustr>) -> MorType {
         match mor_type {
-            MorType::Basic(name) => Ok(name.into()),
-            MorType::Composite(fs) => {
-                let fs: Result<Vec<_>, _> = fs.into_iter().map(|f| f.try_into()).collect();
-                let path = Path::from_vec(fs?).ok_or("Composite should not be empty")?;
-                Ok(path.flatten())
-            }
-            MorType::Hom(x) => (*x).try_into().map(Path::Id),
-        }
-    }
-}
-
-/// Convert from object type in a discrete tabulator theory.
-impl From<TabObType<Ustr, Ustr>> for ObType {
-    fn from(ob_type: TabObType<Ustr, Ustr>) -> Self {
-        match ob_type {
-            TabObType::Basic(name) => ObType::Basic(name),
-            TabObType::Tabulator(m) => ObType::Tabulator(Box::new((*m).into())),
-        }
-    }
-}
-
-/// Convert from morphism type in a discrete tabulator theory.
-impl From<TabMorType<Ustr, Ustr>> for MorType {
-    fn from(mor_type: TabMorType<Ustr, Ustr>) -> Self {
-        match mor_type {
-            TabMorType::Basic(name) => MorType::Basic(name),
-            TabMorType::Hom(x) => MorType::Hom(Box::new((*x).into())),
-        }
-    }
-}
-
-/// Convert into object type in a discrete tabulator theory.
-impl TryFrom<ObType> for TabObType<Ustr, Ustr> {
-    type Error = String;
-
-    fn try_from(ob_type: ObType) -> Result<Self, Self::Error> {
-        match ob_type {
-            ObType::Basic(name) => Ok(TabObType::Basic(name)),
-            ObType::Tabulator(m) => (*m).try_into().map(|m| TabObType::Tabulator(Box::new(m))),
-        }
-    }
-}
-
-/// Convert into morphism type in a discrete tabulator theory.
-impl TryFrom<MorType> for TabMorType<Ustr, Ustr> {
-    type Error = String;
-
-    fn try_from(mor_type: MorType) -> Result<Self, Self::Error> {
-        match mor_type {
-            MorType::Basic(name) => Ok(TabMorType::Basic(name)),
-            MorType::Composite(_) => {
-                Err("Composites not yet implemented for tabulator theories".into())
-            }
-            MorType::Hom(x) => (*x).try_into().map(|x| TabMorType::Hom(Box::new(x))),
+            TabMorType::Basic(name) => MorType::Basic(*name),
+            TabMorType::Hom(x) => MorType::Hom(Box::new(self.quote(&**x))),
         }
     }
 }
@@ -178,8 +145,8 @@ impl DblTheory {
     pub fn src(&self, mor_type: MorType) -> Result<ObType, String> {
         all_the_same!(match &self.0 {
             DblTheoryBox::[Discrete, DiscreteTab](th) => {
-                let m = mor_type.try_into()?;
-                Ok(th.src_type(&m).into())
+                let m = Elaborator.elab(&mor_type)?;
+                Ok(Quoter.quote(&th.src_type(&m)))
             }
         })
     }
@@ -189,8 +156,8 @@ impl DblTheory {
     pub fn tgt(&self, mor_type: MorType) -> Result<ObType, String> {
         all_the_same!(match &self.0 {
             DblTheoryBox::[Discrete, DiscreteTab](th) => {
-                let m = mor_type.try_into()?;
-                Ok(th.tgt_type(&m).into())
+                let m = Elaborator.elab(&mor_type)?;
+                Ok(Quoter.quote(&th.tgt_type(&m)))
             }
         })
     }

--- a/packages/catlog-wasm/src/theory.rs
+++ b/packages/catlog-wasm/src/theory.rs
@@ -36,7 +36,7 @@ impl CanElaborate<MorType, Path<Ustr, Ustr>> for Elaborator {
                 let path = Path::from_vec(fs?).ok_or("Composite should not be empty")?;
                 Ok(path.flatten())
             }
-            MorType::Hom(ob_type) => Ok(Path::Id(self.elab(&**ob_type)?)),
+            MorType::Hom(ob_type) => Ok(Path::Id(self.elab(ob_type.as_ref())?)),
         }
     }
 }
@@ -47,7 +47,7 @@ impl CanElaborate<ObType, TabObType<Ustr, Ustr>> for Elaborator {
         match x {
             ObType::Basic(name) => Ok(TabObType::Basic(*name)),
             ObType::Tabulator(mor_type) => {
-                Ok(TabObType::Tabulator(Box::new(self.elab(&**mor_type)?)))
+                Ok(TabObType::Tabulator(Box::new(self.elab(mor_type.as_ref())?)))
             }
         }
     }
@@ -61,7 +61,7 @@ impl CanElaborate<MorType, TabMorType<Ustr, Ustr>> for Elaborator {
             MorType::Composite(_) => {
                 Err("Composites not yet implemented for tabulator theories".into())
             }
-            MorType::Hom(ob_type) => Ok(TabMorType::Hom(Box::new(self.elab(&**ob_type)?))),
+            MorType::Hom(ob_type) => Ok(TabMorType::Hom(Box::new(self.elab(ob_type.as_ref())?))),
         }
     }
 }
@@ -94,7 +94,9 @@ impl CanQuote<TabObType<Ustr, Ustr>, ObType> for Quoter {
     fn quote(&self, ob_type: &TabObType<Ustr, Ustr>) -> ObType {
         match ob_type {
             TabObType::Basic(name) => ObType::Basic(*name),
-            TabObType::Tabulator(m) => ObType::Tabulator(Box::new(self.quote(&**m))),
+            TabObType::Tabulator(mor_type) => {
+                ObType::Tabulator(Box::new(self.quote(mor_type.as_ref())))
+            }
         }
     }
 }
@@ -104,7 +106,7 @@ impl CanQuote<TabMorType<Ustr, Ustr>, MorType> for Quoter {
     fn quote(&self, mor_type: &TabMorType<Ustr, Ustr>) -> MorType {
         match mor_type {
             TabMorType::Basic(name) => MorType::Basic(*name),
-            TabMorType::Hom(x) => MorType::Hom(Box::new(self.quote(&**x))),
+            TabMorType::Hom(ob_type) => MorType::Hom(Box::new(self.quote(ob_type.as_ref()))),
         }
     }
 }

--- a/packages/notebook-types/src/v0/theory.rs
+++ b/packages/notebook-types/src/v0/theory.rs
@@ -23,6 +23,9 @@ pub enum MorType {
     /// Basic or generating morphism type.
     Basic(Ustr),
 
+    /// Composite of morphism types.
+    Composite(Vec<MorType>),
+
     /// Hom type on an object type.
     Hom(Box<ObType>),
 }


### PR DESCRIPTION
Closes #567. This was more work than I expected since it turns out that #473 hadn't finished refactoring `ObType` and `MorType` to use the quoting and elaboration traits.