### PR TITLE
Changed line height to avoid descender clipping

### DIFF
--- a/packages/frontend/src/components/inline_input.css
+++ b/packages/frontend/src/components/inline_input.css
@@ -7,6 +7,7 @@
 .inline-input {
     border: none;
     border-bottom: 3px solid transparent;
+    line-height: 1.3;
 }
 
 .inline-input-filler {
@@ -31,11 +32,12 @@
     padding-right: 5px;
     font: inherit;
     color: inherit;
+    line-height: 1.3;
 
     &.incomplete {
-        border-bottom: 3px solid sandybrown;
+        border-bottom: 2px solid sandybrown;
     }
     &.invalid {
-        border-bottom: 3px solid indianred;
+        border-bottom: 2px solid indianred;
     }
 }


### PR DESCRIPTION
before:
<img width="134" height="152" alt="image" src="https://github.com/user-attachments/assets/5c9ec95d-0cc0-486a-b4f8-17406e1750ff" />


after:
<img width="183" height="179" alt="image" src="https://github.com/user-attachments/assets/5a3dced9-f300-426b-83e3-b3b292f98898" />


This small PR increases the line height of boxes in order to avoid clipping of descenders.