### PR TITLE
Add version display to frontend header - fixes #554

### DIFF
--- a/packages/frontend/src/components/index.ts
+++ b/packages/frontend/src/components/index.ts
@@ -12,3 +12,4 @@ export * from "./panel";
 export * from "./resizable";
 export * from "./rich_text_editor";
 export * from "./json_import";
+export * from "./version";

--- a/packages/frontend/src/components/version.css
+++ b/packages/frontend/src/components/version.css
@@ -1,0 +1,22 @@
+.version {
+    color: #666;
+    font-weight: normal;
+    padding-left: 5px;
+    padding-right: 10px;
+    margin-right: 2px;
+    margin-left: 2px;
+    margin-top: 2.5px;
+    
+    font: inherit;
+    line-height: inherit;
+    display: inline;
+    text-decoration: none;
+    
+    border-right: 1px solid #ddd;
+    
+    vertical-align: baseline;
+}
+
+.version:hover {
+    text-decoration: underline;
+}

--- a/packages/frontend/src/components/version.tsx
+++ b/packages/frontend/src/components/version.tsx
@@ -1,0 +1,10 @@
+import { APP_VERSION } from "../util/version";
+import "./version.css";
+
+export function Version() {
+    return (
+        <span class="version" title={`CatColab version ${APP_VERSION}`}>
+            v {APP_VERSION}
+        </span>
+    );
+}

--- a/packages/frontend/src/model/model_editor.tsx
+++ b/packages/frontend/src/model/model_editor.tsx
@@ -4,7 +4,7 @@ import invariant from "tiny-invariant";
 
 import type { ModelJudgment } from "catlog-wasm";
 import { useApi } from "../api";
-import { InlineInput } from "../components";
+import { InlineInput, Version } from "../components";
 import {
     type CellConstructor,
     type FormalCellEditorProps,
@@ -63,6 +63,7 @@ export function ModelDocumentEditor(props: {
         <div class="growable-container">
             <Toolbar>
                 <DocumentMenu liveDocument={props.liveModel} />
+                <Version />
                 <DocumentBreadcrumbs document={props.liveModel} />
                 <span class="filler" />
                 <TheoryHelpButton theory={props.liveModel.theory()} />

--- a/packages/frontend/src/page/document_breadcrumbs.css
+++ b/packages/frontend/src/page/document_breadcrumbs.css
@@ -1,5 +1,5 @@
 .breadcrumb-spacer {
-    padding-left: 5px;
+    padding-left: 4px;
     padding-right: 5px;
 }
 
@@ -14,5 +14,5 @@
 .breadcrumbs-wrapper {
     display: flex;
     align-items: center;
-    padding-left: 1em;
+    padding-left: 0.5em;
 }

--- a/packages/frontend/src/util/version.ts
+++ b/packages/frontend/src/util/version.ts
@@ -1,0 +1,3 @@
+import packageJson from "../../package.json";
+
+export const APP_VERSION = packageJson.version;


### PR DESCRIPTION
## Add version display to frontend header

Fixes #554

### Changes
- Created `Version` component that displays current app version (v0.1.0)
- Added version display to model editor toolbar between menu and document breadcrumbs
- Version shows as "v0.1.0 | untitled" with hover underline effect
- Imported version from package.json for automatic updates

### Implementation
- `src/util/version.ts` - Version utility that imports from package.json
- `src/components/version.tsx` - Version display component
- `src/components/version.css` - Styling to match existing UI
- Updated model editor to include version in toolbar

The version is now visible and easily accessible for debugging/support purposes.