### PR TITLE
Mass-action ODE semantics for Petri nets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1871,9 +1871,9 @@ dependencies = [
 
 [[package]]
 name = "nonempty"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "303e8749c804ccd6ca3b428de7fe0d86cb86bc7606bc15291f100fd487960bb8"
+checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
 dependencies = [
  "serde",
 ]
@@ -3737,7 +3737,6 @@ checksum = "b913a3b5fe84142e269d63cc62b64319ccaf89b748fc31fe025177f767a756c4"
 dependencies = [
  "getrandom 0.2.16",
  "serde",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/packages/catlog-wasm/Cargo.toml
+++ b/packages/catlog-wasm/Cargo.toml
@@ -20,7 +20,7 @@ egglog = { version = "0.4", default-features = false, features = [
 ] }
 getrandom = { version = "0.2", features = ["js"] }
 js-sys = "0.3.77"
-nonempty = { version = "0.10", features = ["serialize"] }
+nonempty = { version = "0.12", features = ["serialize"] }
 notebook-types = { version = "0.1.0", path = "../notebook-types" }
 serde = { version = "1", features = ["derive"] }
 tsify = { version = "0.5", features = ["js"] }

--- a/packages/catlog-wasm/src/theories.rs
+++ b/packages/catlog-wasm/src/theories.rs
@@ -116,10 +116,10 @@ impl ThSignedCategory {
             .try_into()
             .map_err(|_| "Lotka-Volterra simulation expects a discrete double model")?;
         Ok(ODEResult(
-            analyses::ode::LotkaVolterraAnalysis::new(ustr("Object"))
+            analyses::ode::SignedCoefficientBuilder::new(ustr("Object"))
                 .add_positive(Path::Id(ustr("Object")))
                 .add_negative(ustr("Negative").into())
-                .create_system(model, data.0)
+                .lotka_volterra_analysis(model, data.0)
                 .solve_with_defaults()
                 .map_err(|err| format!("{err:?}"))
                 .into(),
@@ -137,10 +137,10 @@ impl ThSignedCategory {
             .try_into()
             .map_err(|_| "Linear ODE simulation expects a discrete double model")?;
         Ok(ODEResult(
-            analyses::ode::LinearODEAnalysis::new(ustr("Object"))
+            analyses::ode::SignedCoefficientBuilder::new(ustr("Object"))
                 .add_positive(Path::Id(ustr("Object")))
                 .add_negative(ustr("Negative").into())
-                .create_system(model, data.0)
+                .linear_ode_analysis(model, data.0)
                 .solve_with_defaults()
                 .map_err(|err| format!("{err:?}"))
                 .into(),

--- a/packages/catlog-wasm/src/theories.rs
+++ b/packages/catlog-wasm/src/theories.rs
@@ -271,7 +271,7 @@ impl ThCategoryLinks {
             .map_err(|_| "Mass-action simulation expects a discrete tabulator model")?;
         Ok(ODEResult(
             analyses::ode::StockFlowMassActionAnalysis::default()
-                .create_numerical_system(model, data.0)
+                .build_numerical_system(model, data.0)
                 .solve_with_defaults()
                 .map_err(|err| format!("{err:?}"))
                 .into(),

--- a/packages/catlog-wasm/src/theories.rs
+++ b/packages/catlog-wasm/src/theories.rs
@@ -259,16 +259,15 @@ impl ThCategoryLinks {
         DblTheory(self.0.clone().into())
     }
 
-    /// Simulates the mass-action system derived from a model.
+    /// Simulates the mass-action ODE system derived from a model.
     #[wasm_bindgen(js_name = "massAction")]
     pub fn mass_action(
         &self,
         model: &DblModel,
         data: MassActionModelData,
     ) -> Result<ODEResult, String> {
-        let model: &model::DiscreteTabModel<_, _, _> = (&model.0)
-            .try_into()
-            .map_err(|_| "Mass-action simulation expects a discrete tabulator model")?;
+        let model: &model::DiscreteTabModel<_, _, _> =
+            (&model.0).try_into().map_err(|_| "Model should be of a tabulator theory")?;
         Ok(ODEResult(
             analyses::ode::StockFlowMassActionAnalysis::default()
                 .build_numerical_system(model, data.0)
@@ -293,6 +292,24 @@ impl ThSymMonoidalCategory {
     #[wasm_bindgen]
     pub fn theory(&self) -> DblTheory {
         DblTheory(self.0.clone().into())
+    }
+
+    /// Simulates the mass-action ODE system derived from a model.
+    #[wasm_bindgen(js_name = "massAction")]
+    pub fn mass_action(
+        &self,
+        model: &DblModel,
+        data: MassActionModelData,
+    ) -> Result<ODEResult, String> {
+        let model: &model::ModalDblModel<_, _, _> =
+            (&model.0).try_into().map_err(|_| "Model should be of a modal theory")?;
+        Ok(ODEResult(
+            analyses::ode::PetriNetMassActionAnalysis::default()
+                .build_numerical_system(model, data.0)
+                .solve_with_defaults()
+                .map_err(|err| format!("{err:?}"))
+                .into(),
+        ))
     }
 }
 

--- a/packages/catlog/Cargo.toml
+++ b/packages/catlog/Cargo.toml
@@ -18,7 +18,7 @@ egglog = { version = "0.4", default-features = false }
 ego-tree = "0.10"
 itertools = "0.14"
 nalgebra = { version = "0.33", optional = true }
-nonempty = "0.10"
+nonempty = "0.12"
 num-traits = "0.2"
 ode_solvers = { version = "0.5.0", optional = true }
 ref-cast = "1"

--- a/packages/catlog/src/dbl/modal/model.rs
+++ b/packages/catlog/src/dbl/modal/model.rs
@@ -1,12 +1,13 @@
 //! Models of modal double theories.
 
 use std::fmt::Debug;
-use std::hash::{BuildHasher, Hash, RandomState};
+use std::hash::{BuildHasher, BuildHasherDefault, Hash, RandomState};
 use std::rc::Rc;
 
 use derive_more::From;
 use itertools::Itertools;
 use ref_cast::RefCast;
+use ustr::{IdentityHasher, Ustr};
 
 use super::theory::*;
 use crate::dbl::{
@@ -84,6 +85,9 @@ pub struct ModalDblModel<Id, ThId, S = RandomState> {
     ob_types: HashColumn<Id, ModalObType<ThId>>,
     mor_types: HashColumn<Id, ModalMorType<ThId>>,
 }
+
+/// A model of a modal double theory with `Ustr` identifiers.
+pub type UstrModalDblModel = ModalDblModel<Ustr, Ustr, BuildHasherDefault<IdentityHasher>>;
 
 impl<Id, ThId, S> ModalDblModel<Id, ThId, S> {
     /// Creates an empty model of the given theory.
@@ -429,6 +433,19 @@ impl<ThId> ModalOp<ThId> {
 }
 
 impl<Id, ThId> ModalOb<Id, ThId> {
+    /// Extracts an object generator or nothing.
+    pub fn generator(self) -> Option<Id> {
+        match self {
+            ModalOb::Generator(id) => Some(id),
+            _ => None,
+        }
+    }
+
+    /// Unwraps an object generator, or panics.
+    pub fn unwrap_generator(self) -> Id {
+        self.generator().expect("Object should be a generator")
+    }
+
     /** Collects application of a product operation into a list of objects.
 
     The intended operation has domain equal to the list modality applied to its

--- a/packages/catlog/src/refs.rs
+++ b/packages/catlog/src/refs.rs
@@ -78,6 +78,16 @@ modes.
  */
 pub const AdjointLogic: () = ();
 
+/** Reference: Compositional framework for reaction networks.
+
+John C. Baez & Blake S. Pollard, 2017: A compositional framework for reaction
+networks.
+
+- [DOI:10.1142/S0129055X17500283](https://doi.org/10.1142/S0129055X17500283)
+- [arXiv:1704.02051](https://arxiv.org/abs/1704.02051)
+ */
+pub const ReactionNets: () = ();
+
 /** Reference: Compositional account of biochemical regulatory networks.
 
 Rebekah Aduddell, James Fairbanks, Amit Kumar, Pablo S. Ocal, Evan Patterson,

--- a/packages/catlog/src/simulate/ode/mod.rs
+++ b/packages/catlog/src/simulate/ode/mod.rs
@@ -138,12 +138,10 @@ pub(crate) fn textplot_ode_result<Sys>(
 
     let dim = problem.initial_values.len();
     let line_data: Vec<_> = (0..dim)
-        .into_iter()
         .map(|i| t_out.iter().copied().zip(x_out.iter().map(|x| x[i])).collect::<Vec<_>>())
         .collect();
 
-    let lines: Vec<_> = line_data.iter().map(|data| Shape::Lines(data)).into_iter().collect();
-
+    let lines: Vec<_> = line_data.iter().map(|data| Shape::Lines(data)).collect();
     let chart = lines.iter().fold(&mut chart, |chart, line| chart.lineplot(line));
     chart.axis();
     chart.figures();

--- a/packages/catlog/src/simulate/ode/polynomial.rs
+++ b/packages/catlog/src/simulate/ode/polynomial.rs
@@ -6,7 +6,7 @@ use std::ops::Add;
 
 use derivative::Derivative;
 use nalgebra::DVector;
-use num_traits::{One, Pow};
+use num_traits::{One, Pow, Zero};
 
 #[cfg(test)]
 use super::ODEProblem;
@@ -48,11 +48,24 @@ where
     where
         F: Clone + FnMut(Coef) -> NewCoef,
     {
-        let components = self
-            .components
-            .into_iter()
-            .map(|(var, poly)| (var, poly.extend_scalars(f.clone())))
-            .collect();
+        self.map(|poly| poly.extend_scalars(f.clone()))
+    }
+
+    /// Normalizes the polynomial system by normalizing each polynomial in it.
+    pub fn normalize(self) -> Self
+    where
+        Coef: Zero,
+        Exp: Zero,
+    {
+        self.map(|poly| poly.normalize())
+    }
+
+    /// Maps over the components of the system.
+    pub fn map<NewCoef, NewExp, F>(self, mut f: F) -> PolynomialSystem<Var, NewCoef, NewExp>
+    where
+        F: FnMut(Polynomial<Var, Coef, Exp>) -> Polynomial<Var, NewCoef, NewExp>,
+    {
+        let components = self.components.into_iter().map(|(var, poly)| (var, f(poly))).collect();
         PolynomialSystem { components }
     }
 }

--- a/packages/catlog/src/stdlib/analyses/ode/lotka_volterra.rs
+++ b/packages/catlog/src/stdlib/analyses/ode/lotka_volterra.rs
@@ -1,19 +1,20 @@
-//! Lotka-Volterra ODE analysis of models.
+/*! Lotka-Volterra ODE analysis of models.
+
+The main entry point for this module is
+[`lotka_volterra_analysis`](SignedCoefficientBuilder::lotka_volterra_analysis).
+ */
 
 use std::{collections::HashMap, hash::Hash};
 
-use nalgebra::{DMatrix, DVector};
-use ustr::Ustr;
+use nalgebra::DVector;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "serde-wasm")]
 use tsify::Tsify;
 
-use super::ODEAnalysis;
-use crate::dbl::model::{DiscreteDblModel, FgDblModel};
-use crate::one::fp_category::UstrFpCategory;
-use crate::one::{FgCategory, Path};
+use super::{ODEAnalysis, SignedCoefficientBuilder};
+use crate::dbl::model::FgDblModel;
 use crate::simulate::ode::{LotkaVolterraSystem, ODEProblem};
 
 /// Data defining a Lotka-Volterra ODE problem for a model.
@@ -44,84 +45,34 @@ where
     duration: f32,
 }
 
-type Model<Id> = DiscreteDblModel<Id, UstrFpCategory>;
+impl<ObType, MorType> SignedCoefficientBuilder<ObType, MorType> {
+    /** Lotka-Volterra ODE analysis for a model of a double theory.
 
-/** Lotka-Volterra ODE analysis for models of a double theory.
-
-The main situation we have in mind is the Lotka-Volterra ODE semantics for
-regulatory networks (signed graphs) described in our [*Compositionality*
-paper](crate::refs::RegNets).
-*/
-pub struct LotkaVolterraAnalysis {
-    var_ob_type: Ustr,
-    positive_mor_types: Vec<Path<Ustr, Ustr>>,
-    negative_mor_types: Vec<Path<Ustr, Ustr>>,
-}
-
-impl LotkaVolterraAnalysis {
-    /// Creates a new Lotka-Volterra analysis for the given object type.
-    pub fn new(var_ob_type: Ustr) -> Self {
-        Self {
-            var_ob_type,
-            positive_mor_types: Vec::new(),
-            negative_mor_types: Vec::new(),
-        }
-    }
-
-    /// Adds a morphism type defining a positive interaction between objects.
-    pub fn add_positive(mut self, mor_type: Path<Ustr, Ustr>) -> Self {
-        self.positive_mor_types.push(mor_type);
-        self
-    }
-
-    /// Adds a morphism type defining a negative interaction between objects.
-    pub fn add_negative(mut self, mor_type: Path<Ustr, Ustr>) -> Self {
-        self.negative_mor_types.push(mor_type);
-        self
-    }
-
-    /// Creates a Lotka-Volterra system from a model.
-    pub fn create_system<Id>(
+    The main application we have in mind is the Lotka-Volterra ODE semantics for
+    signed graphs described in our [paper on regulatory
+    networks](crate::refs::RegNets).
+     */
+    pub fn lotka_volterra_analysis<Id>(
         &self,
-        model: &Model<Id>,
+        model: &impl FgDblModel<ObType = ObType, MorType = MorType, Ob = Id, ObGen = Id, MorGen = Id>,
         data: LotkaVolterraProblemData<Id>,
     ) -> ODEAnalysis<Id, LotkaVolterraSystem>
     where
         Id: Eq + Clone + Hash + Ord,
     {
-        let mut objects: Vec<_> = model.ob_generators_with_type(&self.var_ob_type).collect();
-        objects.sort();
-        let ob_index: HashMap<_, _> =
-            objects.iter().cloned().enumerate().map(|(i, x)| (x, i)).collect();
-
-        let n = objects.len();
-
-        let mut A = DMatrix::from_element(n, n, 0.0f32);
-        for mor_type in self.positive_mor_types.iter() {
-            for mor in model.mor_generators_with_type(mor_type) {
-                let i = *ob_index.get(&model.mor_generator_dom(&mor)).unwrap();
-                let j = *ob_index.get(&model.mor_generator_cod(&mor)).unwrap();
-                A[(j, i)] += data.interaction_coeffs.get(&mor).copied().unwrap_or_default();
-            }
-        }
-        for mor_type in self.negative_mor_types.iter() {
-            for mor in model.mor_generators_with_type(mor_type) {
-                let i = *ob_index.get(&model.mor_generator_dom(&mor)).unwrap();
-                let j = *ob_index.get(&model.mor_generator_cod(&mor)).unwrap();
-                A[(j, i)] -= data.interaction_coeffs.get(&mor).copied().unwrap_or_default();
-            }
-        }
+        let (matrix, ob_index) = self.build_matrix(model, &data.interaction_coeffs);
+        let n = ob_index.len();
 
         let growth_rates =
-            objects.iter().map(|ob| data.growth_rates.get(ob).copied().unwrap_or_default());
+            ob_index.keys().map(|ob| data.growth_rates.get(ob).copied().unwrap_or_default());
         let b = DVector::from_iterator(n, growth_rates);
 
-        let initial_values = objects
-            .iter()
+        let initial_values = ob_index
+            .keys()
             .map(|ob| data.initial_values.get(ob).copied().unwrap_or_default());
         let x0 = DVector::from_iterator(n, initial_values);
 
-        let system = LotkaVolterraSystem::new(A, b);
+        let system = LotkaVolterraSystem::new(matrix, b);
         let problem = ODEProblem::new(system, x0).end_time(data.duration);
         ODEAnalysis::new(problem, ob_index)
     }
@@ -133,6 +84,7 @@ mod test {
     use ustr::ustr;
 
     use super::*;
+    use crate::one::Path;
     use crate::{simulate::ode::lotka_volterra, stdlib};
 
     #[test]
@@ -148,10 +100,10 @@ mod test {
             initial_values: [(prey, 1.0), (pred, 1.0)].into_iter().collect(),
             duration: 10.0,
         };
-        let analysis = LotkaVolterraAnalysis::new(ustr("Object"))
+        let analysis = SignedCoefficientBuilder::new(ustr("Object"))
             .add_positive(Path::Id(ustr("Object")))
             .add_negative(Path::single(ustr("Negative")))
-            .create_system(&neg_feedback, data);
+            .lotka_volterra_analysis(&neg_feedback, data);
         assert_eq!(analysis.problem, lotka_volterra::create_predator_prey());
     }
 }

--- a/packages/catlog/src/stdlib/analyses/ode/mass_action.rs
+++ b/packages/catlog/src/stdlib/analyses/ode/mass_action.rs
@@ -4,7 +4,7 @@ Such ODEs are based on the *law of mass action* familiar from chemistry and
 mathematical epidemiology.
  */
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::hash::{BuildHasherDefault, Hash};
 
 use nalgebra::DVector;
@@ -153,7 +153,7 @@ impl StockFlowMassActionAnalysis {
             .to_numerical();
 
         let problem = ODEProblem::new(sys, x0).end_time(data.duration);
-        let ob_index: HashMap<_, _> =
+        let ob_index: BTreeMap<_, _> =
             objects.into_iter().enumerate().map(|(i, x)| (x, i)).collect();
         ODEAnalysis::new(problem, ob_index)
     }

--- a/packages/catlog/src/stdlib/analyses/ode/mass_action.rs
+++ b/packages/catlog/src/stdlib/analyses/ode/mass_action.rs
@@ -103,7 +103,9 @@ impl PetriNetMassActionAnalysis {
                 sys.add_term(output.unwrap_generator(), term.clone());
             }
         }
-        sys
+
+        // Normalize since terms commonly cancel out in mass-action dynamics.
+        sys.normalize()
     }
 
     /// Creates a mass-action system with numerical rate coefficients.
@@ -247,7 +249,7 @@ mod tests {
         let model = catalyzed_reaction(th);
         let sys = PetriNetMassActionAnalysis::default().build_system(&model);
         let expected = expect!([r#"
-            dc = (0 f) c x
+            dc = 0
             dx = ((-1) f) c x
             dy = f c x
         "#]);

--- a/packages/catlog/src/stdlib/analyses/ode/mass_action.rs
+++ b/packages/catlog/src/stdlib/analyses/ode/mass_action.rs
@@ -54,7 +54,11 @@ type Parameter<Id> = Polynomial<Id, f32, u8>;
 
 type PetriNetModel<Id> = ModalDblModel<Id, Ustr, BuildHasherDefault<IdentityHasher>>;
 
-/// Mass-action ODE analysis for Petri nets.
+/** Mass-action ODE analysis for Petri nets.
+
+This struct implements the object part of the functorial semantics for reaction
+networks (aka, Petri nets) due to [Baez & Pollard](crate::refs::ReactionNets).
+ */
 pub struct PetriNetMassActionAnalysis {
     /// Object type for places.
     pub place_ob_type: ModalObType<Ustr>,

--- a/packages/catlog/src/stdlib/analyses/ode/mass_action.rs
+++ b/packages/catlog/src/stdlib/analyses/ode/mass_action.rs
@@ -5,6 +5,7 @@ mathematical epidemiology.
  */
 
 use std::collections::{BTreeMap, HashMap};
+use std::fmt::Debug;
 use std::hash::{BuildHasherDefault, Hash};
 
 use nalgebra::DVector;
@@ -18,8 +19,8 @@ use tsify::Tsify;
 
 use super::ODEAnalysis;
 use crate::dbl::{
-    model::{DiscreteTabModel, FgDblModel, TabEdge},
-    theory::{TabMorType, TabObType},
+    model::{DiscreteTabModel, FgDblModel, ModalDblModel, MutDblModel, TabEdge},
+    theory::{ModalMorType, ModalObType, TabMorType, TabObType},
 };
 use crate::one::FgCategory;
 use crate::simulate::ode::{NumericalPolynomialSystem, ODEProblem, PolynomialSystem};
@@ -48,13 +49,76 @@ where
     duration: f32,
 }
 
+/// Symbolic parameter in mass-action polynomial system.
 type Parameter<Id> = Polynomial<Id, f32, u8>;
+
+type PetriNetModel<Id> = ModalDblModel<Id, Ustr, BuildHasherDefault<IdentityHasher>>;
+
+/// Mass-action ODE analysis for Petri nets.
+pub struct PetriNetMassActionAnalysis {
+    /// Object type for places.
+    pub place_ob_type: ModalObType<Ustr>,
+    /// Morphism type for transitions.
+    pub transition_mor_type: ModalMorType<Ustr>,
+}
+
+impl Default for PetriNetMassActionAnalysis {
+    fn default() -> Self {
+        let ob_type = ModalObType::new(ustr("Object"));
+        Self {
+            place_ob_type: ob_type.clone(),
+            transition_mor_type: ModalMorType::Zero(ob_type),
+        }
+    }
+}
+
+impl PetriNetMassActionAnalysis {
+    /// Creates a mass-action system with symbolic rate coefficients.
+    pub fn build_system<Id: Eq + Clone + Hash + Ord + Debug>(
+        &self,
+        model: &PetriNetModel<Id>,
+    ) -> PolynomialSystem<Id, Parameter<Id>, u8> {
+        let mut sys = PolynomialSystem::new();
+        for ob in model.ob_generators_with_type(&self.place_ob_type) {
+            sys.add_term(ob, Polynomial::zero());
+        }
+        for mor in model.mor_generators_with_type(&self.transition_mor_type) {
+            let inputs = model
+                .get_dom(&mor)
+                .and_then(|ob| ob.clone().collect_product(None))
+                .unwrap_or_default();
+            let outputs = model
+                .get_cod(&mor)
+                .and_then(|ob| ob.clone().collect_product(None))
+                .unwrap_or_default();
+
+            let term: Monomial<_, _> =
+                inputs.iter().map(|ob| (ob.clone().unwrap_generator(), 1)).collect();
+            let term: Polynomial<_, _, _> =
+                [(Parameter::generator(mor), term)].into_iter().collect();
+            for input in inputs {
+                sys.add_term(input.unwrap_generator(), -term.clone());
+            }
+            for output in outputs {
+                sys.add_term(output.unwrap_generator(), term.clone());
+            }
+        }
+        sys
+    }
+
+    /// Creates a mass-action system with numerical rate coefficients.
+    pub fn build_numerical_system<Id: Eq + Clone + Hash + Ord + Debug>(
+        &self,
+        model: &PetriNetModel<Id>,
+        data: MassActionProblemData<Id>,
+    ) -> ODEAnalysis<Id, NumericalPolynomialSystem<u8>> {
+        into_numerical_system(self.build_system(model), data)
+    }
+}
+
 type StockFlowModel<Id> = DiscreteTabModel<Id, Ustr, BuildHasherDefault<IdentityHasher>>;
 
-/** Mass-action ODE analysis for stock-flow models.
-
-Mass action dynamics TODO
- */
+/// Mass-action ODE analysis for stock-flow models.
 pub struct StockFlowMassActionAnalysis {
     /// Object type for stocks.
     pub stock_ob_type: TabObType<Ustr, Ustr>,
@@ -77,11 +141,8 @@ impl Default for StockFlowMassActionAnalysis {
 }
 
 impl StockFlowMassActionAnalysis {
-    /** Creates a mass-action system from a model.
-
-    The resulting system has symbolic rate coefficients.
-     */
-    pub fn create_system<Id: Eq + Clone + Hash + Ord>(
+    /// Creates a mass-action system with symbolic rate coefficients.
+    pub fn build_system<Id: Eq + Clone + Hash + Ord>(
         &self,
         model: &StockFlowModel<Id>,
     ) -> PolynomialSystem<Id, Parameter<Id>, u8> {
@@ -114,7 +175,7 @@ impl StockFlowMassActionAnalysis {
             })
             .collect();
 
-        let mut sys: PolynomialSystem<Id, Parameter<Id>, u8> = PolynomialSystem::new();
+        let mut sys = PolynomialSystem::new();
         for ob in model.ob_generators_with_type(&self.stock_ob_type) {
             sys.add_term(ob, Polynomial::zero());
         }
@@ -129,34 +190,35 @@ impl StockFlowMassActionAnalysis {
         sys
     }
 
-    /** Creates a numerical mass-action system from a model.
-
-    The resulting system has numerical rate coefficients and is ready to solve.
-     */
-    pub fn create_numerical_system<Id: Eq + Clone + Hash + Ord>(
+    /// Creates a mass-action system with numerical rate coefficients.
+    pub fn build_numerical_system<Id: Eq + Clone + Hash + Ord>(
         &self,
         model: &StockFlowModel<Id>,
         data: MassActionProblemData<Id>,
     ) -> ODEAnalysis<Id, NumericalPolynomialSystem<u8>> {
-        let sys = self.create_system(model);
-
-        let objects: Vec<_> = sys.components.keys().cloned().collect();
-        let initial_values = objects
-            .iter()
-            .map(|ob| data.initial_values.get(ob).copied().unwrap_or_default());
-        let x0 = DVector::from_iterator(objects.len(), initial_values);
-
-        let sys = sys
-            .extend_scalars(|poly| {
-                poly.eval(|flow| data.rates.get(flow).copied().unwrap_or_default())
-            })
-            .to_numerical();
-
-        let problem = ODEProblem::new(sys, x0).end_time(data.duration);
-        let ob_index: BTreeMap<_, _> =
-            objects.into_iter().enumerate().map(|(i, x)| (x, i)).collect();
-        ODEAnalysis::new(problem, ob_index)
+        into_numerical_system(self.build_system(model), data)
     }
+}
+
+fn into_numerical_system<Id: Eq + Clone + Hash + Ord>(
+    sys: PolynomialSystem<Id, Parameter<Id>, u8>,
+    data: MassActionProblemData<Id>,
+) -> ODEAnalysis<Id, NumericalPolynomialSystem<u8>> {
+    let ob_index: BTreeMap<_, _> =
+        sys.components.keys().cloned().enumerate().map(|(i, x)| (x, i)).collect();
+    let n = ob_index.len();
+
+    let initial_values = ob_index
+        .keys()
+        .map(|ob| data.initial_values.get(ob).copied().unwrap_or_default());
+    let x0 = DVector::from_iterator(n, initial_values);
+
+    let sys = sys
+        .extend_scalars(|poly| poly.eval(|flow| data.rates.get(flow).copied().unwrap_or_default()))
+        .to_numerical();
+
+    let problem = ODEProblem::new(sys, x0).end_time(data.duration);
+    ODEAnalysis::new(problem, ob_index)
 }
 
 #[cfg(test)]
@@ -165,17 +227,29 @@ mod tests {
     use std::rc::Rc;
 
     use super::*;
-    use crate::stdlib::{models::backward_link, theories::th_category_links};
+    use crate::stdlib::{models::*, theories::*};
 
     #[test]
     fn backward_link_dynamics() {
         let th = Rc::new(th_category_links());
         let model = backward_link(th);
-        let analysis: StockFlowMassActionAnalysis = Default::default();
-        let sys = analysis.create_system(&model);
+        let sys = StockFlowMassActionAnalysis::default().build_system(&model);
         let expected = expect!([r#"
             dx = ((-1) f) x y
             dy = f x y
+        "#]);
+        expected.assert_eq(&sys.to_string());
+    }
+
+    #[test]
+    fn catalysis_dynamics() {
+        let th = Rc::new(th_sym_monoidal_category());
+        let model = catalyzed_reaction(th);
+        let sys = PetriNetMassActionAnalysis::default().build_system(&model);
+        let expected = expect!([r#"
+            dc = (0 f) c x
+            dx = ((-1) f) c x
+            dy = f c x
         "#]);
         expected.assert_eq(&sys.to_string());
     }

--- a/packages/catlog/src/stdlib/analyses/ode/mod.rs
+++ b/packages/catlog/src/stdlib/analyses/ode/mod.rs
@@ -1,8 +1,10 @@
 //! ODE analyses of models.
 
-use std::{collections::HashMap, hash::Hash};
+use std::collections::{BTreeMap, HashMap};
+use std::hash::Hash;
 
 use derivative::Derivative;
+use derive_more::Constructor;
 use ode_solvers::dop_shared::IntegrationError;
 
 #[cfg(feature = "serde")]
@@ -30,23 +32,16 @@ where
 }
 
 /// Data needed to simulate and interpret an ODE analysis of a model.
+#[derive(Constructor)]
 pub struct ODEAnalysis<Id, Sys> {
     /// ODE problem for the analysis.
     pub problem: ODEProblem<Sys>,
 
     /// Mapping from IDs in model (usually object IDs) to variable indices.
-    pub variable_index: HashMap<Id, usize>,
+    pub variable_index: BTreeMap<Id, usize>,
 }
 
 impl<Id, Sys> ODEAnalysis<Id, Sys> {
-    /// Constructs a new ODE analysis.
-    pub fn new(problem: ODEProblem<Sys>, variable_index: HashMap<Id, usize>) -> Self {
-        Self {
-            problem,
-            variable_index,
-        }
-    }
-
     /// Solves the ODE with reasonable default settings and collects results.
     pub fn solve_with_defaults(self) -> Result<ODESolution<Id>, IntegrationError>
     where
@@ -74,13 +69,13 @@ impl<Id, Sys> ODEAnalysis<Id, Sys> {
     }
 }
 
-#[allow(non_snake_case)]
 pub mod linear_ode;
-#[allow(non_snake_case)]
 pub mod lotka_volterra;
 #[allow(clippy::type_complexity)]
 pub mod mass_action;
+pub mod signed_coefficients;
 
 pub use linear_ode::*;
 pub use lotka_volterra::*;
 pub use mass_action::*;
+pub use signed_coefficients::*;

--- a/packages/catlog/src/stdlib/analyses/ode/signed_coefficients.rs
+++ b/packages/catlog/src/stdlib/analyses/ode/signed_coefficients.rs
@@ -1,0 +1,81 @@
+//! Helper module to build analyses based on signed coefficient matrices.
+
+use nalgebra::DMatrix;
+
+use std::collections::{BTreeMap, HashMap};
+use std::hash::Hash;
+
+use crate::dbl::model::FgDblModel;
+
+/** Builder for signed coefficient matrices and analyses based on them.
+
+Used to construct the [linear](Self::linear_ode_analysis) and
+[Lotka-Volterra](Self::lotka_volterra_analysis) ODE analyses.
+ */
+pub struct SignedCoefficientBuilder<ObType, MorType> {
+    var_ob_type: ObType,
+    positive_mor_types: Vec<MorType>,
+    negative_mor_types: Vec<MorType>,
+}
+
+impl<ObType, MorType> SignedCoefficientBuilder<ObType, MorType> {
+    /// Creates a new builder for the given object type.
+    pub fn new(var_ob_type: ObType) -> Self {
+        Self {
+            var_ob_type,
+            positive_mor_types: Vec::new(),
+            negative_mor_types: Vec::new(),
+        }
+    }
+
+    /// Adds a morphism type defining a positive interaction between objects.
+    pub fn add_positive(mut self, mor_type: MorType) -> Self {
+        self.positive_mor_types.push(mor_type);
+        self
+    }
+
+    /// Adds a morphism type defining a negative interaction between objects.
+    pub fn add_negative(mut self, mor_type: MorType) -> Self {
+        self.negative_mor_types.push(mor_type);
+        self
+    }
+
+    /** Builds the matrix of coefficients for the given model.
+
+    Returns the coefficient matrix along with an ordered map from object
+    generators to integer indices.
+     */
+    pub fn build_matrix<Id>(
+        &self,
+        model: &impl FgDblModel<ObType = ObType, MorType = MorType, Ob = Id, ObGen = Id, MorGen = Id>,
+        coeffs: &HashMap<Id, f32>,
+    ) -> (DMatrix<f32>, BTreeMap<Id, usize>)
+    where
+        Id: Eq + Clone + Hash + Ord,
+    {
+        let ob_index: BTreeMap<_, _> = model
+            .ob_generators_with_type(&self.var_ob_type)
+            .enumerate()
+            .map(|(i, x)| (x, i))
+            .collect();
+
+        let n = ob_index.len();
+        let mut mat = DMatrix::from_element(n, n, 0.0f32);
+        for mor_type in self.positive_mor_types.iter() {
+            for mor in model.mor_generators_with_type(mor_type) {
+                let i = *ob_index.get(&model.mor_generator_dom(&mor)).unwrap();
+                let j = *ob_index.get(&model.mor_generator_cod(&mor)).unwrap();
+                mat[(j, i)] += coeffs.get(&mor).copied().unwrap_or_default();
+            }
+        }
+        for mor_type in self.negative_mor_types.iter() {
+            for mor in model.mor_generators_with_type(mor_type) {
+                let i = *ob_index.get(&model.mor_generator_dom(&mor)).unwrap();
+                let j = *ob_index.get(&model.mor_generator_cod(&mor)).unwrap();
+                mat[(j, i)] -= coeffs.get(&mor).copied().unwrap_or_default();
+            }
+        }
+
+        (mat, ob_index)
+    }
+}

--- a/packages/catlog/src/stdlib/models.rs
+++ b/packages/catlog/src/stdlib/models.rs
@@ -96,19 +96,19 @@ pub fn walking_attr(th: Rc<UstrDiscreteDblTheory>) -> UstrDiscreteDblModel {
 
 /** The "walking" backward link.
 
-The free category with links having a link from the codomain of a morphism back
-to the morphism itself.
+This is the free category with links that has a link from the codomain of a
+morphism back to the morphism itself.
 
-In the system dynamics jargon, a backward link defines a "reinforcing loop,"
+In system dynamics jargon, a backward link defines a "reinforcing loop,"
 assuming the link has a positive effect on the flow. An example is an infection
 flow in a model of an infectious disease, where increasing the number of
 infectives increases the rate of infection of the remaining susceptibles (other
 things equal).
  */
 pub fn backward_link(th: Rc<UstrDiscreteTabTheory>) -> UstrDiscreteTabModel {
+    let ob_type = TabObType::Basic(ustr("Object"));
     let mut model = UstrDiscreteTabModel::new(th.clone());
     let (x, y, f) = (ustr("x"), ustr("y"), ustr("f"));
-    let ob_type = TabObType::Basic(ustr("Object"));
     model.add_ob(x, ob_type.clone());
     model.add_ob(y, ob_type.clone());
     model.add_mor(f, TabOb::Basic(x), TabOb::Basic(y), th.hom_type(ob_type));
@@ -117,6 +117,26 @@ pub fn backward_link(th: Rc<UstrDiscreteTabTheory>) -> UstrDiscreteTabModel {
         TabOb::Basic(y),
         model.tabulated_gen(f),
         TabMorType::Basic(ustr("Link")),
+    );
+    model
+}
+
+/** A reaction involving three species, one playing the role of a catalyst.
+
+A free symmetric monoidal category, viewed as a reaction network.
+ */
+pub fn catalyzed_reaction(th: Rc<UstrModalDblTheory>) -> UstrModalDblModel {
+    let (ob_type, op) = (ModalObType::new(ustr("Object")), ustr("tensor"));
+    let mut model = UstrModalDblModel::new(th);
+    let (x, y, c) = (ustr("x"), ustr("y"), ustr("c"));
+    model.add_ob(x, ob_type.clone());
+    model.add_ob(y, ob_type.clone());
+    model.add_ob(c, ob_type.clone());
+    model.add_mor(
+        ustr("f"),
+        ModalOb::App(ModalOb::List(List::Symmetric, vec![x.into(), c.into()]).into(), op),
+        ModalOb::App(ModalOb::List(List::Symmetric, vec![y.into(), c.into()]).into(), op),
+        ModalMorType::Zero(ob_type),
     );
     model
 }
@@ -155,5 +175,11 @@ mod tests {
     fn categories_with_links() {
         let th = Rc::new(th_category_links());
         assert!(backward_link(th).validate().is_ok());
+    }
+
+    #[test]
+    fn sym_monoidal_categories() {
+        let th = Rc::new(th_sym_monoidal_category());
+        assert!(catalyzed_reaction(th).validate().is_ok());
     }
 }

--- a/packages/catlog/src/zero/rig.rs
+++ b/packages/catlog/src/zero/rig.rs
@@ -15,7 +15,7 @@ the same data structure, but with different notation!
  */
 
 use num_traits::{One, Pow, Zero};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, btree_map};
 use std::fmt::Display;
 use std::iter::{Product, Sum};
 use std::ops::{Add, AddAssign, Mul, MulAssign, Neg};
@@ -102,7 +102,7 @@ elements of the set.
 Combinations have exactly the same underlying data structure as
 [monomials](Monomial), but are written additively rather than multiplicatively.
  */
-#[derive(Clone, PartialEq, Eq, Derivative)]
+#[derive(Clone, PartialEq, Eq, Debug, Derivative)]
 #[derivative(Default(bound = ""))]
 pub struct Combination<Var, Coef>(BTreeMap<Var, Coef>);
 
@@ -163,6 +163,14 @@ where
         assert!(iter.next().is_none(), "Too many values");
         value
     }
+
+    /// Normalizes the combination by dropping terms with coefficient zero.
+    pub fn normalize(self) -> Self
+    where
+        Coef: Zero,
+    {
+        self.into_iter().filter(|(coef, _)| !coef.is_zero()).collect()
+    }
 }
 
 /// Constructs a combination from a list of terms (coefficient-variable pairs).
@@ -172,7 +180,7 @@ where
     Coef: Add<Output = Coef>,
 {
     fn from_iter<T: IntoIterator<Item = (Coef, Var)>>(iter: T) -> Self {
-        let mut combination = Combination::zero();
+        let mut combination = Combination::default();
         for rhs in iter {
             combination += rhs;
         }
@@ -180,14 +188,10 @@ where
     }
 }
 
-/// Iterates over the terms (coefficient-variable pairs) of the polynomial.
+/// Iterates over the terms (coefficient-variable pairs) of the combination.
 impl<Var, Coef> IntoIterator for Combination<Var, Coef> {
     type Item = (Coef, Var);
-
-    type IntoIter = std::iter::Map<
-        std::collections::btree_map::IntoIter<Var, Coef>,
-        fn((Var, Coef)) -> (Coef, Var),
-    >;
+    type IntoIter = std::iter::Map<btree_map::IntoIter<Var, Coef>, fn((Var, Coef)) -> (Coef, Var)>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter().map(|(var, coef)| (coef, var))
@@ -196,9 +200,8 @@ impl<Var, Coef> IntoIterator for Combination<Var, Coef> {
 
 impl<'a, Var, Coef> IntoIterator for &'a Combination<Var, Coef> {
     type Item = (&'a Coef, &'a Var);
-
     type IntoIter = std::iter::Map<
-        std::collections::btree_map::Iter<'a, Var, Coef>,
+        btree_map::Iter<'a, Var, Coef>,
         fn((&'a Var, &'a Coef)) -> (&'a Coef, &'a Var),
     >;
 
@@ -296,14 +299,14 @@ where
 impl<Var, Coef> Zero for Combination<Var, Coef>
 where
     Var: Ord,
-    Coef: Add<Output = Coef>,
+    Coef: Add<Output = Coef> + Zero,
 {
     fn zero() -> Self {
         Combination(Default::default())
     }
 
     fn is_zero(&self) -> bool {
-        self.0.is_empty()
+        self.0.values().all(|coef| coef.is_zero())
     }
 }
 
@@ -385,7 +388,7 @@ monomials themselves become ordered under the lexicographic order. This is a
 valid *monomial ordering* as used in Groebner bases
 ([*IVA*](crate::refs::IdealsVarietiesAlgorithms), Section 2.2).
  */
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Derivative)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Derivative)]
 #[derivative(Default(bound = ""))]
 pub struct Monomial<Var, Exp>(BTreeMap<Var, Exp>);
 
@@ -447,6 +450,14 @@ where
     {
         self.0.iter().map(|(var, exp)| (f(var), exp.clone())).collect()
     }
+
+    /// Normalizes the monomial by dropping terms with exponent zero.
+    pub fn normalize(self) -> Self
+    where
+        Exp: Zero,
+    {
+        self.into_iter().filter(|(_, exp)| !exp.is_zero()).collect()
+    }
 }
 
 /// Constructs a monomial from a sequence of variable-exponent pairs.
@@ -456,11 +467,21 @@ where
     Exp: Add<Output = Exp>,
 {
     fn from_iter<T: IntoIterator<Item = (Var, Exp)>>(iter: T) -> Self {
-        let mut monomial = Monomial::one();
+        let mut monomial = Monomial::default();
         for rhs in iter {
             monomial *= rhs;
         }
         monomial
+    }
+}
+
+/// Iterates over the terms (variable-exponent pairs) of the monomial.
+impl<Var, Exp> IntoIterator for Monomial<Var, Exp> {
+    type Item = (Var, Exp);
+    type IntoIter = btree_map::IntoIter<Var, Exp>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 
@@ -535,14 +556,14 @@ where
 impl<Var, Exp> One for Monomial<Var, Exp>
 where
     Var: Ord,
-    Exp: Add<Output = Exp>,
+    Exp: Add<Output = Exp> + Zero,
 {
     fn one() -> Self {
         Monomial(Default::default())
     }
 
     fn is_one(&self) -> bool {
-        self.0.is_empty()
+        self.0.values().all(|exp| exp.is_zero())
     }
 }
 
@@ -596,7 +617,11 @@ mod tests {
 
         let x = Combination::generator('x');
         assert_eq!((x.clone() * -1i32).to_string(), "(-1) x");
-        assert_eq!(x.neg().to_string(), "(-1) x");
+        assert_eq!(x.clone().neg().to_string(), "(-1) x");
+
+        let combination = x.clone() + x.neg();
+        assert_ne!(combination, Combination::default());
+        assert_eq!(combination.normalize(), Combination::default());
     }
 
     #[test]
@@ -614,5 +639,8 @@ mod tests {
         assert_eq!(monomial.map_variables(|_| 'x').to_string(), "x^3");
 
         assert_eq!(Monomial::<char, u32>::one().to_string(), "1");
+
+        let monomial: Monomial<_, u32> = [('x', 1), ('y', 0), ('x', 2)].into_iter().collect();
+        assert_eq!(monomial.normalize().to_string(), "x^3");
     }
 }

--- a/packages/frontend/src/stdlib/theories.tsx
+++ b/packages/frontend/src/stdlib/theories.tsx
@@ -731,6 +731,11 @@ stdTheories.add(
                     name: "Visualization",
                     description: "Visualize the Petri net",
                 }),
+                analyses.configureMassAction({
+                    simulate(model, data) {
+                        return thSymMonoidalCategory.massAction(model, data);
+                    },
+                }),
             ],
         });
     },

--- a/packages/notebook-types/Cargo.toml
+++ b/packages/notebook-types/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2024"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-nonempty = { version = "0.10", features = ["serialize"] }
+nonempty = { version = "0.12", features = ["serialize"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 tsify = { version = "0.5", features = ["js"] }
 ustr = { version = "1.1.0", features = ["serde"] }
-uuid = { version = "1.11", features = ["serde", "v7", "js"] }
+uuid = { version = "1.11", features = ["serde", "v7"] }
 wasm-bindgen = "0.2.100"


### PR DESCRIPTION
Sequel to #597 adding the ODE semantics for Petri nets based on the law of mass action.

I also took the opportunity to refactor the linear ODE/Lotka-Volterra analyses to reuse the code that constructs the coefficient matrix (cc @tim-at-topos).