### PR TITLE
Allow vertical scrolling in theory selector

### DIFF
--- a/packages/frontend/src/model/theory_selector.css
+++ b/packages/frontend/src/model/theory_selector.css
@@ -8,6 +8,10 @@
     border-top: transparent;
     border-left: transparent;
 
+    max-height: 80vh;
+    overflow-y: auto;
+    scrollbar-width: none;
+
     & input[type="radio"] {
         position: absolute;
         opacity: 0;


### PR DESCRIPTION
The list of theories is likely to grow over time, so this small PR adds scrolling on the theory selector when the screen height is small, like on floating windows (or mobile, for CatColabbators on the go).