### PR TITLE
Exclude Nix from GitHub language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+infrastructure/ -linguist-detectable
+*.nix -linguist-detectable


### PR DESCRIPTION
GitHub is currently reporting that our repo is like 30% Nix, a claim that I sure hope isn't true and that I find a little offensive.