### PR TITLE
fix(notebook): prevent cell drop onto itself

### DIFF
--- a/packages/frontend/src/notebook/notebook_cell.tsx
+++ b/packages/frontend/src/notebook/notebook_cell.tsx
@@ -19,6 +19,7 @@ import {
 } from "../components";
 
 import ArrowDown from "lucide-solid/icons/arrow-down";
+import Copy from "lucide-solid/icons/copy";
 import ArrowUp from "lucide-solid/icons/arrow-up";
 import GripVertical from "lucide-solid/icons/grip-vertical";
 import Plus from "lucide-solid/icons/plus";
@@ -61,6 +62,9 @@ export type CellActions = {
 
     /** Delete this cell in the forward/downward direction. */
     deleteForward: () => void;
+
+    /** Duplicate this cell, adding the new cell below this one. */
+    duplicate?: () => void;
 
     /** Move this cell up, if possible. */
     moveUp: () => void;
@@ -129,6 +133,15 @@ export function NotebookCell(props: {
             icon: <Trash2 size={16} />,
             onComplete: props.actions.deleteForward,
         },
+        ...(props.actions.duplicate
+            ? [
+                  {
+                      name: "Duplicate",
+                      icon: <Copy size={16} />,
+                      onComplete: props.actions.duplicate,
+                  },
+              ]
+            : []),
         {
             name: "Move Up",
             icon: <ArrowUp size={16} />,

--- a/packages/frontend/src/notebook/notebook_cell.tsx
+++ b/packages/frontend/src/notebook/notebook_cell.tsx
@@ -19,8 +19,8 @@ import {
 } from "../components";
 
 import ArrowDown from "lucide-solid/icons/arrow-down";
-import Copy from "lucide-solid/icons/copy";
 import ArrowUp from "lucide-solid/icons/arrow-up";
+import Copy from "lucide-solid/icons/copy";
 import GripVertical from "lucide-solid/icons/grip-vertical";
 import Plus from "lucide-solid/icons/plus";
 import Trash2 from "lucide-solid/icons/trash-2";

--- a/packages/frontend/src/notebook/notebook_cell.tsx
+++ b/packages/frontend/src/notebook/notebook_cell.tsx
@@ -175,6 +175,9 @@ export function NotebookCell(props: {
                 element: rootRef,
                 canDrop({ source }) {
                     // TODO: Reject if cell belongs to a different notebook.
+                    if (source.data.cellId === props.cellId) {
+                        return false;
+                    }
                     return isCellDragData(source.data);
                 },
                 getData({ input }) {

--- a/packages/frontend/src/notebook/notebook_editor.tsx
+++ b/packages/frontend/src/notebook/notebook_editor.tsx
@@ -22,7 +22,6 @@ import invariant from "tiny-invariant";
 
 import type { Cell, Notebook } from "catlog-wasm";
 import { type Completion, IconButton } from "../components";
-import { deepCopyJSON } from "../util/deepcopy";
 import {
     type CellActions,
     type FormalCellEditorProps,

--- a/packages/frontend/src/notebook/notebook_editor.tsx
+++ b/packages/frontend/src/notebook/notebook_editor.tsx
@@ -22,6 +22,7 @@ import invariant from "tiny-invariant";
 
 import type { Cell, Notebook } from "catlog-wasm";
 import { type Completion, IconButton } from "../components";
+import { deepCopyJSON } from "../util/deepcopy";
 import {
     type CellActions,
     type FormalCellEditorProps,
@@ -99,25 +100,24 @@ export function NotebookEditor<T>(props: {
     };
 
     const addOrReplaceActiveCell = (cell: Cell<T>) => {
-        const cellId = props.notebook.cellOrder[activeCell()];
-        const c = !cellId ? null : props.notebook.cellContents[cellId];
-        if (c) {
-            if (c.tag === "formal" || c.tag === "rich-text") {
-                addAfterActiveCell(cell);
-            } else if (c.tag === "stem") {
-                replaceCellWith(activeCell(), cell);
-            }
-        } else {
+        const c = NotebookUtils.tryGetCellByIndex(props.notebook, activeCell());
+        if (!c) {
             addAfterActiveCell(cell);
+            return;
+        }
+
+        if (c.tag === "formal" || c.tag === "rich-text") {
+            addAfterActiveCell(cell);
+        } else if (c.tag === "stem") {
+            replaceCellWith(activeCell(), cell);
         }
     };
 
     const appendCell = (cell: Cell<T>) => {
         props.changeNotebook((nb) => {
-            nb.cellOrder.push(cell.id);
-            nb.cellContents[cell.id] = cell;
-            setActiveCell(nb.cellOrder.length - 1);
+            NotebookUtils.appendCell(nb, cell);
         });
+        setActiveCell(NotebookUtils.numCells(props.notebook) - 1);
     };
 
     const insertCommands = (): Completion[] =>
@@ -215,9 +215,7 @@ export function NotebookEditor<T>(props: {
                         axis: "vertical",
                     });
                     props.changeNotebook((nb) => {
-                        const [cellId] = nb.cellOrder.splice(sourceIndex, 1);
-                        // biome-ignore lint/style/noNonNullAssertion:
-                        nb.cellOrder.splice(finalIndex, 0, cellId!);
+                        NotebookUtils.moveCellByIndex(nb, sourceIndex, finalIndex);
                     });
                     setTether(null);
                     setCurrentDropTarget(null);
@@ -263,32 +261,32 @@ export function NotebookEditor<T>(props: {
                                 }
                             },
                             createAbove() {
+                                const index = i();
                                 props.changeNotebook((nb) => {
-                                    const index = i();
                                     NotebookUtils.newStemCellAtIndex(nb, index);
-                                    setActiveCell(index);
                                 });
+                                setActiveCell(index);
                             },
                             createBelow() {
+                                const index = i() + 1;
                                 props.changeNotebook((nb) => {
-                                    const index = i() + 1;
                                     NotebookUtils.newStemCellAtIndex(nb, index);
-                                    setActiveCell(index);
                                 });
+                                setActiveCell(index);
                             },
                             deleteBackward() {
+                                const index = i();
                                 props.changeNotebook((nb) => {
-                                    const index = i();
                                     NotebookUtils.deleteCellAtIndex(nb, index);
-                                    setActiveCell(index - 1);
                                 });
+                                setActiveCell(index - 1);
                             },
                             deleteForward() {
+                                const index = i();
                                 props.changeNotebook((nb) => {
-                                    const index = i();
                                     NotebookUtils.deleteCellAtIndex(nb, index);
-                                    setActiveCell(index);
                                 });
+                                setActiveCell(index);
                             },
                             moveUp() {
                                 props.changeNotebook((nb) => {
@@ -307,6 +305,20 @@ export function NotebookEditor<T>(props: {
 
                         const cell = props.notebook.cellContents[cellId];
                         invariant(cell, `Failed to find contents for cell '${cellId}'`);
+
+                        if (cell.tag !== "rich-text") {
+                            cellActions.duplicate = () => {
+                                const index = i();
+                                props.changeNotebook((nb) => {
+                                    NotebookUtils.duplicateCellAtIndex(
+                                        nb,
+                                        index,
+                                        props.duplicateCell,
+                                    );
+                                });
+                                setActiveCell(index + 1);
+                            };
+                        }
 
                         return (
                             <li>

--- a/packages/frontend/src/notebook/types.ts
+++ b/packages/frontend/src/notebook/types.ts
@@ -2,6 +2,8 @@ import invariant from "tiny-invariant";
 import { v7 } from "uuid";
 
 import type { Cell, Notebook, NotebookCell } from "catlog-wasm";
+import { deepCopyJSON } from "../util/deepcopy";
+import { assertExhaustive } from "../util/assert_exhaustive";
 
 /** Creates an empty notebook. */
 export const newNotebook = <T>(): Notebook<T> => ({
@@ -60,6 +62,19 @@ export namespace NotebookUtils {
         const cellId = getCellIdByIndex(notebook, index);
         return getCellById(notebook, cellId);
     }
+    export function tryGetCellByIndex<T>(notebook: Notebook<T>, index: number): Cell<T> | null {
+        const cellId = notebook.cellOrder[index];
+        if (!cellId) {
+            return null;
+        }
+
+        const cell = notebook.cellContents[cellId];
+        if (!cell) {
+            return null;
+        }
+
+        return cell;
+    }
 
     export function insertCellAtIndex<T>(notebook: Notebook<T>, cell: Cell<T>, index: number) {
         notebook.cellOrder.splice(index, 0, cell.id);
@@ -97,12 +112,47 @@ export namespace NotebookUtils {
         notebook.cellOrder.splice(index + 1, 0, cellIdToMoveUp);
     }
 
+    export function moveCellByIndex<T>(notebook: Notebook<T>, fromIndex: number, toIndex: number) {
+        const [cellId] = notebook.cellOrder.splice(fromIndex, 1);
+        invariant(cellId, () => `Failed to move cell from index '${fromIndex}'`);
+        notebook.cellOrder.splice(toIndex, 0, cellId);
+    }
+
     export function hasFormalCells<T>(notebook: Notebook<T>): boolean {
         return notebook.cellOrder.some((cellId) => notebook.cellContents[cellId]?.tag === "formal");
     }
 
     export function numCells<T>(notebook: Notebook<T>): number {
         return notebook.cellOrder.length;
+    }
+
+    function duplicateCell<T>(cell: Cell<T>, duplicateFn?: (cellContent: T) => T): Cell<T> {
+        switch (cell.tag) {
+            case "formal":
+                const content = (duplicateFn ?? deepCopyJSON)(cell.content);
+                return newFormalCell(content);
+            case "rich-text":
+                throw new Error(`Rich text cells may not be duplicated`);
+            case "stem":
+                return newStemCell();
+            default:
+                assertExhaustive(cell);
+        }
+    }
+
+    export function duplicateCellAtIndex<T>(
+        notebook: Notebook<T>,
+        index: number,
+        duplicateFn?: (cellContent: T) => T,
+    ) {
+        const cell = getCellByIndex(notebook, index);
+        const newCell = duplicateCell(cell, duplicateFn);
+        insertCellAtIndex(notebook, newCell, index + 1);
+    }
+
+    export function appendCell<T>(notebook: Notebook<T>, cell: Cell<T>) {
+        notebook.cellOrder.push(cell.id);
+        notebook.cellContents[cell.id] = cell;
     }
 
     export function mutateCellContentById<T>(

--- a/packages/frontend/src/notebook/types.ts
+++ b/packages/frontend/src/notebook/types.ts
@@ -2,8 +2,8 @@ import invariant from "tiny-invariant";
 import { v7 } from "uuid";
 
 import type { Cell, Notebook, NotebookCell } from "catlog-wasm";
-import { deepCopyJSON } from "../util/deepcopy";
 import { assertExhaustive } from "../util/assert_exhaustive";
+import { deepCopyJSON } from "../util/deepcopy";
 
 /** Creates an empty notebook. */
 export const newNotebook = <T>(): Notebook<T> => ({
@@ -128,11 +128,12 @@ export namespace NotebookUtils {
 
     function duplicateCell<T>(cell: Cell<T>, duplicateFn?: (cellContent: T) => T): Cell<T> {
         switch (cell.tag) {
-            case "formal":
+            case "formal": {
                 const content = (duplicateFn ?? deepCopyJSON)(cell.content);
                 return newFormalCell(content);
+            }
             case "rich-text":
-                throw new Error(`Rich text cells may not be duplicated`);
+                throw new Error("Rich text cells may not be duplicated");
             case "stem":
                 return newStemCell();
             default:

--- a/packages/notebook-types/README.md
+++ b/packages/notebook-types/README.md
@@ -4,7 +4,7 @@ This package defines all versions of notebook types that we have used in CatCola
 
 We start with `v0`, which is meant to be fully compatible with the JSON types that were stored in Automerge when they were defined in Javascript. This is the last version which does not declare its version number. Each successive version will be stored alongside a version number, and a migration function from the previous version.
 
-Versions are identified by a single incrementing integer. Versions may import type definitions from past versions. The last version is aliased as "current". We make a sum type over all versions with a `.to_current()` method which upgrades from any previous version to the current version.
+Versions are identified by a single incrementing integer. Versions may import type definitions from past versions. The last version is aliased as "current". We make a sum type over all versions, that sum type will implement a `.to_current()` method which upgrades from any previous version to the current version.
 
 Version may undergo changes in types only during development; once a version has been committed to `main`, it is frozen. This is so that we don't have to ever purge notebooks from the development server. However, adding a new version shouldn't be too onerous, so this is not a huge limitation in practice.
 


### PR DESCRIPTION
Fixes issue #579 

Dragging a cell onto itself causes a UI update, likely due to an internal Automerge change, even though the actual data remains the same.

This fix resolves the problem by preventing cells from being dropped onto themselves.