### PR TITLE
Automatically clean up old NixOS generations

### DIFF
--- a/infrastructure/modules/catcolab/host.nix
+++ b/infrastructure/modules/catcolab/host.nix
@@ -47,5 +47,15 @@ with lib;
         experimental-features = nix-command flakes
       '';
     };
+
+    programs.nh = {
+      enable = true;
+
+      clean = {
+        enable = true;
+        extraArgs = "--keep 5 --keep-since 5d";
+        dates = "weekly";
+      };
+    };
   };
 }


### PR DESCRIPTION
Closes #642

Keep at least 5 generations and at least the generations from the last 5 days.