### PR TITLE
Fix title of model being needlessly cut off

### DIFF
--- a/packages/frontend/src/model/model_editor.css
+++ b/packages/frontend/src/model/model_editor.css
@@ -6,7 +6,6 @@
 
     & .title {
         font-size: var(--h1-font-size);
-        flex: 1;
     }
 
     & .theory-selector-trigger {


### PR DESCRIPTION
It is currently being cut off when it exceeds ~50% of the available space.

cc @tim-at-topos since this was introduced in #553. Not sure what was the intended effect, but feel free to have another go if there's something you're after.