### PR TITLE
More developer documentation redirects

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -180,6 +180,7 @@ jobs:
           echo '/dev/core /dev/rust/catlog' >> site/_redirects
           echo '/dev/backend /dev/rust/catcolab_backend' >> site/_redirects
           echo '/math /math/index.xml' >> site/_redirects
+          echo '/maths /math/index.xml' >> site/_redirects
           echo '/* /index.html 200' >> site/_redirects
           cd .netlify-env
           prod_flag=""

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Build Rust docs
         run: |
-          cargo doc --all-features --no-deps
+          cargo doc --all-features --no-deps --workspace --exclude "migrator"
 
       - name: Upload Rust docs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -177,6 +177,8 @@ jobs:
           mv frontend_docs site/dev/frontend
           mv math-docs site/math
           echo '/dev/rust /dev/rust/catlog' >> site/_redirects
+          echo '/dev/core /dev/rust/catlog' >> site/_redirects
+          echo '/dev/backend /dev/rust/catcolab_backend' >> site/_redirects
           echo '/math /math/index.xml' >> site/_redirects
           echo '/* /index.html 200' >> site/_redirects
           cd .netlify-env


### PR DESCRIPTION
URL redirects:
- `/dev/core` ➟ `/dev/rust/catlog`
- `/dev/backend` ➟ `/dev/rust/catcolab_backend`
- `/maths` ➟ `/math`

Also:
- exclude `migrator` from appearing in the `/dev/rust/` documentation