### PR TITLE
Add dialog with suggestion to duplicate view-only model

### DIFF
--- a/packages/frontend/src/api/duplicate_document.ts
+++ b/packages/frontend/src/api/duplicate_document.ts
@@ -1,0 +1,36 @@
+import { type LiveDiagramDocument, createDiagramFromDocument } from "../diagram/document";
+import { type LiveModelDocument, createModel } from "../model/document";
+import { assertExhaustive } from "../util/assert_exhaustive";
+import type { Api } from "./";
+
+/**
+ * Duplicates a document (diagram or model) and returns the new reference ID.
+ * The duplicated document will have " (copy)" appended to its name.
+ */
+export async function duplicateDocument(
+    api: Api,
+    liveDocument: LiveDiagramDocument | LiveModelDocument,
+): Promise<string> {
+    if (!liveDocument) {
+        throw new Error("Cannot duplicate: liveDocument not provided");
+    }
+
+    switch (liveDocument.type) {
+        case "diagram": {
+            const diagram = liveDocument.liveDoc.doc;
+            return createDiagramFromDocument(api, {
+                ...diagram,
+                name: `${diagram.name} (copy)`,
+            });
+        }
+        case "model": {
+            const model = liveDocument.liveDoc.doc;
+            return createModel(api, {
+                ...model,
+                name: `${model.name} (copy)`,
+            });
+        }
+        default:
+            assertExhaustive(liveDocument);
+    }
+}

--- a/packages/frontend/src/components/form.css
+++ b/packages/frontend/src/components/form.css
@@ -26,6 +26,7 @@ form button {
     justify-content: center;
     align-items: center;
     gap: 0.25rem;
+    margin: 0.25rem;
 }
 
 form button.utility {

--- a/packages/frontend/src/diagram/diagram_editor.tsx
+++ b/packages/frontend/src/diagram/diagram_editor.tsx
@@ -63,6 +63,7 @@ export function DiagramDocumentEditor(props: {
                 <PermissionsButton
                     permissions={props.liveDiagram.liveDoc.permissions}
                     refId={props.liveDiagram.refId}
+                    liveDocument={props.liveDiagram}
                 />
             </Toolbar>
             <DiagramPane liveDiagram={props.liveDiagram} />

--- a/packages/frontend/src/model/model_editor.tsx
+++ b/packages/frontend/src/model/model_editor.tsx
@@ -66,6 +66,7 @@ export function ModelDocumentEditor(props: {
                 <PermissionsButton
                     permissions={props.liveModel.liveDoc.permissions}
                     refId={props.liveModel.refId}
+                    liveDocument={props.liveModel}
                 />
             </Toolbar>
             <ModelPane liveModel={props.liveModel} />

--- a/packages/frontend/src/page/document_menu.tsx
+++ b/packages/frontend/src/page/document_menu.tsx
@@ -3,12 +3,9 @@ import { Match, Show, Switch } from "solid-js";
 
 import { createAnalysis } from "../analysis/document";
 import { type StableRef, useApi } from "../api";
-import {
-    type LiveDiagramDocument,
-    createDiagram,
-    createDiagramFromDocument,
-} from "../diagram/document";
-import { type LiveModelDocument, createModel } from "../model/document";
+import { duplicateDocument } from "../api/duplicate_document";
+import { type LiveDiagramDocument, createDiagram } from "../diagram/document";
+import type { LiveModelDocument } from "../model/document";
 import {
     AppMenu,
     ImportMenuItem,
@@ -17,7 +14,6 @@ import {
     MenuSeparator,
     NewModelItem,
 } from "../page";
-import { assertExhaustive } from "../util/assert_exhaustive";
 import { copyToClipboard, downloadJson } from "../util/json_export";
 
 import ChartSpline from "lucide-solid/icons/chart-spline";
@@ -66,28 +62,8 @@ export function DocumentMenu(props: {
     };
 
     const onDuplicateDocument = async () => {
-        switch (props.liveDocument.type) {
-            case "diagram": {
-                const diagram = props.liveDocument.liveDoc.doc;
-                const newRef = await createDiagramFromDocument(api, {
-                    ...diagram,
-                    name: `${diagram.name} (copy)`,
-                });
-                navigate(`/diagram/${newRef}`);
-                break;
-            }
-            case "model": {
-                const model = props.liveDocument.liveDoc.doc;
-                const newRef = await createModel(api, {
-                    ...model,
-                    name: `${model.name} (copy)`,
-                });
-                navigate(`/model/${newRef}`);
-                break;
-            }
-            default:
-                assertExhaustive(props.liveDocument);
-        }
+        const newRef = await duplicateDocument(api, props.liveDocument);
+        navigate(`/${props.liveDocument.type}/${newRef}`);
     };
 
     const onDownloadJSON = () => {

--- a/packages/frontend/src/user/permissions.css
+++ b/packages/frontend/src/user/permissions.css
@@ -22,3 +22,12 @@
     display: flex;
     flex-grow: 1;
 }
+
+.duplicate-button-container {
+    display: flex;
+    margin-top: 0.5rem;
+}
+
+.duplicate-button-height-text {
+    line-height: 2.75em;
+}

--- a/packages/frontend/src/user/permissions.tsx
+++ b/packages/frontend/src/user/permissions.tsx
@@ -318,8 +318,13 @@ const ReadonlyPermissionsButton = (props: {
 };
 
 const ReadonlyPermissionsTrigger = (props: ComponentProps<"button">) => {
+    const tooltip = (
+        <>
+            This document is <strong>read-only</strong>. Click to see more info.
+        </>
+    );
     return (
-        <IconButton {...props}>
+        <IconButton {...props} tooltip={tooltip}>
             <FileLock />
         </IconButton>
     );


### PR DESCRIPTION
Partly addresses #376. I think the model/doc should also auto-duplicate when the user starts editing it.

<img width="674" height="277" alt="image" src="https://github.com/user-attachments/assets/f6b218f0-588e-4cf2-b5d2-04c7ba8b31c4" />
