### PR TITLE
Update citation link in schema documentation to correct arXiv link

### DIFF
--- a/packages/frontend/src/help/logics/simple-schema.mdx
+++ b/packages/frontend/src/help/logics/simple-schema.mdx
@@ -30,7 +30,7 @@ Note that consistency constraints on the schema are also not yet supported, thou
 
 ### Further reading
 
-- Evan Patterson, Owen Lynch, James Fairbanks, "Categorical Data Structures for Technical Computing", *Compositionality* **4** (2022). [arXiv:2202.12345](https://arxiv.org/abs/2202.12345) [DOI:10.32408/compositionality-4-5](
+- Evan Patterson, Owen Lynch, James Fairbanks, "Categorical Data Structures for Technical Computing", *Compositionality* **4** (2022). [arXiv:2106.04703v5](https://arxiv.org/abs/2106.04703v5) [DOI:10.32408/compositionality-4-5](
 https://doi.org/10.32408/compositionality-4-5)
 - Brendan Fong, David I. Spivak, "Databases: Categories, Functors, and Universal Constructions" in *An Invitation to Applied Category Theory* (2019). [arXiv:1803.05316](https://arxiv.org/abs/1803.05316) [DOI:10.1017/9781108668804](
     https://doi.org/10.1017/9781108668804)


### PR DESCRIPTION
Fix documentation typo: this link was going to a seemingly unrelated paper.