### PR TITLE
Reorganize landing page for math docs

### DIFF
--- a/math-docs/trees/bib-0002.tree
+++ b/math-docs/trees/bib-0002.tree
@@ -1,8 +1,21 @@
-\title{Double categories}
+\title{Double category theory}
 \taxon{bibliography}
 
+\p{General double category theory:}
+
 \ul{
-\li{General reference: [[grandis-2019]]}
+\li{A textbook: [[grandis-2019]]}
+}
+
+\p{Double-categorical logic:}
+
+\ul{
 \li{[[cartesian-double-theories-2024]]}
 \li{[[double-products-2024]]}
+}
+
+\p{Background on categorical logic:}
+
+\ul{
+\li{[[shulman-2016]]}
 }

--- a/math-docs/trees/dbl-0001.tree
+++ b/math-docs/trees/dbl-0001.tree
@@ -1,4 +1,4 @@
-\title{Background on double categories}
+\title{Double category theory}
 
 \p{General double category theory:
 \ul{
@@ -6,11 +6,14 @@
 }
 }
 
-\p{Double theories and models:
+\p{Double-categorical logic:
 \ul{
 \li{[[dbl-0008]]}
 \li{[Discrete models](dbl-0005)}
 \li{[Free models](dbl-000D)}
 \li{[[dbl-000C]]}
+\li{[[mdt-0008]]}
 }
+
+\p{Bibliography: [[bib-0002]]}
 }

--- a/math-docs/trees/mat-0001.tree
+++ b/math-docs/trees/mat-0001.tree
@@ -1,29 +1,43 @@
 \title{CatColab: Mathematical Documentation}
 \import{macros}
 
+\subtree{
+\title{Introduction}
+
 \p{
   As the name suggests, CatColab is based on mathematical ideas from category
-  theory. It is a specific design goal that the system be usable \em{without} any
-  knowledge of such ideas. Still, for those curious about the underlying
-  mathematics, here are a few pointers for further reading.
+  theory. It is a specific design goal that the system be usable \em{without}
+  any knowledge of such ideas. These docs are for people who want to know about
+  the mathematics, perhaps because they want to develop the core package
+  [catlog](/dev/rust/catlog/) or just out of curiosity. At the moment, these
+  pages are from being a self-contained introduction, serving mainly to collect
+  new bits of CatColab-related mathematics as they are created. For proper
+  exposition, see the [published literature](bib-0001).
 }
 
 \p{
-  CatColab is an editor for categorical structures and their morphisms and higher
-  morphisms. The meta-logical framework organizing these categorical structures is
-  based on [double category theory](https://mathoverflow.net/q/476936). More
-  precisely, the \strong{domain-specific logics} in CatColab are defined by [double
-  theories](https://arxiv.org/abs/2310.05384), and the \strong{models} in CatColab are
-  models of double theories.
+  In mathematical terms, CatColab is an editor for categorical structures and
+  their morphisms and higher morphisms. The meta-logical framework organizing
+  these categorical structures is based on [double category
+  theory](https://mathoverflow.net/q/476936). More precisely, the
+  \strong{domain-specific logics} in CatColab are defined by [double
+  theories](cartesian-double-theories-2024), and the \strong{models} in
+  CatColab are models of double theories.
 }
 
 \p{
-  The library of domain-specific logics in CatColab, available now and to grow
-  over time, is inspired by a wide body of research in applied category theory and
-  beyond. Incomplete bibliographies are in [\code{bib-0001}](https://next.catcolab.org/math/bib-0001.xml) and the [\code{catlog} docs](https://next.catcolab.org/dev/rust/catlog/refs).
+  The library of domain-specific logics in CatColab is inspired by a wide body
+  of research in applied category theory and beyond. Incomplete bibliographies
+  are in [these docs](bib-0003) and the [\code{catlog}
+  docs](https://next.catcolab.org/dev/rust/catlog/refs).
+}
 }
 
-\p{Doctrines whose free objects have a systems interpretation:}
+\subtree{
+\title{Doctrines}
+
+\p{Systems of categorical logic, or \em{doctrines}, whose free objects have a
+systems interpretation:}
 
 \table{
   \tr{\th{Doctrine} \th{Free objects} \th{Systems interpretation}}
@@ -33,14 +47,12 @@
   \tr{\td{[[dct-000B]]} \td{Signed graphs with delays} \td{Variant of causal loop diagram}}
   \tr{\td{[[dct-0007]]} \td{Nullable signed graphs} \td{Variant of causal loop diagram}}
   \tr{\td{[[dct-0003]]} \td{Graphs with links} \td{Stock-flow diagrams}}
-  \tr{\td{Commutative monoidal categories} \td{Petri nets} \td{Reaction networks}}
+  \tr{\td{Symmetric monoidal categories} \td{Petri nets} \td{Reaction networks}}
   \tr{\td{[[dct-0004]]} \td{Sets} \td{Labels}}
   \tr{\td{[[dct-0005]]} \td{Deterministic transition systems, aka semiautomata} \td{State diagrams}}
 }
 
-\ul{
-\li{Additional doctrines: [[dct-0008]], [[dct-0009]], [[dct-000A]]}
-\li{Mathematical background: [[dbl-0001]]}
-\li{[[mdt-0008]]}
-\li{[[bib-0001]]}
+\p{Additional doctrines: [[dct-0008]], [[dct-0009]], [[dct-000A]]}
 }
+
+\transclude{dbl-0001}

--- a/math-docs/trees/mdt-0007.tree
+++ b/math-docs/trees/mdt-0007.tree
@@ -120,8 +120,7 @@ This visibly produces a functor on the loose category of \Span.
     We now put a double monad structure on #{\S}. The tight part of the monad will be restricted from that of #{\func{List}}, which implies that #{\S_0} contains #{1} and the sum of any family of
     its elements indexed by any of its members. (The only obvious examples of that are all the natural numbers, the positive ones, and #{1}, although more singular examples exist.) 
     On spans, the unit will map an element #{x:a\proto b} of a span #{A\leftarrow X\to B} to the element 
-    % https://q.uiver.app/#q=WzAsNixbMCwwLCIxIl0sWzEsMCwiMSJdLFsyLDAsIjEiXSxbMCwxLCJBIl0sWzEsMSwiWCJdLFsyLDEsIkIiXSxbMSwwLCIiLDAseyJsZXZlbC
-    I6Miwic3R5bGUiOnsiaGVhZCI6eyJuYW1lIjoibm9uZSJ9fX1dLFsxLDIsIiIsMix7ImxldmVsIjoyLCJzdHlsZSI6eyJoZWFkIjp7Im5hbWUiOiJub25lIn19fV0sWzQsM10sWzQsNV0sWzAsMywiYSIsMV0sWzEsNCwieCIsMV0sWzIsNSwiYiIsMV1d
+    % https://q.uiver.app/#q=WzAsNixbMCwwLCIxIl0sWzEsMCwiMSJdLFsyLDAsIjEiXSxbMCwxLCJBIl0sWzEsMSwiWCJdLFsyLDEsIkIiXSxbMSwwLCIiLDAseyJsZXZlbCI6Miwic3R5bGUiOnsiaGVhZCI6eyJuYW1lIjoibm9uZSJ9fX1dLFsxLDIsIiIsMix7ImxldmVsIjoyLCJzdHlsZSI6eyJoZWFkIjp7Im5hbWUiOiJub25lIn19fV0sWzQsM10sWzQsNV0sWzAsMywiYSIsMV0sWzEsNCwieCIsMV0sWzIsNSwiYiIsMV1d
     \quiver{\begin{tikzcd}
         1 & 1 & 1 \\
         A & X & B


### PR DESCRIPTION
Further improvement is certainly possible, but now at least:

- there are a few section headers
- everything currently in the math docs should be pretty easily findable from the landing page