### PR TITLE
Fix duplicated/missing TS type defs for `notebook-types`

### DIFF
--- a/packages/catlog-wasm/src/lib.rs
+++ b/packages/catlog-wasm/src/lib.rs
@@ -27,23 +27,6 @@ pub mod theories;
 
 use wasm_bindgen::prelude::*;
 
-/** Produce type defs for dependencies supporting `serde` but not `tsify`.
-
-Somewhat amazingly, the type system in TypeScript can express the constraint
-that an array be nonempty, with certain usage caveats:
-
-https://stackoverflow.com/q/56006111
-
-For now, though, we will not attempt to enforce this in the TypeScript layer.
- */
-#[wasm_bindgen(typescript_custom_section)]
-const TS_APPEND_CONTENT: &'static str = r#"
-export type Uuid = string;
-export type Ustr = string;
-
-export type NonEmpty<T> = Array<T>;
-"#;
-
 /** Set panic hook to get better error messages on panics.
 
 When the `console_error_panic_hook` feature is enabled, we can call the

--- a/packages/notebook-types/Cargo.toml
+++ b/packages/notebook-types/Cargo.toml
@@ -18,5 +18,5 @@ serde-wasm-bindgen = "0.6.5"
 serde_json = "1.0.140"
 tsify = { version = "0.5", features = ["js"] }
 ustr = { version = "1.1.0", features = ["serde"] }
-uuid = { version = "1.11", features = ["serde", "v7"] }
+uuid = { version = "1.11", features = ["serde"] }
 wasm-bindgen = "0.2.100"

--- a/packages/notebook-types/src/lib.rs
+++ b/packages/notebook-types/src/lib.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use serde_wasm_bindgen::{from_value, Serializer};
+use serde_wasm_bindgen::{Serializer, from_value};
 use wasm_bindgen::prelude::*;
 
 mod v0;
@@ -15,17 +15,22 @@ pub mod current {
     pub use crate::v1::*;
 }
 
-/** Produce type defs for dependencies supporting `serde` but not `tsify`.
+/** Generate type defs for dependencies supporting `serde` but not `tsify`.
 
-Somewhat amazingly, the type system in TypeScript can express the constraint
-that an array be nonempty, with certain usage caveats:
+Comments on specific definitions:
 
-https://stackoverflow.com/q/56006111
-
-For now, though, we will not attempt to enforce this in the TypeScript layer.
+- Re: `Value`, we could borrow the definition of `JsonValue` in the `ts-rs` crate:
+  <https://github.com/Aleph-Alpha/ts-rs/blob/main/ts-rs/tests/integration/serde_json.rs>.
+  However, this is causing mysterious TS errors, so we use `unknown` instead.
+- Re: `NonEmpty`, somewhat amazingly, the type system in TypeScript can express
+  the constraint that an array be nonempty, with certain usage caveats:
+  <https://stackoverflow.com/q/56006111>. For now, we will not attempt to
+  enforce non-emptiness in the TypeScript layer.
  */
 #[wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = r#"
+export type Value = unknown;
+
 export type Uuid = string;
 export type Ustr = string;
 

--- a/packages/notebook-types/src/v0/document.rs
+++ b/packages/notebook-types/src/v0/document.rs
@@ -9,16 +9,14 @@ use tsify::Tsify;
 
 /// This is the content of a model document. For legacy reasons, we reserve
 /// the name "ModelDocument" for `Document & { type: "model" }`.
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct ModelDocumentContent {
     pub name: String,
     pub theory: String,
     pub notebook: Notebook<ModelJudgment>,
 }
 
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct DiagramDocumentContent {
     pub name: String,
     #[serde(rename = "diagramIn")]
@@ -35,8 +33,7 @@ pub enum AnalysisType {
     Diagram,
 }
 
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct AnalysisDocumentContent {
     pub name: String,
     #[serde(rename = "analysisType")]
@@ -46,9 +43,8 @@ pub struct AnalysisDocumentContent {
     pub notebook: Notebook<Analysis>,
 }
 
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize)]
 #[serde(tag = "type")]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 pub enum Document {
     #[serde(rename = "model")]
     Model(ModelDocumentContent),


### PR DESCRIPTION
The duplication was introduced in #603.