### PR TITLE
Avoid use of `NonEmpty` in `notebook-types`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,7 +1883,6 @@ name = "notebook-types"
 version = "0.1.0"
 dependencies = [
  "getrandom 0.2.16",
- "nonempty",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",

--- a/packages/notebook-types/Cargo.toml
+++ b/packages/notebook-types/Cargo.toml
@@ -11,7 +11,6 @@ name = "migrate_examples"
 path = "src/bin/migrate_examples.rs"
 
 [dependencies]
-nonempty = { version = "0.12", features = ["serialize"] }
 getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"

--- a/packages/notebook-types/src/lib.rs
+++ b/packages/notebook-types/src/lib.rs
@@ -17,24 +17,18 @@ pub mod current {
 
 /** Generate type defs for dependencies supporting `serde` but not `tsify`.
 
-Comments on specific definitions:
+To define `Value`, we could borrow the definition of `JsonValue` from `ts-rs`:
+<https://github.com/Aleph-Alpha/ts-rs/blob/main/ts-rs/tests/integration/serde_json.rs>.
+However, this causes mysterious TS errors, so we use `unknown` instead.
 
-- Re: `Value`, we could borrow the definition of `JsonValue` in the `ts-rs` crate:
-  <https://github.com/Aleph-Alpha/ts-rs/blob/main/ts-rs/tests/integration/serde_json.rs>.
-  However, this is causing mysterious TS errors, so we use `unknown` instead.
-- Re: `NonEmpty`, somewhat amazingly, the type system in TypeScript can express
-  the constraint that an array be nonempty, with certain usage caveats:
-  <https://stackoverflow.com/q/56006111>. For now, we will not attempt to
-  enforce non-emptiness in the TypeScript layer.
+TODO: Do not use `NonEmpty` in wasm-bound types to avoid need for alias.
  */
 #[wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = r#"
-export type Value = unknown;
-
+type NonEmpty<T> = Array<T>;
 export type Uuid = string;
-export type Ustr = string;
-
-export type NonEmpty<T> = Array<T>;
+type Ustr = string;
+type Value = unknown;
 "#;
 
 pub static CURRENT_VERSION: &str = "1";

--- a/packages/notebook-types/src/v0/path.rs
+++ b/packages/notebook-types/src/v0/path.rs
@@ -1,4 +1,3 @@
-use nonempty::NonEmpty;
 use serde::{Deserialize, Serialize};
 use tsify::Tsify;
 
@@ -7,5 +6,5 @@ use tsify::Tsify;
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub enum Path<V, E> {
     Id(V),
-    Seq(NonEmpty<E>),
+    Seq(Vec<E>),
 }


### PR DESCRIPTION
Instead, use a fallible promotion mechanism, in keeping with the spirit of elaboration.

This is a non-breaking change to the notebook types since it does not affect the generated TypeScript type defs.