### PR TITLE
Fixes and QoL improvements for CatColabInterop kernel management

### DIFF
--- a/packages/algjulia-interop/src/CatColabInterop.jl
+++ b/packages/algjulia-interop/src/CatColabInterop.jl
@@ -76,7 +76,7 @@ export ImplError
 
 Base.showerror(io::IO, e::ImplError) = print(io, "$(e.name) not implemented")
 
-include("run_jupyter.jl")
+include("kernel_management.jl")
 include("kernel_support.jl")
 include("decapodes-service/DecapodesService.jl")
 

--- a/packages/algjulia-interop/src/CatColabInterop.jl
+++ b/packages/algjulia-interop/src/CatColabInterop.jl
@@ -76,6 +76,7 @@ export ImplError
 
 Base.showerror(io::IO, e::ImplError) = print(io, "$(e.name) not implemented")
 
+include("result.jl")
 include("kernel_management.jl")
 include("kernel_support.jl")
 include("decapodes-service/DecapodesService.jl")

--- a/packages/algjulia-interop/src/kernel_management.jl
+++ b/packages/algjulia-interop/src/kernel_management.jl
@@ -10,20 +10,20 @@ end
 
 KernelNotFoundException() = KernelNotFoundException(IJulia.kerneldir())
 
-function Base.showerror(err::KernelNotFoundException)
-    """
-    IJulia cannot find any kernels in the directory $(err.dir). To install a kernel, you may run `CatColabInterop.install_ccl_kernel()`. Refer to the [IJulia documentation](https://julialang.github.io/IJulia.jl/stable/library/public/#IJulia.installkernel) for more information about managing Jupyter kernels in IJulia.
+function Base.showerror(io::IO, err::KernelNotFoundException)
+    print(io, """
+    IJulia cannot find any kernels in the directory `$(err.dir)`.
+
+    To install a kernel, you may run `CatColabInterop.install_ccl_kernel()`.
+    Refer to the [IJulia documentation](https://julialang.github.io/IJulia.jl/stable/library/public/#IJulia.installkernel)
+    for more information about managing Jupyter kernels in IJulia.
 
     If you wish to install a sysimage instead, run
     ```julia
     using PackageCompiler
     install_ccl_kernel(Val(:sysimge))
     ```
-    """
-end
-
-function Base.showerror(io::IO, err::KernelNotFoundException)
-    print(io, showerror(err))
+    """)
 end
 
 const YESNO = ["Yes", "No"]
@@ -116,7 +116,7 @@ function load_kernels!(;config::ServerConfig=CONFIG, warn=false)
         return Ok("Kernels reloaded!")
     end
     # otherwise, throw a warning or an error
-    warn ? @warn(showerror(KernelNotFoundException(dir))) : throw(KernelNotFoundException(dir))
+    warn ? @warn(sprint(showerror, KernelNotFoundException(dir))) : throw(KernelNotFoundException(dir))
 end
 
 """    uninstall_kernel!(;config::ServerConfig=CONFIG)::Union{Nothing, Bool}

--- a/packages/algjulia-interop/src/kernel_management.jl
+++ b/packages/algjulia-interop/src/kernel_management.jl
@@ -7,11 +7,25 @@ struct KernelNotFoundException <: Exception
     dir::String
 end
 
-function Base.showerror(io, e::KernelNotFoundException)
-    print(io, """IJulia cannot find any kernels in
-    $(e.dir)
-    To install a kernel, you may run `CatColabInterop.install_ccl_kernel()`. Refer to the [IJulia documentation](https://julialang.github.io/IJulia.jl/stable/library/public/#IJulia.installkernel) for more information about managing Jupyter kernels in IJulia.""")
+KernelNotFoundException() = KernelNotFoundException(IJulia.kerneldir())
+
+function Base.String(err::KernelNotFoundException)
+    """
+    IJulia cannot find any kernels in the directory $(err.dir). To install a kernel, you may run `CatColabInterop.install_ccl_kernel()`. Refer to the [IJulia documentation](https://julialang.github.io/IJulia.jl/stable/library/public/#IJulia.installkernel) for more information about managing Jupyter kernels in IJulia.
+
+    If you wish to install a sysimage instead, run
+    ```julia
+    using PackageCompiler
+    install_ccl_kernel(Val(:sysimge))
+    ```
+    """
 end
+
+function Base.showerror(io::IO, err::KernelNotFoundException)
+    print(io, String(err))
+end
+
+const YESNO = ["Yes", "No"]
 
 const MODES = Dict("dev" => "http://localhost:5173",
              "staging" => "https://next.catcolab.org",
@@ -19,7 +33,7 @@ const MODES = Dict("dev" => "http://localhost:5173",
 
 @kwdef mutable struct ServerConfig
     sysimg_path::Union{String, Nothing} = nothing
-    kernels::Vector{String} = readdir(IJulia.kerneldir(), join=true)
+    kernels::Vector{String} = basename.(readdir(IJulia.kerneldir(), join=true))
     kernel::Union{String, Nothing} = @load_preference("kernel", nothing)
     modes::Dict{String, String} = MODES 
     mode::String = @load_preference("mode", "production")
@@ -54,7 +68,7 @@ function set_mode!(config::ServerConfig, mode::String)
     end
 end
 
-function change_mode!(prefer::Bool=true; config::ServerConfig=CONFIG)
+function change_mode!(prefer::Bool=true; config::ServerConfig=CONFIG)::Union{Bool, Nothing}
     modes = collect(keys(config.modes))
     menu = RadioMenu(modes, pagesize=3)
     cursor = something(findfirst(==(config.mode), modes), 0)
@@ -63,27 +77,32 @@ function change_mode!(prefer::Bool=true; config::ServerConfig=CONFIG)
         config.mode = modes[choice]
         if prefer
             @set_preferences!("mode" => modes[choice])
+            @info "Preferred mode set to $(modes[choice])"
         end
         println("""Mode "$(config.mode)" chosen.""")
+        return nothing 
     else
         println("Mode selection canceled")
+        return false
     end
 end
 export change_mode!
 
-function change_kernel!(prefer::Bool=true; config::ServerConfig=CONFIG)
-    menu = RadioMenu(basename.(config.kernels), pagesize=4)
+function change_kernel!(prefer::Bool=true; config::ServerConfig=CONFIG)::Union{Bool, Nothing}
+    menu = RadioMenu(config.kernels, pagesize=4)
     cursor = something(findfirst(==(config.kernel), config.kernels), 0)
     choice = request("Select a kernel: ", menu; cursor=cursor)
     if choice != -1
-        # Assumes kernel name is a path
         config.kernel = config.kernels[choice]
         if prefer
             @set_preferences!("kernel" => config.kernel)
+            @info "Preferred kernel set to $(config.kernels[choice])"
         end
-        println("Kernel $(basename(config.kernel)) chosen.")
+        println("Kernel $(config.kernel) chosen.")
+        return nothing 
     else
         println("Kernel selection canceled")
+        return false
     end
 end
 export change_kernel!
@@ -92,12 +111,57 @@ export change_kernel!
 
 Loads kernels visible to IJulia's [kernel_dir](@ref IJulia.kerneldir) function.
 """
-function load_kernels!(;config::ServerConfig=CONFIG)
+function load_kernels!(;config::ServerConfig=CONFIG, warn=false)
     dir = IJulia.kerneldir()
     kernels = readdir(dir, join=true)
-    isempty(kernels) && throw(KernelNotFoundException(dir))
+    isempty(kernels) && (warn ? @warn(String(KernelNotFoundException(dir))) : throw(KernelNotFoundException(dir)))
     config.kernels = basename.(kernels)
+    println("Kernels reloaded!")
+    return nothing
 end
+
+"""    uninstall_kernel!(;config::ServerConfig=CONFIG)::Union{Nothing, Bool}
+
+Wraps `Base.rm` in a terminal menu interface to uninstall Julia kernels. Using `Base.rm` is recommended by IJulia.
+
+Usage:
+```
+uninstall_kernel!()
+```
+"""
+function uninstall_kernel!(;config::ServerConfig=CONFIG)::Union{Nothing, Bool}
+    isempty(config.kernels) && throw(KernelNotFoundException()) 
+    menu = MultiSelectMenu(config.kernels, pagesize=4)
+    cursor = something(findfirst(==(config.kernel), config.kernels), 0)
+    choices = request("Select a kernel to be uninstalled: ", menu; cursor=cursor)
+    if !isempty(choices)
+        selections = getindex(config.kernels, collect(choices))
+        confirm = RadioMenu(YESNO, pagesize=2)
+        permission = request("The following kernel(s) will be uninstalled from your machine. Continue?", confirm)
+        if YESNO[permission] == "Yes"
+            for selection in selections
+                isdir(selection) && rm(selection; recursive=true)
+            end
+            preferred = @load_preference("kernel", nothing)
+            if preferred ∈ selections
+                @delete_preferences!("kernel")
+                @info "Preferred kernel $preferred was removed."
+            end
+            load_kernels!(;config=config, warn=true)
+            return nothing
+        else
+            println("Kernel uninstallation cancelled.")
+            return false
+        end
+        println("Kernel deletion successful.")
+        return nothing
+    else
+        println("Kernel uninstallation cancelled")
+        return false
+    end
+end
+export uninstall_kernel!
+
 
 """    install_ccl_kernel!()
 
@@ -123,7 +187,12 @@ install_ccl_kernel!(Val(:sysimg))
 """
 function install_ccl_kernel!(;config::ServerConfig=CONFIG, kwargs...)
     kernel = installkernel("CatColabInteropKernel", "--project=@.", kwargs...)
-    load_kernels!(config)
+    load_kernels!(config=config)
+    preferred = @load_preference("kernel", nothing)
+    if isnothing(preferred) || length(config.kernels) == 1
+        @set_preferences!("kernel" => kernel)
+        @info "Preferred kernel set to $(kernel)"
+    end
 end
 export install_ccl_kernel!
 
@@ -143,7 +212,7 @@ function build_jupyter_server_cmd(config::ServerConfig)
     build_jupyter_server_cmd(Dict{String, Any}("limit" => config.limit, "kernel" => config.kernel, "mode" => origin(config)))
 end
 
-"""    start_server(;config::ServerConfig=CONFIG, mode::Union{String, Nothing}=nothing)
+"""    start_server(;config::ServerConfig=CONFIG, mode::Union{String, Nothing}=nothing, manual=false)
 
 This starts a Jupyter server with an optional kernel and mode.
 
@@ -158,8 +227,16 @@ start_server!()
 # do stuff
 stop_server!()
 ```
+To select the kernel and mode in a wizard-like interface,
+```julia
+start_server!(;manual=true)
+```
 """
-function start_server!(;config::ServerConfig=CONFIG, mode::Union{String, Nothing}=nothing)
+function start_server!(;config::ServerConfig=CONFIG, mode::Union{String, Nothing}=nothing, manual=false)
+    if manual
+        isnothing(change_kernel!(;config=config)) || error("Start server process aborted because kernel selection was cancelled.")
+        isnothing(change_mode!(;config=config)) || error("Start server process aborted because mode selection was cancelled.")
+    end
     if isnothing(config.kernel)
         change_kernel!(;config=config)
     end
@@ -169,8 +246,7 @@ function start_server!(;config::ServerConfig=CONFIG, mode::Union{String, Nothing
     cmd = build_jupyter_server_cmd(config)
     @info "Starting server:
         kernel: $(config.kernel)
-        mode: $(origin(config))
-    "
+        mode: $(origin(config))"
     config.server = open(pipeline(cmd))
 end
 export start_server!

--- a/packages/algjulia-interop/src/result.jl
+++ b/packages/algjulia-interop/src/result.jl
@@ -1,0 +1,23 @@
+struct ResultException <: Exception
+    msg::String
+end
+
+Base.showerror(io::IO, err::ResultException) = print(io, err.msg)
+
+@data Result begin
+    Ok(msg::String)
+    Err(msg::String)
+end
+
+Ok() = Ok("")
+
+Base.show(io::IO, ok::Ok) = !isempty(ok.msg) ? print(io, ok.msg) : nothing
+Base.show(io::IO, err::Err) = !isempty(err.msg) ? print(io, err.msg) : nothing
+
+import Base: |
+
+(|)(left::Ok, right) = handle(left)
+(|)(left::Err, right) = handle(right)
+
+handle(ok::Ok) = ok
+handle(err::Err) = throw(ResultException(err.msg))

--- a/packages/frontend/src/stdlib/analyses/decapodes.tsx
+++ b/packages/frontend/src/stdlib/analyses/decapodes.tsx
@@ -341,6 +341,10 @@ type SimulationData = {
 /** Julia code run after kernel is started. */
 const makeInitCode = () =>
     `
+    for k in keys(Base.text_colors)
+		Base.text_colors[k] = ""
+	end
+
     import IJulia
     import JSON3
     IJulia.register_jsonmime(MIME"application/json"())


### PR DESCRIPTION
- Added `uninstall_kernel!` function
- Bumped IJulia to v1.30.1, resolving a bug where `IJulia.set_max_stdio` breaks from unspecified kernel (c.f., [this PR](https://github.com/JuliaLang/IJulia.jl/pull/1178#event-19377499266))
- Added `manual` keyword argument to `start_server!` to select kernel and mode before starting the server
- Removed terminal colors to cut down ANSI codes appearing in Julia kernel output