### PR TITLE
Upgrade `uuid` crate to v1.12+ and `getrandom` to v0.3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,9 @@ jobs:
 
       - name: Install Rust toolchain from file
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          # Don't override flags in cargo config files.
+          rustflags: ""
 
       - name: Build for Staging
         if: github.event_name == 'push' || github.event_name == 'pull_request'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,7 @@ dependencies = [
  "derive_more",
  "egglog",
  "getrandom 0.2.16",
+ "getrandom 0.3.3",
  "js-sys",
  "nonempty",
  "notebook-types",
@@ -1032,9 +1033,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1882,7 +1885,6 @@ dependencies = [
 name = "notebook-types"
 version = "0.1.0"
 dependencies = [
- "getrandom 0.2.16",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
@@ -2658,9 +2660,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "itoa",
  "memchr",
@@ -3732,12 +3734,24 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.11.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b913a3b5fe84142e269d63cc62b64319ccaf89b748fc31fe025177f767a756c4"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.3.3",
+ "js-sys",
  "serde",
+ "uuid-rng-internal",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "uuid-rng-internal"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23bf87b6052a24c8ebbe4a5301be9df955b874cb3a6d2ede0e1b2468dc7d0e65"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]

--- a/packages/catlog-wasm/.cargo/config.toml
+++ b/packages/catlog-wasm/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/packages/catlog-wasm/Cargo.toml
+++ b/packages/catlog-wasm/Cargo.toml
@@ -18,14 +18,15 @@ derive_more = { version = "2", features = ["from", "try_into"] }
 egglog = { version = "0.4", default-features = false, features = [
     "wasm-bindgen",
 ] }
-getrandom = { version = "0.2", features = ["js"] }
+getrandom_v03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
+getrandom_v02 = { package = "getrandom", version = "0.2", features = ["js"] }
 js-sys = "0.3.77"
 nonempty = { version = "0.12", features = ["serialize"] }
 notebook-types = { version = "0.1.0", path = "../notebook-types" }
 serde = { version = "1", features = ["derive"] }
 tsify = { version = "0.5", features = ["js"] }
 ustr = "1"
-uuid = { version = "=1.11", features = ["v7", "serde"] }
+uuid = { version = "1.18", features = ["v7", "rng-getrandom", "serde"] }
 wasm-bindgen = "0.2.100"
 
 [dev-dependencies]

--- a/packages/catlog/Cargo.toml
+++ b/packages/catlog/Cargo.toml
@@ -26,9 +26,9 @@ serde = { version = "1", features = ["derive"], optional = true }
 thiserror = "1"
 tsify = { version = "0.5", features = ["js"], optional = true }
 ustr = "1"
-uuid = { version = "=1.11" }
+uuid = { version = "1.18" }
 wasm-bindgen = { version = "0.2.100", optional = true }
 
 [dev-dependencies]
 expect-test = "1.5"
-textplots = "0.8.6"
+textplots = "0.8.7"

--- a/packages/notebook-types/Cargo.toml
+++ b/packages/notebook-types/Cargo.toml
@@ -11,11 +11,10 @@ name = "migrate_examples"
 path = "src/bin/migrate_examples.rs"
 
 [dependencies]
-getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"
-serde_json = "1.0.140"
+serde_json = "1.0.143"
 tsify = { version = "0.5", features = ["js"] }
 ustr = { version = "1.1.0", features = ["serde"] }
-uuid = { version = "1.11", features = ["serde"] }
+uuid = { version = "1.18", features = ["serde"] }
 wasm-bindgen = "0.2.100"


### PR DESCRIPTION
Previously I had `uuid` pinned to v0.11 to avoid upgrading `getrandom` to v0.3, which requires setting extra config flags to compile to Wasm. This messy upgrade path is discussed here: https://github.com/uuid-rs/uuid/issues/792

We'll need `getrandom` v0.3 in #619. Unfortunately, we can't eliminate the dependency on `getrandom` v0.2 either since it is forced by the chain `egglog` -> `im-rc` v15 -> `rand_core` v0.6.