### PR TITLE
Alternative pathway to fetch live documents using only Automerge

### DIFF
--- a/packages/frontend/src/analysis/document.ts
+++ b/packages/frontend/src/analysis/document.ts
@@ -1,6 +1,6 @@
 import invariant from "tiny-invariant";
 
-import { type Document, currentVersion } from "catlog-wasm";
+import { type AnalysisType, type Document, currentVersion } from "catlog-wasm";
 import { type Api, type LiveDoc, type StableRef, getLiveDoc } from "../api";
 import { type LiveDiagramDocument, getLiveDiagram } from "../diagram";
 import { type LiveModelDocument, getLiveModel } from "../model";
@@ -8,27 +8,20 @@ import { newNotebook } from "../notebook";
 import type { TheoryLibrary } from "../stdlib";
 import type { InterfaceToType } from "../util/types";
 
-type AnalysisType = "model" | "diagram";
-
-type BaseAnalysisDocument<T extends AnalysisType> = Document & {
-    type: "analysis";
-    analysisType: T;
-};
+/** A document defining an analysis. */
+export type AnalysisDocument = Document & { type: "analysis" };
 
 /** A document defining an analysis of a model. */
-export type ModelAnalysisDocument = BaseAnalysisDocument<"model">;
+export type ModelAnalysisDocument = AnalysisDocument & { analysisType: "model" };
 
 /** A document defining an analysis of a diagram. */
-export type DiagramAnalysisDocument = BaseAnalysisDocument<"diagram">;
-
-/** A document defining an analysis. */
-export type AnalysisDocument = ModelAnalysisDocument | DiagramAnalysisDocument;
+export type DiagramAnalysisDocument = AnalysisDocument & { analysisType: "diagram" };
 
 /** Create an empty analysis. */
 export const newAnalysisDocument = (
     analysisType: AnalysisType,
     analysisOf: StableRef,
-): BaseAnalysisDocument<typeof analysisType> => ({
+): AnalysisDocument => ({
     name: "",
     type: "analysis",
     analysisType,
@@ -40,12 +33,20 @@ export const newAnalysisDocument = (
     version: currentVersion(),
 });
 
-/** A model analysis document "live" for editing. */
-export type LiveModelAnalysisDocument = {
-    analysisType: "model";
+type BaseLiveAnalysisDocument = {
+    /** Tag for use in tagged unions of document types. */
+    type: "analysis";
+
+    /** Type of document that this analysis is of. */
+    analysisType: AnalysisType;
 
     /** The ref for which this is a live document. */
     refId: string;
+};
+
+/** A model analysis document "live" for editing. */
+export type LiveModelAnalysisDocument = BaseLiveAnalysisDocument & {
+    analysisType: "model";
 
     /** Live document defining the analysis. */
     liveDoc: LiveDoc<ModelAnalysisDocument>;
@@ -55,16 +56,13 @@ export type LiveModelAnalysisDocument = {
 };
 
 /** A diagram analysis document "live" for editing. */
-export type LiveDiagramAnalysisDocument = {
+export type LiveDiagramAnalysisDocument = BaseLiveAnalysisDocument & {
     analysisType: "diagram";
-
-    /** The ref for which this is a live document. */
-    refId: string;
 
     /** Live document defining the analysis. */
     liveDoc: LiveDoc<DiagramAnalysisDocument>;
 
-    /** Live diagarm that the analysis is of. */
+    /** Live diagram that the analysis is of. */
     liveDiagram: LiveDiagramDocument;
 };
 
@@ -90,9 +88,11 @@ export async function getLiveAnalysis(
     const liveDoc = await getLiveDoc<AnalysisDocument>(api, refId, "analysis");
     const { doc } = liveDoc;
 
+    // XXX: TypeScript cannot narrow types in nested tagged unions.
     if (doc.analysisType === "model") {
         const liveModel = await getLiveModel(doc.analysisOf._id, api, theories);
         return {
+            type: "analysis",
             analysisType: "model",
             refId,
             liveDoc: liveDoc as LiveDoc<ModelAnalysisDocument>,
@@ -101,11 +101,12 @@ export async function getLiveAnalysis(
     } else if (doc.analysisType === "diagram") {
         const liveDiagram = await getLiveDiagram(doc.analysisOf._id, api, theories);
         return {
+            type: "analysis",
             analysisType: "diagram",
             refId,
             liveDoc: liveDoc as LiveDoc<DiagramAnalysisDocument>,
             liveDiagram,
         };
     }
-    throw new Error(`Unknown analysis type: ${(doc as AnalysisDocument).analysisType}`);
+    throw new Error(`Unknown analysis type: ${doc.analysisType}`);
 }

--- a/packages/frontend/src/diagram/document.ts
+++ b/packages/frontend/src/diagram/document.ts
@@ -36,8 +36,7 @@ export const newDiagramDocument = (modelRef: StableRef): DiagramDocument => ({
     version: currentVersion(),
 });
 
-/** A diagram document "live" for editing.
- */
+/** A diagram document "live" for editing. */
 export type LiveDiagramDocument = {
     /** Tag for use in tagged unions of document types. */
     type: "diagram";
@@ -164,7 +163,7 @@ export async function getLiveDiagram(
 
 /** Get a diagram from an Automerge repo and make it "live" for editing.
 
-Prefer [`getLiveDiagram`] unless you're bypassing the official CatColab backend.
+Prefer [`getLiveDiagram`] unless you're bypassing the official backend.
  */
 export async function getLiveDiagramFromRepo(
     docId: AutomergeUrl,

--- a/packages/frontend/src/diagram/document.ts
+++ b/packages/frontend/src/diagram/document.ts
@@ -1,3 +1,4 @@
+import type { AutomergeUrl, Repo } from "@automerge/automerge-repo";
 import { type Accessor, createMemo } from "solid-js";
 import invariant from "tiny-invariant";
 
@@ -8,8 +9,14 @@ import type {
     ModelDiagramValidationResult,
 } from "catlog-wasm";
 import { currentVersion, elaborateDiagram } from "catlog-wasm";
-import { type Api, type LiveDoc, type StableRef, getLiveDoc } from "../api";
-import { type LiveModelDocument, getLiveModel } from "../model";
+import {
+    type Api,
+    type LiveDoc,
+    type StableRef,
+    getLiveDoc,
+    getLiveDocFromDocHandle,
+} from "../api";
+import { type LiveModelDocument, getLiveModel, getLiveModelFromRepo } from "../model";
 import { NotebookUtils, newNotebook } from "../notebook";
 import type { TheoryLibrary } from "../stdlib";
 import type { InterfaceToType } from "../util/types";
@@ -35,8 +42,8 @@ export type LiveDiagramDocument = {
     /** Tag for use in tagged unions of document types. */
     type: "diagram";
 
-    /** The ref for which this is a live document. */
-    refId: string;
+    /** The ref in the backend, if any, for which this is a live document. */
+    refId?: string;
 
     /** Live document containing the diagram data. */
     liveDoc: LiveDoc<DiagramDocument>;
@@ -74,7 +81,6 @@ export type ValidatedDiagram =
       };
 
 function enlivenDiagramDocument(
-    refId: string,
     liveDoc: LiveDoc<DiagramDocument>,
     liveModel: LiveModelDocument,
 ): LiveDiagramDocument {
@@ -121,7 +127,6 @@ function enlivenDiagramDocument(
 
     return {
         type: "diagram",
-        refId,
         liveDoc,
         liveModel,
         formalJudgments,
@@ -150,9 +155,26 @@ export async function getLiveDiagram(
     theories: TheoryLibrary,
 ): Promise<LiveDiagramDocument> {
     const liveDoc = await getLiveDoc<DiagramDocument>(api, refId, "diagram");
-    const { doc } = liveDoc;
+    const modelRefId = liveDoc.doc.diagramIn._id;
 
-    const liveModel = await getLiveModel(doc.diagramIn._id, api, theories);
+    const liveModel = await getLiveModel(modelRefId, api, theories);
+    const liveDiagram = enlivenDiagramDocument(liveDoc, liveModel);
+    return { ...liveDiagram, refId };
+}
 
-    return enlivenDiagramDocument(refId, liveDoc, liveModel);
+/** Get a diagram from an Automerge repo and make it "live" for editing.
+
+Prefer [`getLiveDiagram`] unless you're bypassing the official CatColab backend.
+ */
+export async function getLiveDiagramFromRepo(
+    docId: AutomergeUrl,
+    repo: Repo,
+    theories: TheoryLibrary,
+): Promise<LiveDiagramDocument> {
+    const docHandle = await repo.find<DiagramDocument>(docId);
+    const liveDoc = getLiveDocFromDocHandle(docHandle);
+    const modelDocId = liveDoc.doc.diagramIn._id as AutomergeUrl;
+
+    const liveModel = await getLiveModelFromRepo(modelDocId, repo, theories);
+    return enlivenDiagramDocument(liveDoc, liveModel);
 }

--- a/packages/frontend/src/diagram/document.ts
+++ b/packages/frontend/src/diagram/document.ts
@@ -32,7 +32,7 @@ export const newDiagramDocument = (modelRef: StableRef): DiagramDocument => ({
 /** A diagram document "live" for editing.
  */
 export type LiveDiagramDocument = {
-    /** discriminator for use in union types */
+    /** Tag for use in tagged unions of document types. */
     type: "diagram";
 
     /** The ref for which this is a live document. */

--- a/packages/frontend/src/model/document.ts
+++ b/packages/frontend/src/model/document.ts
@@ -1,4 +1,4 @@
-import type { DocHandle } from "@automerge/automerge-repo";
+import type { AutomergeUrl, Repo } from "@automerge/automerge-repo";
 import { type Accessor, createMemo, createResource } from "solid-js";
 import invariant from "tiny-invariant";
 
@@ -165,15 +165,16 @@ export async function getLiveModel(
     return { ...liveModel, refId };
 }
 
-/** Get a model from an Automerge doc handle and make it "live" for editing.
+/** Get a model from an Automerge repo and make it "live" for editing.
 
-Unless you're bypassing the official CatColab backend, you should call
-[`getLiveModel`] instead.
+Prefer [`getLiveModel`] unless you're bypassing the official CatColab backend.
  */
-export function getLiveModelFromDocHandle(
-    docHandle: DocHandle<ModelDocument>,
+export async function getLiveModelFromRepo(
+    docId: AutomergeUrl,
+    repo: Repo,
     theories: TheoryLibrary,
-): LiveModelDocument {
+): Promise<LiveModelDocument> {
+    const docHandle = await repo.find<ModelDocument>(docId);
     const liveDoc = getLiveDocFromDocHandle(docHandle);
     return enlivenModelDocument(liveDoc, theories);
 }

--- a/packages/frontend/src/page/document_breadcrumbs.tsx
+++ b/packages/frontend/src/page/document_breadcrumbs.tsx
@@ -1,4 +1,6 @@
 import { For, Show, createResource } from "solid-js";
+import invariant from "tiny-invariant";
+
 import type { AnalysisDocument, LiveAnalysisDocument } from "../analysis";
 import { getLiveDoc, useApi } from "../api";
 import type { DiagramDocument, LiveDiagramDocument } from "../diagram";
@@ -6,6 +8,7 @@ import type { LiveModelDocument, ModelDocument } from "../model";
 import { assertExhaustive } from "../util/assert_exhaustive";
 import "./document_breadcrumbs.css";
 
+// FIXME: These unions should be defined elsewhere.
 type AnyDocument = ModelDocument | DiagramDocument | AnalysisDocument;
 type AnyLiveDocument = LiveModelDocument | LiveDiagramDocument | LiveAnalysisDocument;
 type AnyDocumentWithRefId = {
@@ -50,6 +53,8 @@ export function getParentRefId(document: AnyDocument): string | null {
 }
 
 async function getDocumentChain(document: AnyLiveDocument): Promise<AnyDocumentWithRefId[]> {
+    invariant(document.refId, "Document should have a ref ID");
+
     const api = useApi();
     const documentChain: AnyDocumentWithRefId[] = [
         { document: document.liveDoc.doc, refId: document.refId },

--- a/packages/frontend/src/page/document_menu.tsx
+++ b/packages/frontend/src/page/document_menu.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "@solidjs/router";
 import { Match, Show, Switch } from "solid-js";
+import invariant from "tiny-invariant";
 
 import { createAnalysis } from "../analysis/document";
 import { type StableRef, useApi } from "../api";
@@ -41,27 +42,23 @@ export function DocumentMenu(props: {
     });
 
     const onNewDiagram = async () => {
-        const modelRefId = (() => {
-            switch (props.liveDocument.type) {
-                case "diagram":
-                    return props.liveDocument.liveModel.refId;
-                case "model":
-                    return props.liveDocument.refId;
-                default:
-                    assertExhaustive(props.liveDocument);
-            }
-        })();
+        let modelRefId: string | undefined;
+        if (props.liveDocument.type === "diagram") {
+            modelRefId = props.liveDocument.liveModel.refId;
+        } else if (props.liveDocument.type === "model") {
+            modelRefId = props.liveDocument.refId;
+        }
+        invariant(modelRefId, "To create diagram, parent model should have a ref ID");
 
         const newRef = await createDiagram(api, unversionedRef(modelRefId));
         navigate(`/diagram/${newRef}`);
     };
 
     const onNewAnalysis = async () => {
-        const newRef = await createAnalysis(
-            api,
-            props.liveDocument.type,
-            unversionedRef(props.liveDocument.refId),
-        );
+        const refId = props.liveDocument.refId;
+        invariant(refId, "To create analysis, parent document should have aa ref ID");
+
+        const newRef = await createAnalysis(api, props.liveDocument.type, unversionedRef(refId));
         navigate(`/analysis/${newRef}`);
     };
 


### PR DESCRIPTION
Adds an alternative pathway to fetch live documents, including models, diagrams, and analyses, that ignores the official backend and assumes only that an Automerge repo is available. In this pathway, cross-links between documents are interpreted as Automerge IDs rather than ref IDs in the backend (which are UUIDs).

Towards #714.