### PR TITLE
Generate `catlog` models from doublett types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "fnotation"
-version = "0.8.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022b6c756653ad725b475641caa29b074065b39bc7b060df71173b7afce61e57"
+checksum = "db95701550ee5c911d678a7b9da12d6fe4b2aa7a856c05ce2a3570d96e53dd39"
 dependencies = [
  "ansi_term",
  "bumpalo",

--- a/packages/catlog/Cargo.toml
+++ b/packages/catlog/Cargo.toml
@@ -19,7 +19,7 @@ duplicate = "2"
 egglog = { version = "0.5", default-features = false }
 ego-tree = "0.10"
 instant = { version = "0.1", optional = true } # Needed for egglog v0.5
-fnotation = "0.8.1"
+fnotation = "0.10.2"
 indexmap = "2.11.1"
 itertools = "0.14"
 nalgebra = { version = "0.33", optional = true }

--- a/packages/catlog/examples/test.dbltt
+++ b/packages/catlog/examples/test.dbltt
@@ -14,6 +14,8 @@ type WeightedGraph := [
   weight : Attr[E, Weight]
 ]
 
+generate WeightedGraph
+
 type EntityArr := [
   dom : Entity,
   cod : Entity,
@@ -91,3 +93,5 @@ type Graph2 := [
 syn [g : Graph2] g.g1.V
 
 norm [g : Graph2] g.g1.V
+
+generate Graph2

--- a/packages/catlog/examples/test.dbltt.snapshot
+++ b/packages/catlog/examples/test.dbltt.snapshot
@@ -17,6 +17,18 @@ type WeightedGraph := [
 ]
 /# declared: WeightedGraph
 
+generate WeightedGraph
+/# result: 
+#/ object generators: 
+#/  E : Entity
+#/  Weight : AttrType
+#/  V : Entity
+#/ morphism generators: 
+#/  weight : E -> Weight (Attr)
+#/  tgt : E -> V (Id Entity)
+#/  src : E -> V (Id Entity)
+
+
 type EntityArr := [
   dom : Entity,
   cod : Entity,
@@ -41,18 +53,20 @@ chk [G : Graph1] (G.src : EntityArr)
 chk [G : Graph1] (G.src : EntityArr & [ .dom := G.E ] )
 /# result: G.src
 
+#(should_fail)
 chk [G : Graph1] (G.src : EntityArr & [ .dom := G.V ] )
 /# expected errors:
 /# error[elab]: evaluated term [ dom := G.E, cod := G.V, arr := <opaque> ] is not an element of specialized type [ dom : Entity, cod : Entity, arr : (Id Entity)[ self.dom, self.cod ] ] &
 /#   [ .dom : @sing G.V ]:
 /# Neutrals G.E and G.V are not equal.
-/# --> examples/test.dbltt:37:19
-/# 37| chk [G : Graph1] (G.src : EntityArr & [ .dom := G.V ] )
-/# 37|                   ^^^^^
+/# --> examples/test.dbltt:39:19
+/# 39| chk [G : Graph1] (G.src : EntityArr & [ .dom := G.V ] )
+/# 39|                   ^^^^^
 
 norm [x : [a : Entity, b : @sing a]] x.b
 /# result: x.a
 
+#(should_fail)
 type Graph1 := [
   V : Entity,
   E : Entity,
@@ -62,9 +76,9 @@ type Graph1 := [
 /# error[elab]: Failed to specialize:
 /# ... because @sing self.V is not a subtype of @sing self.E:
 /# ... because Neutrals self.V and self.E are not equal.
-/# --> examples/test.dbltt:45:34
-/# 45|   src : EntityArr & [ .dom := E, .dom := V ]
-/# 45|                                  ^^^^^^^^^
+/# --> examples/test.dbltt:47:34
+/# 47|   src : EntityArr & [ .dom := E, .dom := V ]
+/# 47|                                  ^^^^^^^^^
 
 type Graph := [
   V : Entity,
@@ -82,6 +96,7 @@ def reverse[G : Graph] : Graph := [
 ]
 /# declared: reverse
 
+#(should_fail)
 def reverse[G : Graph] : Graph := [
   V := G.E,
   E := G.E,
@@ -91,9 +106,9 @@ def reverse[G : Graph] : Graph := [
 /# expected errors:
 /# error[elab]: synthesized type (Id Entity)[ G.E, G.V ] does not match expected type (Id Entity)[ G.E, G.E ]:
 /# could not convert codomains: Neutrals G.V and G.E are not equal.
-/# --> examples/test.dbltt:66:10
-/# 66|   src := G.tgt,
-/# 66|          ^^^^^
+/# --> examples/test.dbltt:68:10
+/# 68|   src := G.tgt,
+/# 68|          ^^^^^
 
 norm [G : Graph] (reverse[G]).E
 /# result: G.E
@@ -128,4 +143,17 @@ syn [g : Graph2] g.g1.V
 
 norm [g : Graph2] g.g1.V
 /# result: g.V
+
+generate Graph2
+/# result: 
+#/ object generators: 
+#/  g2.E : Entity
+#/  g1.E : Entity
+#/  V : Entity
+#/ morphism generators: 
+#/  g2.tgt : g2.E -> V (Id Entity)
+#/  g1.tgt : g1.E -> V (Id Entity)
+#/  g1.src : g1.E -> V (Id Entity)
+#/  g2.src : g2.E -> V (Id Entity)
+
 

--- a/packages/catlog/examples/test.dbltt.snapshot
+++ b/packages/catlog/examples/test.dbltt.snapshot
@@ -20,8 +20,8 @@ type WeightedGraph := [
 generate WeightedGraph
 #/ result: 
 #/ object generators: 
-#/  E : Entity
 #/  V : Entity
+#/  E : Entity
 #/  Weight : AttrType
 #/ morphism generators: 
 #/  src : E -> V (Id Entity)

--- a/packages/catlog/examples/test.dbltt.snapshot
+++ b/packages/catlog/examples/test.dbltt.snapshot
@@ -1,11 +1,11 @@
 type u := Unit
-/# declared: u
+#/ declared: u
 
 type u2 := u
-/# declared: u2
+#/ declared: u2
 
 def t : u := 'tt
-/# declared: t
+#/ declared: t
 
 type WeightedGraph := [
   V : Entity,
@@ -15,18 +15,18 @@ type WeightedGraph := [
   tgt : (Id Entity)[E, V],
   weight : Attr[E, Weight]
 ]
-/# declared: WeightedGraph
+#/ declared: WeightedGraph
 
 generate WeightedGraph
-/# result: 
+#/ result: 
 #/ object generators: 
 #/  E : Entity
-#/  Weight : AttrType
 #/  V : Entity
+#/  Weight : AttrType
 #/ morphism generators: 
-#/  weight : E -> Weight (Attr)
-#/  tgt : E -> V (Id Entity)
 #/  src : E -> V (Id Entity)
+#/  tgt : E -> V (Id Entity)
+#/  weight : E -> Weight (Attr)
 
 
 type EntityArr := [
@@ -34,7 +34,7 @@ type EntityArr := [
   cod : Entity,
   arr : (Id Entity)[dom, cod]
 ]
-/# declared: EntityArr
+#/ declared: EntityArr
 
 type Graph1 := [
   V : Entity,
@@ -42,29 +42,29 @@ type Graph1 := [
   src : EntityArr & [ .dom := E, .cod := V ],
   tgt : EntityArr & [ .dom := E, .cod := V ],
 ]
-/# declared: Graph1
+#/ declared: Graph1
 
 chk [G : Graph1] (G.src.arr : (Id Entity)[G.E, G.V])
-/# result: G.src.arr
+#/ result: G.src.arr
 
 chk [G : Graph1] (G.src : EntityArr)
-/# result: G.src
+#/ result: G.src
 
 chk [G : Graph1] (G.src : EntityArr & [ .dom := G.E ] )
-/# result: G.src
+#/ result: G.src
 
 #(should_fail)
 chk [G : Graph1] (G.src : EntityArr & [ .dom := G.V ] )
-/# expected errors:
-/# error[elab]: evaluated term [ dom := G.E, cod := G.V, arr := <opaque> ] is not an element of specialized type [ dom : Entity, cod : Entity, arr : (Id Entity)[ self.dom, self.cod ] ] &
-/#   [ .dom : @sing G.V ]:
-/# Neutrals G.E and G.V are not equal.
-/# --> examples/test.dbltt:39:19
-/# 39| chk [G : Graph1] (G.src : EntityArr & [ .dom := G.V ] )
-/# 39|                   ^^^^^
+#/ expected errors:
+#/ error[elab]: evaluated term [ dom := G.E, cod := G.V, arr := <opaque> ] is not an element of specialized type [ dom : Entity, cod : Entity, arr : (Id Entity)[ self.dom, self.cod ] ] &
+#/   [ .dom : @sing G.V ]:
+#/ Neutrals G.E and G.V are not equal.
+#/ --> examples/test.dbltt:39:19
+#/ 39| chk [G : Graph1] (G.src : EntityArr & [ .dom := G.V ] )
+#/ 39|                   ^^^^^
 
 norm [x : [a : Entity, b : @sing a]] x.b
-/# result: x.a
+#/ result: x.a
 
 #(should_fail)
 type Graph1 := [
@@ -72,13 +72,13 @@ type Graph1 := [
   E : Entity,
   src : EntityArr & [ .dom := E, .dom := V ]
 ]
-/# expected errors:
-/# error[elab]: Failed to specialize:
-/# ... because @sing self.V is not a subtype of @sing self.E:
-/# ... because Neutrals self.V and self.E are not equal.
-/# --> examples/test.dbltt:47:34
-/# 47|   src : EntityArr & [ .dom := E, .dom := V ]
-/# 47|                                  ^^^^^^^^^
+#/ expected errors:
+#/ error[elab]: Failed to specialize:
+#/ ... because @sing self.V is not a subtype of @sing self.E:
+#/ ... because Neutrals self.V and self.E are not equal.
+#/ --> examples/test.dbltt:47:34
+#/ 47|   src : EntityArr & [ .dom := E, .dom := V ]
+#/ 47|                                  ^^^^^^^^^
 
 type Graph := [
   V : Entity,
@@ -86,7 +86,7 @@ type Graph := [
   src : (Id Entity)[E, V],
   tgt : (Id Entity)[E, V]
 ]
-/# declared: Graph
+#/ declared: Graph
 
 def reverse[G : Graph] : Graph := [
   V := G.V,
@@ -94,7 +94,7 @@ def reverse[G : Graph] : Graph := [
   src := G.tgt,
   tgt := G.src
 ]
-/# declared: reverse
+#/ declared: reverse
 
 #(should_fail)
 def reverse[G : Graph] : Graph := [
@@ -103,18 +103,18 @@ def reverse[G : Graph] : Graph := [
   src := G.tgt,
   tgt := G.src
 ]
-/# expected errors:
-/# error[elab]: synthesized type (Id Entity)[ G.E, G.V ] does not match expected type (Id Entity)[ G.E, G.E ]:
-/# could not convert codomains: Neutrals G.V and G.E are not equal.
-/# --> examples/test.dbltt:68:10
-/# 68|   src := G.tgt,
-/# 68|          ^^^^^
+#/ expected errors:
+#/ error[elab]: synthesized type (Id Entity)[ G.E, G.V ] does not match expected type (Id Entity)[ G.E, G.E ]:
+#/ could not convert codomains: Neutrals G.V and G.E are not equal.
+#/ --> examples/test.dbltt:68:10
+#/ 68|   src := G.tgt,
+#/ 68|          ^^^^^
 
 norm [G : Graph] (reverse[G]).E
-/# result: G.E
+#/ result: G.E
 
 syn [G : Graph] (reverse[G]).src
-/# result: reverse[ G ].src : (Id Entity)[ G.E, G.V ]
+#/ result: reverse[ G ].src : (Id Entity)[ G.E, G.V ]
 
 type ReflexiveGraph := [
   V : Entity,
@@ -123,37 +123,37 @@ type ReflexiveGraph := [
   tgt : (Id Entity)[E, V],
   refl : (Id Entity)[V, E]
 ]
-/# declared: ReflexiveGraph
+#/ declared: ReflexiveGraph
 
 def edge_id[G : ReflexiveGraph] : (Id Entity)[G.E, G.E] := @id G.E
-/# declared: edge_id
+#/ declared: edge_id
 
 def edge_src[G : ReflexiveGraph] : (Id Entity)[G.E, G.E] := G.src * G.refl
-/# declared: edge_src
+#/ declared: edge_src
 
 type Graph2 := [
   V : Entity,
   g1 : Graph & [ .V := V],
   g2 : Graph & [ .V := V]
 ]
-/# declared: Graph2
+#/ declared: Graph2
 
 syn [g : Graph2] g.g1.V
-/# result: g.g1.V : @sing g.V
+#/ result: g.g1.V : @sing g.V
 
 norm [g : Graph2] g.g1.V
-/# result: g.V
+#/ result: g.V
 
 generate Graph2
-/# result: 
+#/ result: 
 #/ object generators: 
-#/  g2.E : Entity
-#/  g1.E : Entity
 #/  V : Entity
+#/  g1.E : Entity
+#/  g2.E : Entity
 #/ morphism generators: 
-#/  g2.tgt : g2.E -> V (Id Entity)
-#/  g1.tgt : g1.E -> V (Id Entity)
 #/  g1.src : g1.E -> V (Id Entity)
+#/  g1.tgt : g1.E -> V (Id Entity)
 #/  g2.src : g2.E -> V (Id Entity)
+#/  g2.tgt : g2.E -> V (Id Entity)
 
 

--- a/packages/catlog/src/tt/batch.rs
+++ b/packages/catlog/src/tt/batch.rs
@@ -72,7 +72,7 @@ impl BatchOutput {
     fn declared(&self, name: NameSegment) {
         match self {
             BatchOutput::Snapshot(out) => {
-                writeln!(out.borrow_mut(), "/# declared: {}", name).unwrap();
+                writeln!(out.borrow_mut(), "#/ declared: {}", name).unwrap();
             }
             BatchOutput::Interactive => {}
         }
@@ -81,7 +81,7 @@ impl BatchOutput {
     fn got_result(&self, result: &str) {
         match self {
             BatchOutput::Snapshot(out) => {
-                writeln!(out.borrow_mut(), "/# result: {}", result).unwrap();
+                writeln!(out.borrow_mut(), "#/ result: {}", result).unwrap();
             }
             BatchOutput::Interactive => {
                 println!("{}", result);
@@ -95,9 +95,9 @@ impl BatchOutput {
                 let mut out = out.borrow_mut();
                 if reporter.errored() {
                     if should_fail {
-                        writeln!(out, "/# expected errors:").unwrap();
+                        writeln!(out, "#/ expected errors:").unwrap();
                     } else {
-                        writeln!(out, "/# unexpected errors:").unwrap();
+                        writeln!(out, "#/ unexpected errors:").unwrap();
                     }
                     let mut errors = String::new();
                     source_info
@@ -108,7 +108,7 @@ impl BatchOutput {
                         )
                         .unwrap();
                     for l in errors.lines() {
-                        writeln!(out, "/# {l}").unwrap();
+                        writeln!(out, "#/ {l}").unwrap();
                     }
                 }
                 writeln!(out).unwrap();

--- a/packages/catlog/src/tt/batch.rs
+++ b/packages/catlog/src/tt/batch.rs
@@ -11,6 +11,7 @@ use crate::{stdlib, tt::*};
 use elab::*;
 use fnotation::parser::Prec;
 use fnotation::{FNtnTop, ParseConfig};
+use prelude::*;
 use scopeguard::guard;
 use tattle::display::SourceInfo;
 use tattle::{Reporter, declare_error};
@@ -24,7 +25,7 @@ const PARSE_CONFIG: ParseConfig = ParseConfig::new(
         ("*", Prec::lassoc(60)),
     ],
     &[":", ":=", "&", "Unit", "Id", "*"],
-    &["type", "def", "syn", "chk", "norm"],
+    &["type", "def", "syn", "chk", "norm", "generate"],
 );
 
 declare_error!(TOP_ERROR, "top", "an error at the top-level");
@@ -167,7 +168,7 @@ pub fn elaborate(src: &str, path: &str, output: &BatchOutput) -> io::Result<bool
     });
     let mut succeeded = true;
     let _ = PARSE_CONFIG.with_parsed_top(src, reporter.clone(), |topntns| {
-        let mut toplevel = Toplevel::new(stdlib::th_schema());
+        let mut toplevel = Toplevel::new(Rc::new(stdlib::th_schema()));
         for topntn in topntns.iter() {
             output.log_input(src, topntn);
             let mut should_fail = false;

--- a/packages/catlog/src/tt/elab.rs
+++ b/packages/catlog/src/tt/elab.rs
@@ -39,22 +39,18 @@ pub struct TopElaborator<'a> {
 fn model_output(out: &mut impl fmt::Write, model: &DiscreteDblModel) -> fmt::Result {
     writeln!(out)?;
     writeln!(out, "#/ object generators: ")?;
-    let mut obgens = model.ob_generators().collect::<Vec<_>>();
-    obgens.sort();
-    for obgen in obgens.iter() {
-        writeln!(out, "#/  {} : {}", obgen, model.ob_type(obgen))?;
+    for obgen in model.ob_generators() {
+        writeln!(out, "#/  {} : {}", obgen, model.ob_type(&obgen))?;
     }
     writeln!(out, "#/ morphism generators: ")?;
-    let mut morgens = model.mor_generators().collect::<Vec<_>>();
-    morgens.sort();
-    for morgen in morgens.iter() {
+    for morgen in model.mor_generators() {
         writeln!(
             out,
             "#/  {} : {} -> {} ({})",
             morgen,
-            model.mor_generator_dom(morgen),
-            model.mor_generator_cod(morgen),
-            MorphismType(model.mor_generator_type(morgen))
+            model.mor_generator_dom(&morgen),
+            model.mor_generator_cod(&morgen),
+            MorphismType(model.mor_generator_type(&morgen))
         )?;
     }
     Ok(())

--- a/packages/catlog/src/tt/elab.rs
+++ b/packages/catlog/src/tt/elab.rs
@@ -176,7 +176,7 @@ impl<'a> TopElaborator<'a> {
                 let mut obgens = model.ob_generators().collect::<Vec<_>>();
                 obgens.sort();
                 for obgen in obgens.iter() {
-                    writeln!(&mut out, "#/  {} : {}", obgen, model.ob_type(&obgen)).unwrap();
+                    writeln!(&mut out, "#/  {} : {}", obgen, model.ob_type(obgen)).unwrap();
                 }
                 writeln!(&mut out, "#/ morphism generators: ").unwrap();
                 let mut morgens = model.mor_generators().collect::<Vec<_>>();
@@ -186,9 +186,9 @@ impl<'a> TopElaborator<'a> {
                         &mut out,
                         "#/  {} : {} -> {} ({})",
                         morgen,
-                        model.mor_generator_dom(&morgen),
-                        model.mor_generator_cod(&morgen),
-                        MorphismType(model.mor_generator_type(&morgen))
+                        model.mor_generator_dom(morgen),
+                        model.mor_generator_cod(morgen),
+                        MorphismType(model.mor_generator_type(morgen))
                     )
                     .unwrap();
                 }

--- a/packages/catlog/src/tt/elab.rs
+++ b/packages/catlog/src/tt/elab.rs
@@ -173,11 +173,15 @@ impl<'a> TopElaborator<'a> {
                 let mut out = String::new();
                 writeln!(&mut out).unwrap();
                 writeln!(&mut out, "#/ object generators: ").unwrap();
-                for obgen in model.ob_generators() {
+                let mut obgens = model.ob_generators().collect::<Vec<_>>();
+                obgens.sort();
+                for obgen in obgens.iter() {
                     writeln!(&mut out, "#/  {} : {}", obgen, model.ob_type(&obgen)).unwrap();
                 }
                 writeln!(&mut out, "#/ morphism generators: ").unwrap();
-                for morgen in model.mor_generators() {
+                let mut morgens = model.mor_generators().collect::<Vec<_>>();
+                morgens.sort();
+                for morgen in morgens.iter() {
                     writeln!(
                         &mut out,
                         "#/  {} : {} -> {} ({})",

--- a/packages/catlog/src/tt/eval.rs
+++ b/packages/catlog/src/tt/eval.rs
@@ -121,7 +121,8 @@ impl<'a> Evaluator<'a> {
         }
     }
 
-    fn bind_neu(&self, name: VarName, ty: TyV) -> (TmN, Self) {
+    /// Bind a new neutral of type `ty`
+    pub fn bind_neu(&self, name: VarName, ty: TyV) -> (TmN, Self) {
         let n = TmN::var(self.scope_length.into(), name);
         let v = TmV::Neu(n.clone(), ty);
         (

--- a/packages/catlog/src/tt/mod.rs
+++ b/packages/catlog/src/tt/mod.rs
@@ -355,6 +355,8 @@ be semantically the same type.
 pub mod batch;
 pub mod elab;
 pub mod eval;
+#[allow(unused)]
+pub mod modelgen;
 pub mod prelude;
 pub mod stx;
 pub mod toplevel;

--- a/packages/catlog/src/tt/mod.rs
+++ b/packages/catlog/src/tt/mod.rs
@@ -355,7 +355,6 @@ be semantically the same type.
 pub mod batch;
 pub mod elab;
 pub mod eval;
-#[allow(unused)]
 pub mod modelgen;
 pub mod prelude;
 pub mod stx;

--- a/packages/catlog/src/tt/modelgen.rs
+++ b/packages/catlog/src/tt/modelgen.rs
@@ -1,0 +1,61 @@
+/*! Generate catlog models from doublett types. */
+
+use crate::dbl::model::DiscreteDblModel;
+use crate::dbl::model::MutDblModel;
+use crate::tt::toplevel::Toplevel;
+use crate::tt::{eval::*, prelude::*, val::*};
+use crate::zero::QualifiedName;
+
+/** Generate a discrete double model from a type.
+
+Precondition: `ty` must be valid in the empty context. */
+pub fn generate(toplevel: &Toplevel, ty: &TyV) -> DiscreteDblModel {
+    let eval = Evaluator::new(toplevel, Env::Nil, 0);
+    let (elt, eval) = eval.bind_neu(text_seg("self"), ty.clone());
+    let elt = eval.eta_neu(&elt, ty);
+    let mut out = DiscreteDblModel::new(toplevel.theory.clone());
+    extract_to(&eval, &mut out, vec![], &elt, &ty);
+    out
+}
+
+// val must be an eta-expanded element of an object type
+fn name_of(val: &TmV) -> QualifiedName {
+    let mut out = Vec::new();
+    let mut n = val.as_neu();
+    while let TmN_::Proj(n1, f) = &*n.clone() {
+        n = n1.clone();
+        out.push(f.clone());
+    }
+    out.reverse();
+    out.into()
+}
+
+fn extract_to(
+    eval: &Evaluator,
+    out: &mut DiscreteDblModel,
+    prefix: Vec<NameSegment>,
+    val: &TmV,
+    ty: &TyV,
+) {
+    match &**ty {
+        TyV_::Object(ot) => out.add_ob(prefix.into(), ot.clone()),
+        TyV_::Morphism(mt, dom, cod) => {
+            out.add_mor(prefix.into(), name_of(dom), name_of(cod), mt.0.clone())
+        }
+        TyV_::Record(r) => {
+            for (name, _) in r.fields1.iter() {
+                let mut prefix = prefix.clone();
+                prefix.push(*name);
+                extract_to(
+                    eval,
+                    out,
+                    prefix,
+                    &eval.proj(val, *name),
+                    &eval.field_ty(ty, val, *name),
+                )
+            }
+        }
+        TyV_::Sing(ty_v, tm_v) => {}
+        TyV_::Unit => {}
+    }
+}

--- a/packages/catlog/src/tt/modelgen.rs
+++ b/packages/catlog/src/tt/modelgen.rs
@@ -55,7 +55,7 @@ fn extract_to(
                 )
             }
         }
-        TyV_::Sing(ty_v, tm_v) => {}
+        TyV_::Sing(_, _) => {}
         TyV_::Unit => {}
     }
 }

--- a/packages/catlog/src/tt/modelgen.rs
+++ b/packages/catlog/src/tt/modelgen.rs
@@ -14,7 +14,7 @@ pub fn generate(toplevel: &Toplevel, ty: &TyV) -> DiscreteDblModel {
     let (elt, eval) = eval.bind_neu(text_seg("self"), ty.clone());
     let elt = eval.eta_neu(&elt, ty);
     let mut out = DiscreteDblModel::new(toplevel.theory.clone());
-    extract_to(&eval, &mut out, vec![], &elt, &ty);
+    extract_to(&eval, &mut out, vec![], &elt, ty);
     out
 }
 
@@ -24,7 +24,7 @@ fn name_of(val: &TmV) -> QualifiedName {
     let mut n = val.as_neu();
     while let TmN_::Proj(n1, f) = &*n.clone() {
         n = n1.clone();
-        out.push(f.clone());
+        out.push(*f);
     }
     out.reverse();
     out.into()

--- a/packages/catlog/src/tt/toplevel.rs
+++ b/packages/catlog/src/tt/toplevel.rs
@@ -63,14 +63,14 @@ impl TopDecl {
 /** Storage for toplevel declarations. */
 pub struct Toplevel {
     /// The theory that we are elaborating with respect to
-    pub theory: DiscreteDblTheory,
+    pub theory: Rc<DiscreteDblTheory>,
     /// The toplevel declarations, indexed by their name.
     pub declarations: HashMap<TopVarName, TopDecl>,
 }
 
 impl Toplevel {
     /// Constructor for an empty [Toplevel].
-    pub fn new(theory: DiscreteDblTheory) -> Self {
+    pub fn new(theory: Rc<DiscreteDblTheory>) -> Self {
         Toplevel {
             theory,
             declarations: HashMap::new(),


### PR DESCRIPTION
This is surprisingly easy. This can be seen in action at `packages/catlog/examples/test.dbltt`, results in `test.dbltt.snapshot`.