### PR TITLE
Ensure stable order of object/morphism generators and plot variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.1"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown",

--- a/packages/catlog-wasm/src/model.rs
+++ b/packages/catlog-wasm/src/model.rs
@@ -446,25 +446,21 @@ impl DblModel {
     /// Returns the object generators for the model.
     #[wasm_bindgen(js_name = "obGenerators")]
     pub fn ob_generators(&self) -> Vec<QualifiedName> {
-        let mut ob_gens: Vec<_> = all_the_same!(match &self.model {
+        all_the_same!(match &self.model {
             DblModelBox::[Discrete, DiscreteTab, Modal](model) => {
                 model.ob_generators().collect()
             }
-        });
-        ob_gens.sort(); // Ensure stable order in frontend.
-        ob_gens
+        })
     }
 
     /// Returns the morphism generators for the model.
     #[wasm_bindgen(js_name = "morGenerators")]
     pub fn mor_generators(&self) -> Vec<QualifiedName> {
-        let mut mor_gens: Vec<_> = all_the_same!(match &self.model {
+        all_the_same!(match &self.model {
             DblModelBox::[Discrete, DiscreteTab, Modal](model) => {
                 model.mor_generators().collect()
             }
-        });
-        mor_gens.sort(); // Ensure stable order in frontend.
-        mor_gens
+        })
     }
 
     /// Returns the object generators of the given object type.

--- a/packages/catlog-wasm/src/model_diagram.rs
+++ b/packages/catlog-wasm/src/model_diagram.rs
@@ -171,27 +171,23 @@ impl DblModelDiagram {
     /// Returns the object generators for the diagram's indexing model.
     #[wasm_bindgen(js_name = "obGenerators")]
     pub fn ob_generators(&self) -> Vec<QualifiedName> {
-        let mut ob_gens: Vec<_> = all_the_same!(match &self.diagram {
+        all_the_same!(match &self.diagram {
             DblModelDiagramBox::[Discrete](diagram) => {
                 let (_, model) = diagram.into();
                 model.ob_generators().collect()
             }
-        });
-        ob_gens.sort();
-        ob_gens
+        })
     }
 
     /// Returns the morphism generators for the diagram's indexing model.
     #[wasm_bindgen(js_name = "morGenerators")]
     pub fn mor_generators(&self) -> Vec<QualifiedName> {
-        let mut mor_gens: Vec<_> = all_the_same!(match &self.diagram {
+        all_the_same!(match &self.diagram {
             DblModelDiagramBox::[Discrete](diagram) => {
                 let (_, model) = diagram.into();
                 model.mor_generators().collect()
             }
-        });
-        mor_gens.sort();
-        mor_gens
+        })
     }
 
     /// Returns the object generators of the given object type.

--- a/packages/catlog/Cargo.toml
+++ b/packages/catlog/Cargo.toml
@@ -20,7 +20,7 @@ egglog = { version = "0.5", default-features = false }
 ego-tree = "0.10"
 instant = { version = "0.1", optional = true } # Needed for egglog v0.5
 fnotation = "0.8.1"
-indexmap = "2.11.1"
+indexmap = "2.11"
 itertools = "0.14"
 nalgebra = { version = "0.33", optional = true }
 nonempty = "0.12"

--- a/packages/catlog/src/zero/set.rs
+++ b/packages/catlog/src/zero/set.rs
@@ -4,11 +4,12 @@ This module provides interfaces and simple wrapper types to enable sets to be
 treated in a generic way.
  */
 
+use std::hash::Hash;
 use std::ops::Range;
-use std::{collections::HashSet, hash::Hash};
 
 use derivative::Derivative;
 use derive_more::{From, Into};
+use indexmap::IndexSet;
 use ref_cast::RefCast;
 use ustr::Ustr;
 
@@ -116,12 +117,17 @@ impl IntoIterator for SkelFinSet {
     }
 }
 
-/// A finite set backed by a hash set.
-#[derive(Clone, Debug, From, Into, Derivative)]
+/** A finite set backed by a hash set.
+
+A stable order is guaranteed when iterating over the elements of the set.
+Currently, this achieved by using an [`IndexSet`] rather than a `HashSet` for
+the underlying data structure.
+ */
+#[derive(Clone, Debug, Derivative)]
 #[derivative(Default(bound = ""))]
 #[derivative(PartialEq(bound = "T: Eq + Hash"))]
 #[derivative(Eq(bound = "T: Eq + Hash"))]
-pub struct HashFinSet<T>(HashSet<T>);
+pub struct HashFinSet<T>(IndexSet<T>);
 
 /// A finite set with elements of type `Ustr`.
 pub type UstrFinSet = HashFinSet<Ustr>;
@@ -179,7 +185,7 @@ where
     T: Eq + Hash,
 {
     type Item = T;
-    type IntoIter = std::collections::hash_set::IntoIter<T>;
+    type IntoIter = indexmap::set::IntoIter<T>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
@@ -275,10 +281,7 @@ mod tests {
         assert!(s.contains(&3));
         assert!(s.contains(&7));
         assert!(!s.contains(&2));
-
-        let s = HashFinSet::from(HashSet::from([3, 5, 7]));
-        let sum: i32 = s.iter().sum();
-        assert_eq!(sum, 15);
+        assert_eq!(s.iter().sum::<i32>(), 15);
         assert_eq!(s.len(), 3);
     }
 

--- a/packages/frontend/src/stdlib/analyses/simulation.ts
+++ b/packages/frontend/src/stdlib/analyses/simulation.ts
@@ -2,7 +2,7 @@ import { type Accessor, createMemo } from "solid-js";
 
 import type { DblModel, JsResult, ODEResult } from "catlog-wasm";
 import type { LiveModelDocument } from "../../model";
-import type { ODEPlotData } from "../../visualization";
+import type { ODEPlotData, StateVarData } from "../../visualization";
 
 /** Reactively simulate and plot an ODE derived from a model.
 
@@ -24,15 +24,19 @@ export function createModelODEPlot(
             if (simulationResult?.tag !== "Ok") {
                 return simulationResult;
             }
-
             const solution = simulationResult.content;
-            const content = {
-                time: solution.time,
-                states: Array.from(solution.states.entries()).map(([id, data]) => ({
-                    name: model.obGeneratorLabel(id)?.join(".") ?? "",
-                    data,
-                })),
-            };
+
+            const states: StateVarData[] = [];
+            for (const id of model.obGenerators()) {
+                const data = solution.states.get(id);
+                if (data !== undefined) {
+                    states.push({
+                        name: model.obGeneratorLabel(id)?.join(".") ?? "",
+                        data,
+                    });
+                }
+            }
+            const content = { time: solution.time, states };
             return { tag: "Ok", content };
         },
         undefined,

--- a/packages/frontend/src/visualization/ode_plot.tsx
+++ b/packages/frontend/src/visualization/ode_plot.tsx
@@ -13,7 +13,7 @@ export type ODEPlotData = {
 };
 
 /** Values of a state variable over time. */
-type StateVarData = {
+export type StateVarData = {
     name: string;
     data: number[];
 };


### PR DESCRIPTION
Towards #13. We don't need to used `IndexMap` everywhere but we might want to use them for the mappings underlying model morphisms once we start editing morphisms in the frontend.