### PR TITLE
FIX: deploying from CI failing due to missing git

### DIFF
--- a/infrastructure/modules/catcolab/host.nix
+++ b/infrastructure/modules/catcolab/host.nix
@@ -1,6 +1,7 @@
 {
   lib,
   config,
+  pkgs,
   ...
 }:
 with lib;
@@ -47,6 +48,10 @@ with lib;
         experimental-features = nix-command flakes
       '';
     };
+
+    environment.systemPackages = with pkgs; [
+      git
+    ];
 
     programs.nh = {
       enable = true;


### PR DESCRIPTION
The issue was introduced in https://github.com/ToposInstitute/CatColab/commit/a431b73218b54f157c4d839e212ac57fadea251d by adding a git cargo dependency. It's likely a bug that crane isn't including git in it's build environment, since git is required for resolving git dependencies.