### PR TITLE
FIX: Cargo warning from patched dependency

### DIFF
--- a/packages/backend/Cargo.toml
+++ b/packages/backend/Cargo.toml
@@ -43,11 +43,3 @@ ts-rs = { version = "10.1.0", features = [
   "chrono-impl",
 ] }
 uuid = { version = "1.10.0", features = ["v7", "serde"] }
-
-
-[patch.crates-io]
-# Pin reqwest to rustls; add subfeatures only if you need them
-reqwest = { version = "0.12.23", default-features = false, features = [
-  "rustls-tls",
-  "json",
-] }


### PR DESCRIPTION
Fixes the cargo build warning

```
warning: patch for the non root package will be ignored, specify patch at the workspace root:
package:   /home/epatters/Local/topos/catcolab/packages/backend/Cargo.toml
workspace: /home/epatters/Local/topos/catcolab/Cargo.toml
```

Introduced in https://github.com/ToposInstitute/CatColab/pull/724. The patch worked, but was made redundant by upgrading the `firebase-auth` package (which was done in the same PR...)