### PR TITLE
Minimum viable document deletion

### DIFF
--- a/packages/backend/src/migrations/m20250924133640_add_refs_deleted_at.rs
+++ b/packages/backend/src/migrations/m20250924133640_add_refs_deleted_at.rs
@@ -1,0 +1,46 @@
+use sqlx::{PgConnection, Postgres};
+use sqlx_migrator::Operation;
+use sqlx_migrator::error::Error;
+use sqlx_migrator::migration;
+use sqlx_migrator::vec_box;
+
+pub(crate) struct AddRefsDeletedAt;
+
+migration!(
+    Postgres,
+    AddRefsDeletedAt,
+    "backend",
+    "20250924133640_add_refs_deleted_at",
+    vec_box![],
+    vec_box![MigrationOperation]
+);
+
+struct MigrationOperation;
+#[async_trait::async_trait]
+impl Operation<Postgres> for MigrationOperation {
+    async fn up(&self, conn: &mut PgConnection) -> Result<(), Error> {
+        sqlx::query(
+            "
+            ALTER TABLE refs
+            ADD COLUMN deleted_at TIMESTAMPTZ NULL;
+            ",
+        )
+        .execute(conn)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, conn: &mut PgConnection) -> Result<(), Error> {
+        sqlx::query(
+            "
+            ALTER TABLE refs
+            DROP COLUMN deleted_at;
+            ",
+        )
+        .execute(conn)
+        .await?;
+
+        Ok(())
+    }
+}

--- a/packages/backend/src/migrations/mod.rs
+++ b/packages/backend/src/migrations/mod.rs
@@ -7,6 +7,7 @@ mod m20241025030906_users;
 mod m20250409171833_add_permissions_object_subject_idx;
 mod m20250516154702_automerge_storage;
 mod m20250805230408_fix_automerge_storage;
+mod m20250924133640_add_refs_deleted_at;
 
 pub fn migrations() -> Vec<Box<dyn Migration<Postgres>>> {
     vec_box![
@@ -15,5 +16,6 @@ pub fn migrations() -> Vec<Box<dyn Migration<Postgres>>> {
         m20250409171833_add_permissions_object_subject_idx::AddPermissionsObjectSubjectIdx,
         m20250516154702_automerge_storage::AutomergeStorage,
         m20250805230408_fix_automerge_storage::FixAutomergeStorage,
+        m20250924133640_add_refs_deleted_at::AddRefsDeletedAt,
     ]
 }


### PR DESCRIPTION
I am working on document deletion which is one of the points in #500 . 

- This will be done via soft deletion using a `deleted_at` column in `refs` and possibly on `snapshots` (still need to look into that)

- The initial UI will simply add a delete button to the My Documents table and have a dialog for "are you sure?". When deleting a model

Mockups:

<img width="693" height="297" alt="image" src="https://github.com/user-attachments/assets/6c3a5f92-0d65-4621-ae09-086e6829570f" />

<img width="694" height="297" alt="image" src="https://github.com/user-attachments/assets/936c90f5-8a76-49da-bd13-133f611a899a" />


## Implementation status

So far I have only added the `deleted_at` column via a DB migration. 


## Further future enhancements (possibly going to to be on this PR, or a new one)

- Show the user an informative message when a document has been deleted and they are trying to access it
- Display analysis as a sub-row of its model and give more details on what would be deleted when

Mockups: 

<img width="814" height="875" alt="image" src="https://github.com/user-attachments/assets/21286031-659a-4f1c-9c8d-28a03c2d0f6c" />


Link to mockups: https://excalidraw.com/#json=H0ASC9D2Yg4rHphcXQPjk,20XDpsaAxY0cMZTRw-rZGA