### PR TITLE
Replace typeName with relative icons

### DIFF
--- a/packages/frontend/src/user/documents.tsx
+++ b/packages/frontend/src/user/documents.tsx
@@ -9,7 +9,7 @@ import "./documents.css";
 import { useNavigate } from "@solidjs/router";
 import { Spinner } from "../components/spinner";
 import ChartSpline from "lucide-solid/icons/chart-spline";
-import FilePlus from "lucide-solid/icons/file-plus";
+import File from "lucide-solid/icons/file";
 import UploadIcon from "lucide-solid/icons/upload";
 import { IconButton } from "../components";
 
@@ -229,7 +229,7 @@ function DocumentIconType(props: { typeName?: string }) {
                     <UploadIcon size="20" />
                 </Match>
                 <Match when={props.typeName === "model"}>
-                    <FilePlus size="20" />
+                    <File size="20" />
                 </Match>
             </Switch>
         </IconButton>

--- a/packages/frontend/src/user/documents.tsx
+++ b/packages/frontend/src/user/documents.tsx
@@ -8,6 +8,9 @@ import { LoginGate } from "./login";
 import "./documents.css";
 import { useNavigate } from "@solidjs/router";
 import { Spinner } from "../components/spinner";
+import ChartSpline from "lucide-solid/icons/chart-spline";
+import FilePlus from "lucide-solid/icons/file-plus";
+import UploadIcon from "lucide-solid/icons/upload";
 
 export default function UserDocuments() {
     return (
@@ -198,7 +201,7 @@ function RefStubRow(props: { stub: RefStub }) {
 
     return (
         <tr class="ref-stub-row" onClick={handleClick}>
-            <td>{props.stub.typeName}</td>
+            <td><DocumentIconType typeName={props.stub.typeName}></DocumentIconType></td>
             <td>{props.stub.name}</td>
             <td>{ownerName}</td>
             <td>{props.stub.permissionLevel}</td>
@@ -210,5 +213,22 @@ function RefStubRow(props: { stub: RefStub }) {
                 })}
             </td>
         </tr>
+    );
+}
+
+function DocumentIconType(props: { typeName?: string }) {
+
+    return (
+        <Switch fallback={props.typeName}>
+            <Match when={props.typeName === "analysis"}>
+                <ChartSpline size="20"></ChartSpline>
+            </Match>
+            <Match when={props.typeName === "diagram"}>
+                <UploadIcon size="20" />
+            </Match>
+            <Match when={props.typeName === "model"}>
+                <FilePlus size="20" />
+            </Match>
+        </Switch>
     );
 }

--- a/packages/frontend/src/user/documents.tsx
+++ b/packages/frontend/src/user/documents.tsx
@@ -11,6 +11,7 @@ import { Spinner } from "../components/spinner";
 import ChartSpline from "lucide-solid/icons/chart-spline";
 import FilePlus from "lucide-solid/icons/file-plus";
 import UploadIcon from "lucide-solid/icons/upload";
+import { IconButton } from "../components";
 
 export default function UserDocuments() {
     return (
@@ -201,8 +202,8 @@ function RefStubRow(props: { stub: RefStub }) {
 
     return (
         <tr class="ref-stub-row" onClick={handleClick}>
-            <td><DocumentIconType typeName={props.stub.typeName}></DocumentIconType></td>
-            <td>{props.stub.name}</td>
+            <td class=" tooltip" data-tooltip={props.stub.typeName}><DocumentIconType typeName={props.stub.typeName}></DocumentIconType></td>
+            <td class=" tooltip" data-tooltip={props.stub.typeName}>{props.stub.name}</td>
             <td>{ownerName}</td>
             <td>{props.stub.permissionLevel}</td>
             <td>
@@ -219,16 +220,18 @@ function RefStubRow(props: { stub: RefStub }) {
 function DocumentIconType(props: { typeName?: string }) {
 
     return (
-        <Switch fallback={props.typeName}>
-            <Match when={props.typeName === "analysis"}>
-                <ChartSpline size="20"></ChartSpline>
-            </Match>
-            <Match when={props.typeName === "diagram"}>
-                <UploadIcon size="20" />
-            </Match>
-            <Match when={props.typeName === "model"}>
-                <FilePlus size="20" />
-            </Match>
-        </Switch>
+        <IconButton tooltip={props.typeName ?? "unknown"}>
+            <Switch fallback={props.typeName}>
+                <Match when={props.typeName === "analysis"}>
+                    <ChartSpline size={20} />
+                </Match>
+                <Match when={props.typeName === "diagram"}>
+                    <UploadIcon size="20" />
+                </Match>
+                <Match when={props.typeName === "model"}>
+                    <FilePlus size="20" />
+                </Match>
+            </Switch>
+        </IconButton>
     );
 }


### PR DESCRIPTION

Task 2. Currently, the document type is displayed as plain text (“model”, “diagram”, “analysis”), causing much repetition of the same words. Instead, display a different icon for each document type.
Notes: 
- specific icons for at least diagrams and analyses are already in use in the document menu.
I've used a component that handle the icon rendering, wich also add a tooltip for UX reasons. In order to reuse code i wrapped it with `IconButton` wich already implements the tooltip. That's not very semantic thosuh and  I would rather create a general CustomToolitp component instead.
- I've also learnt that at this stage there is no typeName `type`
- I couldn't reuse the `.tooltip` css class since it has doesn't overlap the table and the css should be [amended  ](https://github.com/chinchang/hint.css/issues/209), and check that the change will work in other part of the application
<img width="1159" height="137" alt="image" src="https://github.com/user-attachments/assets/f49a4262-3f06-4e9f-bf7d-4b2742e1bd96" />

Task 1.  Currently, the documents page shows all documents for which you have some level of permissions. Add an option to filter the documents to show only the documents that you own.
Notes: 
- Not yet done.
- Added a checkbox to filter data by owned
- Uses and update the api `search_ref_stubs` with field `ownerUsernameQuery` when teh filter is set
- I notice that the userprofile is fetched only in the profile page. It shoould be nice to fetch the user at the start of the applicaiton (or login) and  have it available in all app for instance in the localStorage or sessionStorage
- Similarly filter like the one implmented can be stored so that when the user goes back to my document page it will preserve the previous selection
- There are a some extra calls to the server that may need to be 
- On another side i noticed that the application does a first redirect wich can potentially be done differently. Currently it create a page and call the html <Navigate> to redirect. I think that the redirection can be done withouth loading the DOM to and save some milliseconds.
