### PR TITLE
Remove lingering type defs for links from frontend

### DIFF
--- a/packages/backend/src/document.rs
+++ b/packages/backend/src/document.rs
@@ -214,9 +214,8 @@ pub struct NewDocSocketResponse {
     pub doc_json: Value,
 }
 
-/// A subset of user relevant information about a ref. Used for showing
-/// users information on a variety of refs without having to load whole
-/// refs.
+/// A subset of user relevant information about a ref. Used for showing users
+/// information on a variety of refs without having to load whole refs.
 #[derive(Clone, Debug, Serialize, Deserialize, TS)]
 pub struct RefStub {
     pub name: String,

--- a/packages/frontend/src/analysis/document.ts
+++ b/packages/frontend/src/analysis/document.ts
@@ -1,14 +1,14 @@
 import type { AutomergeUrl, Repo } from "@automerge/automerge-repo";
 import invariant from "tiny-invariant";
 
-import { type Analysis, type AnalysisType, type Document, currentVersion } from "catlog-wasm";
 import {
-    type Api,
-    type LiveDoc,
+    type Analysis,
+    type AnalysisType,
+    type Document,
     type StableRef,
-    getLiveDoc,
-    getLiveDocFromDocHandle,
-} from "../api";
+    currentVersion,
+} from "catlog-wasm";
+import { type Api, type LiveDoc, getLiveDoc, getLiveDocFromDocHandle } from "../api";
 import { type LiveDiagramDocument, getLiveDiagram, getLiveDiagramFromRepo } from "../diagram";
 import { type LiveModelDocument, getLiveModel, getLiveModelFromRepo } from "../model";
 import { newNotebook } from "../notebook";

--- a/packages/frontend/src/api/types.ts
+++ b/packages/frontend/src/api/types.ts
@@ -1,6 +1,5 @@
 import type { Repo } from "@automerge/automerge-repo";
 
-import type { Uuid } from "catlog-wasm";
 import type { RpcClient } from "./rpc";
 
 /** Bundle of everything needed to interact with the CatColab backend. */
@@ -13,53 +12,4 @@ export type Api = {
 
     /** Automerge repo connected to the Automerge document server. */
     repo: Repo;
-};
-
-/** A stable reference to a document in the database.
-
-Such a reference identifies a specific document, possibly at a specific version.
-The keys are prefixed with an underscore, e.g. `_id` instead of `id`, to avoid
-conflicts with other keys and unambiguously signal that the ID and other data
-apply at the *database* level, rather than merely the *document* level. The same
-convention is used in document databases like CouchDB and MongoDB.
- */
-export type StableRef = {
-    /** Unique identifier of the document. */
-    _id: Uuid;
-
-    /** Version of the document.
-
-    If null, refers to the head snapshot of document. This is the case when the
-    referenced document will receive live updates.
-     */
-    _version: string | null;
-
-    /** Server containing the document.
-
-    Assuming one of the official deployments is used, this will be either
-    `catcolab.org` or `next.catcolab.org`.
-     */
-    _server: string;
-};
-
-/** Base type for a document persisted in the database. */
-export type Document<T extends string> = {
-    /** Type of the document, such as "model" or "diagram". */
-    type: T;
-
-    /** Human-readable name of the document. */
-    name: string;
-};
-
-/** A document located within the database. */
-export type StableDocument<T extends string> = StableRef & Document<T>;
-
-/** A link from one document to another.
-
-The source of the link is the document containing this data and the target of
-link is given by the data itself.
- */
-export type Link<T extends string> = StableRef & {
-    /** Type of the link, such as "diagramIn" or "analysisOf" .*/
-    type: T;
 };

--- a/packages/frontend/src/components/json_import.tsx
+++ b/packages/frontend/src/components/json_import.tsx
@@ -1,13 +1,13 @@
-import { createSignal } from "solid-js";
-import type { JSX } from "solid-js";
-import type { Document } from "../api";
+import { type JSX, createSignal } from "solid-js";
+
+import type { Document } from "catlog-wasm";
 import { FormGroup, InputField, TextAreaField } from "./form";
 
 import "./json_import.css";
 
-interface JsonImportProps<T extends string> {
-    onImport: (data: Document<T>) => void;
-    validate?: (data: Document<T>) => boolean | string;
+interface JsonImportProps {
+    onImport: (data: Document) => void;
+    validate?: (data: Document) => boolean | string;
 }
 
 /**
@@ -16,7 +16,7 @@ interface JsonImportProps<T extends string> {
  * File size is currently limited to 5MB.
  *
  */
-export const JsonImport = <T extends string>({ onImport, validate }: JsonImportProps<T>) => {
+export const JsonImport = ({ onImport, validate }: JsonImportProps) => {
     const [error, setError] = createSignal<string | null>(null);
     const [importValue, setImportValue] = createSignal("");
 

--- a/packages/frontend/src/diagram/document.ts
+++ b/packages/frontend/src/diagram/document.ts
@@ -7,15 +7,10 @@ import type {
     DiagramJudgment,
     Document,
     ModelDiagramValidationResult,
+    StableRef,
 } from "catlog-wasm";
 import { currentVersion, elaborateDiagram } from "catlog-wasm";
-import {
-    type Api,
-    type LiveDoc,
-    type StableRef,
-    getLiveDoc,
-    getLiveDocFromDocHandle,
-} from "../api";
+import { type Api, type LiveDoc, getLiveDoc, getLiveDocFromDocHandle } from "../api";
 import { type LiveModelDocument, getLiveModel, getLiveModelFromRepo } from "../model";
 import { NotebookUtils, newNotebook } from "../notebook";
 import type { TheoryLibrary } from "../stdlib";

--- a/packages/frontend/src/page/document_menu.tsx
+++ b/packages/frontend/src/page/document_menu.tsx
@@ -2,8 +2,9 @@ import { useNavigate } from "@solidjs/router";
 import { Match, Show, Switch } from "solid-js";
 import invariant from "tiny-invariant";
 
+import type { StableRef } from "catlog-wasm";
 import { createAnalysis } from "../analysis/document";
-import { type StableRef, useApi } from "../api";
+import { useApi } from "../api";
 import { duplicateDocument } from "../api/duplicate_document";
 import { type LiveDiagramDocument, createDiagram } from "../diagram/document";
 import type { LiveModelDocument } from "../model/document";

--- a/packages/frontend/src/page/import_document.tsx
+++ b/packages/frontend/src/page/import_document.tsx
@@ -1,13 +1,15 @@
 import { useNavigate } from "@solidjs/router";
 import invariant from "tiny-invariant";
-import { type Document, useApi } from "../api";
+
+import type { Document } from "catlog-wasm";
+import { useApi } from "../api";
 import { JsonImport } from "../components";
 import { type DiagramDocument, createDiagramFromDocument } from "../diagram";
 import { type ModelDocument, createModel } from "../model";
 
 type ImportableDocument = ModelDocument | DiagramDocument;
 
-function isImportableDocument(doc: Document<string>): doc is ImportableDocument {
+function isImportableDocument(doc: Document): doc is ImportableDocument {
     return doc.type === "model" || doc.type === "diagram";
 }
 
@@ -16,7 +18,7 @@ export function ImportDocument(props: { onComplete?: () => void }) {
     const api = useApi();
     const navigate = useNavigate();
 
-    const handleImport = async (data: Document<string>) => {
+    const handleImport = async (data: Document) => {
         invariant(
             isImportableDocument(data),
             "Analysis and other document types cannot be imported at this time.",
@@ -52,12 +54,12 @@ export function ImportDocument(props: { onComplete?: () => void }) {
 
     // Placeholder, not doing more than typechecking does for now but
     // will eventually validate against json schema
-    const validateJson = (data: Document<string>) => {
+    const validateJson = (data: Document) => {
         if (!isImportableDocument(data)) {
             return "Analysis and other document types cannot be imported at this time.";
         }
         return true;
     };
 
-    return <JsonImport<"model" | "diagram"> onImport={handleImport} validate={validateJson} />;
+    return <JsonImport onImport={handleImport} validate={validateJson} />;
 }

--- a/packages/notebook-types/src/v0/api.rs
+++ b/packages/notebook-types/src/v0/api.rs
@@ -3,22 +3,47 @@ use uuid::Uuid;
 use serde::{Deserialize, Serialize};
 use tsify::Tsify;
 
+/// A stable reference to a document in the database.
+///
+/// Such a reference identifies a specific document, possibly at a specific
+/// version. The keys are prefixed with an underscore, e.g. `_id` instead of
+/// `id`, to avoid conflicts with other keys and unambiguously signal that the
+/// ID and other data apply at the *database* level, rather than merely the
+/// *document* level. The same convention is used in document databases like
+/// CouchDB and MongoDB.
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[tsify(missing_as_null)]
 pub struct StableRef {
+    /// Unique identifier of the referenced document.
     #[serde(rename = "_id")]
     pub id: Uuid,
+
+    /// Version of the document.
+    ///
+    /// If null, refers to the head snapshot of document. This is the case when
+    /// the referenced document will receive live updates.
     #[serde(rename = "_version")]
     pub version: Option<String>,
+
+    /// Server containing the document.
+    ///
+    /// Assuming one of the official deployments is used, this will be either
+    /// `catcolab.org` or `next.catcolab.org`.
     #[serde(rename = "_server")]
     pub server: String,
 }
 
+/// A link from one document to another.
+///
+/// The source of the link is the document containing this data and the target
+/// of link is given by the data itself.
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub struct Link {
     #[serde(flatten)]
     pub stable_ref: StableRef,
+
+    /// Type of the link, such as "diagramIn" or "analysisOf".
     pub r#type: String,
 }

--- a/packages/notebook-types/src/v0/document.rs
+++ b/packages/notebook-types/src/v0/document.rs
@@ -7,8 +7,8 @@ use super::notebook::Notebook;
 use serde::{Deserialize, Serialize};
 use tsify::Tsify;
 
-/// This is the content of a model document. For legacy reasons, we reserve
-/// the name "ModelDocument" for `Document & { type: "model" }`.
+/// The content of a model document. For legacy reasons, we reserve the name
+/// `ModelDocument` for the type `Document & { type: "model" }`.
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct ModelDocumentContent {
     pub name: String,


### PR DESCRIPTION
Another remnant, hopefully the last one, from the refactor that moved the notebook and document types from TypeScript to Rust (#473).