### PR TITLE
Bump rebop to v0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2482,8 +2482,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rebop"
-version = "0.9.2"
-source = "git+https://github.com/Armavica/rebop.git?rev=eb1e500#eb1e500511721dd1981e3ea7792dc65cf5f28066"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e68473e30430c07a9058b63688fe3a4bd25301be660ebc0f598a5fa320d9d1"
 dependencies = [
  "rand 0.9.2",
  "rand_distr",
@@ -4506,9 +4507,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]

--- a/packages/catlog/Cargo.toml
+++ b/packages/catlog/Cargo.toml
@@ -27,7 +27,7 @@ nonempty = "0.12"
 num-traits = "0.2"
 ode_solvers = { version = "0.5.0", optional = true }
 pretty = "0.12.4"
-rebop = { git = "https://github.com/Armavica/rebop.git", rev = "eb1e500", default-features = false, optional = true }
+rebop = { version = "0.9.3", default-features = false, optional = true }
 ref-cast = "1"
 scopeguard = "1.2.0"
 serde = { version = "1", features = ["derive"], optional = true }


### PR DESCRIPTION
Rebop latest now has our refactor, so we can point our Cargo.toml to it rather than a specific commit.

Front-end validation:
<img width="2137" height="1037" alt="image" src="https://github.com/user-attachments/assets/db713228-f687-43ba-99ff-ad44d394f82f" />
