### PR TITLE
Reimplement keyboard shortcuts in notebook more simply

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -39,7 +39,7 @@
         "@solid-primitives/active-element": "^2.1.1",
         "@solid-primitives/context": "^0.3.1",
         "@solid-primitives/destructure": "^0.2.1",
-        "@solid-primitives/keyboard": "^1.3.1",
+        "@solid-primitives/event-listener": "^2.4.3",
         "@solid-primitives/timer": "^1.4.1",
         "@solidjs/router": "^0.15.3",
         "@viz-js/viz": "^3.15.0",

--- a/packages/frontend/pnpm-lock.yaml
+++ b/packages/frontend/pnpm-lock.yaml
@@ -68,9 +68,9 @@ importers:
       '@solid-primitives/destructure':
         specifier: ^0.2.1
         version: 0.2.2(solid-js@1.9.7)
-      '@solid-primitives/keyboard':
-        specifier: ^1.3.1
-        version: 1.3.3(solid-js@1.9.7)
+      '@solid-primitives/event-listener':
+        specifier: ^2.4.3
+        version: 2.4.3(solid-js@1.9.7)
       '@solid-primitives/timer':
         specifier: ^1.4.1
         version: 1.4.2(solid-js@1.9.7)
@@ -1074,18 +1074,8 @@ packages:
     peerDependencies:
       solid-js: ^1.6.12
 
-  '@solid-primitives/event-listener@2.3.3':
-    resolution: {integrity: sha512-DAJbl+F0wrFW2xmcV8dKMBhk9QLVLuBSW+TR4JmIfTaObxd13PuL7nqaXnaYKDWOYa6otB00qcCUIGbuIhSUgQ==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
   '@solid-primitives/event-listener@2.4.3':
     resolution: {integrity: sha512-h4VqkYFv6Gf+L7SQj+Y6puigL/5DIi7x5q07VZET7AWcS+9/G3WfIE9WheniHWJs51OEkRB43w6lDys5YeFceg==}
-    peerDependencies:
-      solid-js: ^1.6.12
-
-  '@solid-primitives/keyboard@1.3.3':
-    resolution: {integrity: sha512-9dQHTTgLBqyAI7aavtO+HnpTVJgWQA1ghBSrmLtMu1SMxLPDuLfuNr+Tk5udb4AL4Ojg7h9JrKOGEEDqsJXWJA==}
     peerDependencies:
       solid-js: ^1.6.12
 
@@ -4129,20 +4119,8 @@ snapshots:
       '@solid-primitives/utils': 6.3.2(solid-js@1.9.7)
       solid-js: 1.9.7
 
-  '@solid-primitives/event-listener@2.3.3(solid-js@1.9.7)':
-    dependencies:
-      '@solid-primitives/utils': 6.2.3(solid-js@1.9.7)
-      solid-js: 1.9.7
-
   '@solid-primitives/event-listener@2.4.3(solid-js@1.9.7)':
     dependencies:
-      '@solid-primitives/utils': 6.3.2(solid-js@1.9.7)
-      solid-js: 1.9.7
-
-  '@solid-primitives/keyboard@1.3.3(solid-js@1.9.7)':
-    dependencies:
-      '@solid-primitives/event-listener': 2.4.3(solid-js@1.9.7)
-      '@solid-primitives/rootless': 1.5.2(solid-js@1.9.7)
       '@solid-primitives/utils': 6.3.2(solid-js@1.9.7)
       solid-js: 1.9.7
 
@@ -4175,7 +4153,7 @@ snapshots:
 
   '@solid-primitives/resize-observer@2.0.26(solid-js@1.9.7)':
     dependencies:
-      '@solid-primitives/event-listener': 2.3.3(solid-js@1.9.7)
+      '@solid-primitives/event-listener': 2.4.3(solid-js@1.9.7)
       '@solid-primitives/rootless': 1.4.5(solid-js@1.9.7)
       '@solid-primitives/static-store': 0.0.8(solid-js@1.9.7)
       '@solid-primitives/utils': 6.2.3(solid-js@1.9.7)

--- a/packages/frontend/src/components/completions.tsx
+++ b/packages/frontend/src/components/completions.tsx
@@ -1,5 +1,6 @@
-import type { KbdKey } from "@solid-primitives/keyboard";
 import { For, type JSX, Show, createMemo, createSignal, onMount } from "solid-js";
+
+import type { KbdKey } from "../util/keyboard";
 
 import "./completions.css";
 
@@ -96,7 +97,7 @@ export function Completions(props: {
                             <div class="completion-name">{c.name}</div>
                             <Show when={c.shortcut}>
                                 <div class="completion-shortcut">
-                                    <KbdShortcut shortcut={c.shortcut as KbdKey[]} />
+                                    <KbdShortcut shortcut={c.shortcut ?? []} />
                                 </div>
                             </Show>
                         </div>

--- a/packages/frontend/src/diagram/diagram_editor.tsx
+++ b/packages/frontend/src/diagram/diagram_editor.tsx
@@ -11,7 +11,6 @@ import {
     type CellConstructor,
     type FormalCellEditorProps,
     NotebookEditor,
-    cellShortcutModifier,
     newFormalCell,
 } from "../notebook";
 import { DocumentBreadcrumbs, DocumentLoadingScreen, Toolbar } from "../page";
@@ -179,7 +178,7 @@ function diagramCellConstructor(meta: InstanceTypeMeta): CellConstructor<Diagram
     return {
         name,
         description,
-        shortcut: shortcut && [cellShortcutModifier, ...shortcut],
+        shortcut,
         construct() {
             return meta.tag === "ObType"
                 ? newFormalCell(newDiagramObjectDecl(meta.obType))

--- a/packages/frontend/src/model/model_editor.tsx
+++ b/packages/frontend/src/model/model_editor.tsx
@@ -12,7 +12,6 @@ import {
     type FormalCellEditorProps,
     NotebookEditor,
     NotebookUtils,
-    cellShortcutModifier,
     newFormalCell,
 } from "../notebook";
 import { DocumentBreadcrumbs, DocumentLoadingScreen, Toolbar } from "../page";
@@ -195,7 +194,7 @@ function modelCellConstructor(meta: ModelTypeMeta): CellConstructor<ModelJudgmen
     return {
         name,
         description,
-        shortcut: shortcut && [cellShortcutModifier, ...shortcut],
+        shortcut,
         construct() {
             return meta.tag === "ObType"
                 ? newFormalCell(newObjectDecl(meta.obType))

--- a/packages/frontend/src/theory/theory.ts
+++ b/packages/frontend/src/theory/theory.ts
@@ -1,9 +1,8 @@
-import type { KbdKey } from "@solid-primitives/keyboard";
-
 import type { DblModel, DblTheory, MorType, ObOp, ObType } from "catlog-wasm";
 import { MorTypeIndex, ObTypeIndex } from "catlog-wasm";
 import type { DiagramAnalysisComponent, ModelAnalysisComponent } from "../analysis";
 import { uniqueIndexArray } from "../util/indexing";
+import type { KbdKey } from "../util/keyboard";
 import type { ArrowStyle } from "../visualization";
 
 /** A double theory configured for the frontend.

--- a/packages/frontend/src/util/keyboard.ts
+++ b/packages/frontend/src/util/keyboard.ts
@@ -1,0 +1,26 @@
+/** Utilities for keyboard events and shortcuts.
+
+The types `ModifierKey` and `KbdKey` are borrowed from
+`@solid-primitives/keyboard`, a package that we're no longer using.
+
+@module
+ */
+
+export type ModifierKey = "Alt" | "Control" | "Meta" | "Shift";
+export type KbdKey = ModifierKey | (string & {});
+
+/** Returns whether the modifier key is active in the keyboard event. */
+export function keyEventHasModifier(evt: KeyboardEvent, key: ModifierKey): boolean {
+    switch (key) {
+        case "Alt":
+            return evt.altKey;
+        case "Control":
+            return evt.ctrlKey;
+        case "Meta":
+            return evt.metaKey;
+        case "Shift":
+            return evt.shiftKey;
+        default:
+            throw new Error(`Key is not a modifier: ${key}`);
+    }
+}


### PR DESCRIPTION
In my PR introducing a `ModelLibrary` (#758), the previous approach to handling keyboard shortcuts in the notebook was causing an infinite loop. That's quite horrifying and possibly indicative of other problems with the new code. Nevertheless, the previous approach to shortcuts reactively calls `createShortcut` from `@solid-primitives/keyboard` whenever the list of shortcut changes (due to the theory changing). That's a lot of unnecessary signalling. In the new approach, we just handle the key down event directly.  