### PR TITLE
Fix failing integration test and improve error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,7 @@ dependencies = [
  "hyper 1.6.0",
  "jsonrpsee 0.24.9",
  "jsonrpsee-server 0.24.9",
+ "notebook-types",
  "qubit",
  "regex",
  "sd-notify",

--- a/packages/automerge-doc-server/src/server.ts
+++ b/packages/automerge-doc-server/src/server.ts
@@ -15,10 +15,20 @@ import type { Pool as PoolType } from "pg";
 import { PostgresStorageAdapter } from "./postgres_storage_adapter.js";
 import type { NewDocSocketResponse, StartListeningSocketResponse } from "./types.js";
 import type { SocketIOHandlers } from "./socket.js";
+import { serializeError } from "./socket.js";
 import jsonpatch from "fast-json-patch";
 
 // Load environment variables from .env
 dotenv.config();
+
+/** Attempt to migrate a document, returning the migrated document or an error message. */
+function migrateDocument(doc: unknown): { Ok: any } | { Err: string } {
+    try {
+        return { Ok: notbookTypes.migrateDocument(doc) };
+    } catch (e) {
+        return { Err: `Failed to migrate document: ${serializeError(e)}` };
+    }
+}
 
 export class AutomergeServer implements SocketIOHandlers {
     private docMap: Map<string, DocHandle<unknown>>;
@@ -66,7 +76,12 @@ export class AutomergeServer implements SocketIOHandlers {
     }
 
     async createDoc(content: unknown): Promise<NewDocSocketResponse> {
-        const handle = this.repo.create(content);
+        const migrateResult = migrateDocument(content);
+        if ("Err" in migrateResult) {
+            return migrateResult;
+        }
+
+        const handle = this.repo.create(migrateResult.Ok);
         if (!handle) {
             return {
                 Err: "Failed to create a new document",
@@ -133,14 +148,18 @@ export class AutomergeServer implements SocketIOHandlers {
         //
         // XXX: frontend/src/api/document.ts needs to be kept up to date with this
         const docBefore = handle.doc();
-        const docAfter = notbookTypes.migrateDocument(docBefore);
+        const migrateResult = migrateDocument(docBefore);
+        if ("Err" in migrateResult) {
+            return migrateResult;
+        }
+        const docAfter = migrateResult.Ok;
+
         if ((docBefore as any).version !== docAfter.version) {
             const patches = jsonpatch.compare(docBefore as any, docAfter);
             handle.change((doc: any) => {
                 jsonpatch.applyPatch(doc, patches);
             });
         }
-
         this.docMap.set(refId, handle);
 
         return { Ok: null };

--- a/packages/backend/Cargo.toml
+++ b/packages/backend/Cargo.toml
@@ -16,6 +16,7 @@ http = "1.1.0"
 hyper = { version = "1.4.1", features = ["server"] }
 jsonrpsee = "0.24.6"
 jsonrpsee-server = "0.24.6"
+notebook-types = { version = "0.1.0", path = "../notebook-types" }
 qubit = "0.10.2"
 regex = "1.11.1"
 sd-notify = "0.4.5"

--- a/packages/backend/src/document.rs
+++ b/packages/backend/src/document.rs
@@ -12,6 +12,10 @@ use crate::{auth::PermissionLevel, user::UserSummary};
 
 /// Creates a new document ref with initial content.
 pub async fn new_ref(ctx: AppCtx, content: Value) -> Result<Uuid, AppError> {
+    // Validate document structure by attempting to deserialize it
+    let _validated_doc: notebook_types::VersionedDocument = serde_json::from_value(content.clone())
+        .map_err(|e| AppError::Invalid(format!("Failed to parse document: {}", e)))?;
+
     let ref_id = Uuid::now_v7();
 
     // If the document is created but the db transaction doesn't complete, then the document will be

--- a/packages/frontend/src/api/user_rpc.test.ts
+++ b/packages/frontend/src/api/user_rpc.test.ts
@@ -5,7 +5,7 @@ import { v4 } from "uuid";
 import { assert, afterAll, describe, test } from "vitest";
 
 import type { UserProfile } from "catcolab-api";
-import { initTestUserAuth } from "../util/test_util.ts";
+import { createTestDocument, initTestUserAuth } from "../util/test_util.ts";
 import { createRpcClient, unwrap, unwrapErr } from "./rpc.ts";
 
 const serverUrl = import.meta.env.VITE_SERVER_URL;
@@ -113,12 +113,7 @@ describe("Sharing documents between users", async () => {
     unwrap(await rpc.sign_up_or_sign_in.mutate());
 
     // Create the document to be shared.
-    const refId = unwrap(
-        await rpc.new_ref.mutate({
-            type: "model",
-            name: "My shared model",
-        }),
-    );
+    const refId = unwrap(await rpc.new_ref.mutate(createTestDocument("My shared model")));
 
     // Share the document with read-only permissions.
     unwrap(

--- a/packages/frontend/src/util/test_util.ts
+++ b/packages/frontend/src/util/test_util.ts
@@ -1,3 +1,5 @@
+import type { JsonValue } from "catcolab-api";
+import type { Document } from "catlog-wasm";
 import { FirebaseError } from "firebase/app";
 import {
     type Auth,
@@ -16,4 +18,17 @@ export async function initTestUserAuth(auth: Auth, email: string, password: stri
             throw err;
         }
     }
+}
+
+/** Creates a valid test document with the given name. */
+export function createTestDocument(name: string): JsonValue {
+    const doc: Document = {
+        type: "model",
+        name,
+        theory: "empty",
+        notebook: { cellOrder: [], cellContents: {} },
+        version: "1",
+    };
+
+    return doc as unknown as JsonValue;
 }


### PR DESCRIPTION
The frontend tests were failing because they were creating outdated documents:
```
{
    type: "model"
    name: "name"
}
```

These invalid models were still getting added to automerge, and were failing to parse during the migration that occurs when we attempt to connect to a ref. The errors logged by `automerge-doc-server` were not very useful and similar to the errors recently seen on the `catcolab-next`.

Changes:
- Validate document contents in `new_ref`
- Validate document contents `createDoc`
- Improve handling of uncaught error in `automerge-doc-server`
- Update tests to use the new `Document` type

Since we did not have these guards previously, it is likely that `catcolab-next` has invalid documents, production might as well. This could explain the errors seen on `catcolab-next`. I will investigate this further.

Note:
I was running into some difficulty with the different sources for our generated typescript types:
- `ts_rs` for `backend`
- `tsify` for `frontend`

In rust I can't write:
```
async fn new_ref(ctx: AppCtx, document: VersionedDocument)
```
since the `TS` trait from `ts_rs` is not implement on `VersionedDocument`. 

We could implement `TS` on everything that currently implements `Tsify`, but that would still generate types in two different places and they are not guaranteed to be the same (though I see no reason why they wouldn't be).

This is only an issue for some rpc endpoints that deal with more complicated types. Given that, the surface area for this problem is quite small, so living with it could be less painful than a fix, especially since I see no obvious fix.