### PR TITLE
Fix `notebook-types` package missing from `backend` Nix package

### DIFF
--- a/packages/backend/default.nix
+++ b/packages/backend/default.nix
@@ -31,6 +31,7 @@ craneLib.buildPackage {
       ../../Cargo.toml
       ../../Cargo.lock
       (craneLib.fileset.commonCargoSources ./.)
+      (craneLib.fileset.commonCargoSources ../notebook-types)
       ./.sqlx
     ];
   };


### PR DESCRIPTION
https://github.com/ToposInstitute/CatColab/pull/765 Added a dependency for `backend` on `notebook-types`, however the nix  package `backend` did not have access to the `notebook-types` package.