### PR TITLE
Move Nix build job for `catcolab-next` to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,3 +129,26 @@ jobs:
       - name: Format/linting/import sorting
         run: |
           pnpm --filter "./packages/*" run ci
+
+  build_nixos_system:
+    name: build NixOS system
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    
+    - name: Install Nix
+      uses: cachix/install-nix-action@v25
+      with:
+        nix_path: nixpkgs=channel:25.05
+
+    - name: Configure Cachix
+      uses: cachix/cachix-action@v14
+      with:
+        name: catcolab-jmoggr
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+    - name: Build the NixOS system for catcolab-next
+      run: nix build .#nixosConfigurations.catcolab-next.config.system.build.toplevel
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -232,9 +232,6 @@ jobs:
         name: catcolab-jmoggr
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-    - name: Build the NixOS system for catcolab-next
-      run: nix build .#nixosConfigurations.catcolab-next.config.system.build.toplevel
-
     - name: Set the SSH key for deployment to catcolab-next
       run: |
         mkdir -p ~/.ssh


### PR DESCRIPTION
This should help catch nix build errors during CI instead of deployment.

I tested the deploy step as well.
