### PR TITLE
Allow adding proarrow composites in modal theories

### DIFF
--- a/packages/catlog/src/dbl/computad.rs
+++ b/packages/catlog/src/dbl/computad.rs
@@ -55,7 +55,7 @@ where
 /// We say "augmented" because the generating squares have co-arity zero or one,
 /// like the cells in an *augmented VDC* ([Koudenburg
 /// 2020](crate::refs::AugmentedVDCs)), though we use such computads to generate
-/// unital* VDCs.
+/// *unital* VDCs.
 #[derive(Constructor)]
 pub struct AVDCComputad<'a, Ob, Arr, Pro, ObSet, ArrGraph, ProGraph, Sq> {
     objects: &'a ObSet,

--- a/packages/catlog/src/dbl/theory.rs
+++ b/packages/catlog/src/dbl/theory.rs
@@ -266,7 +266,7 @@ impl<VDC: VDCWithComposites> DblTheory for VDC {
 }
 
 /// A failure of a double theory to be well defined.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum InvalidDblTheory {
     /// Morphism type with an invalid source type.
     SrcType(QualifiedName),


### PR DESCRIPTION
Spun out from #783.

Note that the composites are only stored and validated. They cannot yet be used.