### PR TITLE
Classes for maps with object/morphism types as keys

### DIFF
--- a/packages/catlog-wasm/src/theory.rs
+++ b/packages/catlog-wasm/src/theory.rs
@@ -352,6 +352,12 @@ impl ObTypeIndex {
         Default::default()
     }
 
+    /// Returns whether the object type is set.
+    #[wasm_bindgen(js_name = "has")]
+    pub fn contains_key(&self, x: &ObType) -> bool {
+        self.0.contains_key(x)
+    }
+
     /// Gets the index of an object type, if set.
     #[wasm_bindgen]
     pub fn get(&self, x: &ObType) -> Option<usize> {
@@ -359,8 +365,8 @@ impl ObTypeIndex {
     }
 
     /// Sets the index of an object type.
-    #[wasm_bindgen]
-    pub fn set(&mut self, x: ObType, i: usize) {
+    #[wasm_bindgen(js_name = "set")]
+    pub fn insert(&mut self, x: ObType, i: usize) {
         self.0.insert(x, i);
     }
 }
@@ -381,6 +387,12 @@ impl MorTypeIndex {
         Default::default()
     }
 
+    /// Returns whether the morphism type is set.
+    #[wasm_bindgen(js_name = "has")]
+    pub fn contains_key(&self, m: &MorType) -> bool {
+        self.0.contains_key(m)
+    }
+
     /// Gets the index of a morphism type, if set.
     #[wasm_bindgen]
     pub fn get(&self, m: &MorType) -> Option<usize> {
@@ -388,8 +400,8 @@ impl MorTypeIndex {
     }
 
     /// Sets the index of a morphism type.
-    #[wasm_bindgen]
-    pub fn set(&mut self, m: MorType, i: usize) {
+    #[wasm_bindgen(js_name = "set")]
+    pub fn insert(&mut self, m: MorType, i: usize) {
         self.0.insert(m, i);
     }
 }

--- a/packages/frontend/src/theory/index.ts
+++ b/packages/frontend/src/theory/index.ts
@@ -1,3 +1,4 @@
 export * from "./context";
 export * from "./theory";
 export * from "./theory_library";
+export * from "./types";

--- a/packages/frontend/src/theory/theory.ts
+++ b/packages/frontend/src/theory/theory.ts
@@ -1,9 +1,10 @@
 import type { DblModel, DblTheory, MorType, ObOp, ObType } from "catlog-wasm";
-import { MorTypeIndex, ObTypeIndex } from "catlog-wasm";
+
 import type { DiagramAnalysisComponent, ModelAnalysisComponent } from "../analysis";
 import { uniqueIndexArray } from "../util/indexing";
 import type { KbdKey } from "../util/keyboard";
 import type { ArrowStyle } from "../visualization";
+import { MorTypeMap, ObTypeMap } from "./types";
 
 /** A double theory configured for the frontend.
 
@@ -33,14 +34,11 @@ export class Theory {
      */
     readonly description: string;
 
-    /** List of IDs of theories that this theory includes into.
+    /** Metadata for object and morphism types in the theory, as used in models.
 
-    Migrations along such inclusions are trivial.
+    In a model editor, the types are listed in this order.
      */
-    readonly inclusions: string[];
-
-    /** List of pushforward (covariant) migrations out of this theory. */
-    readonly pushforwards: ModelMigration[];
+    readonly modelTypes: ModelTypeMeta[];
 
     /** Whether models of the double theory are constrained to be free. */
     readonly onlyFreeModels!: boolean;
@@ -51,8 +49,26 @@ export class Theory {
      */
     readonly instanceOfName: string;
 
-    private readonly modelTypeMeta: TypeMetadata<ModelObTypeMeta, ModelMorTypeMeta>;
-    private readonly instanceTypeMeta: TypeMetadata<InstanceObTypeMeta, InstanceMorTypeMeta>;
+    /** Metadata for types in the theory, as used in instances of models.
+
+    In an instance editor, the types are listed in this order. If the list is
+    empty, then instances will not be supported for models of this theory.
+     */
+    readonly instanceTypes: InstanceTypeMeta[];
+
+    /** List of IDs of theories that this theory includes into.
+
+    Migrations along such inclusions are trivial.
+     */
+    readonly inclusions: string[];
+
+    /** List of pushforward (covariant) migrations out of this theory. */
+    readonly pushforwards: ModelMigration[];
+
+    private readonly modelObTypeMap: ObTypeMap<ModelObTypeMeta>;
+    private readonly modelMorTypeMap: MorTypeMap<ModelMorTypeMeta>;
+    private readonly instanceObTypeMap: ObTypeMap<InstanceObTypeMeta>;
+    private readonly instanceMorTypeMap: MorTypeMap<InstanceMorTypeMeta>;
 
     /** Map from IDs of model analyses to their metadata. */
     private readonly modelAnalysisMap: Map<string, ModelAnalysisMeta>;
@@ -87,15 +103,33 @@ export class Theory {
         // Models.
         this.name = props.name;
         this.description = props.description;
-        this.modelTypeMeta = new TypeMetadata<ModelObTypeMeta, ModelMorTypeMeta>(props.modelTypes);
+        this.modelTypes = props.modelTypes ?? [];
+        [this.modelObTypeMap, this.modelMorTypeMap] = [new ObTypeMap(), new MorTypeMap()];
+        for (const meta of this.modelTypes) {
+            if (meta.tag === "ObType") {
+                this.modelObTypeMap.set(meta.obType, meta);
+            } else if (meta.tag === "MorType") {
+                this.modelMorTypeMap.set(meta.morType, meta);
+            } else {
+                throw new Error(`Invalid discriminator for model-level type metadata: ${meta}`);
+            }
+        }
         this.modelAnalysisMap = uniqueIndexArray(props.modelAnalyses ?? [], (meta) => meta.id);
         this.onlyFreeModels = props.onlyFreeModels ?? false;
 
         // Instances.
         this.instanceOfName = props.instanceOfName ?? "Instance of";
-        this.instanceTypeMeta = new TypeMetadata<InstanceObTypeMeta, InstanceMorTypeMeta>(
-            props.instanceTypes,
-        );
+        this.instanceTypes = props.instanceTypes ?? [];
+        [this.instanceObTypeMap, this.instanceMorTypeMap] = [new ObTypeMap(), new MorTypeMap()];
+        for (const meta of this.instanceTypes) {
+            if (meta.tag === "ObType") {
+                this.instanceObTypeMap.set(meta.obType, meta);
+            } else if (meta.tag === "MorType") {
+                this.instanceMorTypeMap.set(meta.morType, meta);
+            } else {
+                throw new Error(`Invalid discriminator for instance-level type metadata: ${meta}`);
+            }
+        }
         this.diagramAnalysisMap = uniqueIndexArray(props.diagramAnalyses ?? [], (meta) => meta.id);
     }
 
@@ -104,22 +138,14 @@ export class Theory {
         return this.inclusions.concat(this.pushforwards.map((m) => m.target));
     }
 
-    /** Metadata for types in the theory, as used in models.
-
-    In a model editor, the types are listed in this order.
-     */
-    get modelTypes(): Array<ModelTypeMeta> {
-        return this.modelTypeMeta.types;
-    }
-
     /** Get metadata for an object type as used in models. */
     modelObTypeMeta(typ: ObType): ModelObTypeMeta | undefined {
-        return this.modelTypeMeta.obTypeMeta(typ);
+        return this.modelObTypeMap.get(typ);
     }
 
     /** Get metadata for a morphism type as used in models. */
     modelMorTypeMeta(typ: MorType): ModelMorTypeMeta | undefined {
-        return this.modelTypeMeta.morTypeMeta(typ);
+        return this.modelMorTypeMap.get(typ);
     }
 
     /** Is the theory configured to support instances of its model? */
@@ -127,23 +153,14 @@ export class Theory {
         return this.instanceTypes.length > 0;
     }
 
-    /** Metadata for types in the theory, as used in instances of models.
-
-    In an instance editor, the types are listed in this order. If the list is
-    empty, then instances will not be supported for models of this theory.
-     */
-    get instanceTypes(): Array<InstanceTypeMeta> {
-        return this.instanceTypeMeta.types;
-    }
-
     /** Get metadata for an object type as used in instances. */
     instanceObTypeMeta(typ: ObType): InstanceObTypeMeta | undefined {
-        return this.instanceTypeMeta.obTypeMeta(typ);
+        return this.instanceObTypeMap.get(typ);
     }
 
     /** Get metadata for a morphism type as used in instances. */
     instanceMorTypeMeta(typ: MorType): InstanceMorTypeMeta | undefined {
-        return this.instanceTypeMeta.morTypeMeta(typ);
+        return this.instanceMorTypeMap.get(typ);
     }
 
     /** List of analyses defined for models. */
@@ -164,41 +181,6 @@ export class Theory {
     /** Get metadata for a diagram analysis. */
     diagramAnalysis(id: string): DiagramAnalysisMeta | undefined {
         return this.diagramAnalysisMap.get(id);
-    }
-}
-
-/** Helper class to index and lookup metadata for object and morphism types. */
-class TypeMetadata<ObMeta extends HasObTypeMeta, MorMeta extends HasMorTypeMeta> {
-    readonly types: Array<ObMeta | MorMeta>;
-
-    private readonly obTypeIndex: ObTypeIndex;
-    private readonly morTypeIndex: MorTypeIndex;
-
-    constructor(types?: Array<ObMeta | MorMeta>) {
-        this.types = [];
-        this.obTypeIndex = new ObTypeIndex();
-        this.morTypeIndex = new MorTypeIndex();
-        types?.forEach(this.bindMeta, this);
-    }
-
-    private bindMeta(meta: ObMeta | MorMeta) {
-        const index = this.types.length;
-        if (meta.tag === "ObType") {
-            this.obTypeIndex.set(meta.obType, index);
-        } else if (meta.tag === "MorType") {
-            this.morTypeIndex.set(meta.morType, index);
-        }
-        this.types.push(meta);
-    }
-
-    obTypeMeta(typ: ObType): ObMeta | undefined {
-        const i = this.obTypeIndex.get(typ);
-        return i !== undefined ? (this.types[i] as ObMeta) : undefined;
-    }
-
-    morTypeMeta(typ: MorType): MorMeta | undefined {
-        const i = this.morTypeIndex.get(typ);
-        return i !== undefined ? (this.types[i] as MorMeta) : undefined;
     }
 }
 
@@ -223,31 +205,22 @@ export type BaseTypeMeta = {
     textClasses?: string[];
 };
 
-type HasObTypeMeta = {
-    tag: "ObType";
+/** Metadata for a type as used in models. */
+export type ModelTypeMeta =
+    | ({ tag: "ObType" } & ModelObTypeMeta)
+    | ({ tag: "MorType" } & ModelMorTypeMeta);
 
+/** Metadata for an object type as used in models. */
+export type ModelObTypeMeta = BaseTypeMeta & {
     /** Object type in the underlying double theory. */
     obType: ObType;
 };
 
-type HasMorTypeMeta = {
-    tag: "MorType";
-
+/** Metadata for a morphism type as used in models. */
+export type ModelMorTypeMeta = BaseTypeMeta & {
     /** Morphism type in the underlying double theory. */
     morType: MorType;
-};
 
-type BaseObTypeMeta = BaseTypeMeta & HasObTypeMeta;
-type BaseMorTypeMeta = BaseTypeMeta & HasMorTypeMeta;
-
-/** Metadata for a type as used in models. */
-export type ModelTypeMeta = ModelObTypeMeta | ModelMorTypeMeta;
-
-/** Metadata for an object type as used in models. */
-export type ModelObTypeMeta = BaseObTypeMeta;
-
-/** Metadata for a morphism type as used in models. */
-export type ModelMorTypeMeta = BaseMorTypeMeta & {
     /** Style of arrow to use for morphisms of this type. */
     arrowStyle?: ArrowStyle;
 
@@ -272,13 +245,21 @@ export type MorDomainMeta = {
 };
 
 /** Metadata for a type as used in instances of a model. */
-export type InstanceTypeMeta = InstanceObTypeMeta | InstanceMorTypeMeta;
+export type InstanceTypeMeta =
+    | ({ tag: "ObType" } & InstanceObTypeMeta)
+    | ({ tag: "MorType" } & InstanceMorTypeMeta);
 
 /** Metadata for an object type as used in instances. */
-export type InstanceObTypeMeta = BaseObTypeMeta;
+export type InstanceObTypeMeta = BaseTypeMeta & {
+    /** Object type in the underlying double theory. */
+    obType: ObType;
+};
 
 /** Metadata for a morphism type as used in instances. */
-export type InstanceMorTypeMeta = BaseMorTypeMeta;
+export type InstanceMorTypeMeta = BaseTypeMeta & {
+    /** Morphism type in the underlying double theory. */
+    morType: MorType;
+};
 
 /** Specifies a migration of models from one theory into another. */
 type ModelMigration = {

--- a/packages/frontend/src/theory/types.ts
+++ b/packages/frontend/src/theory/types.ts
@@ -1,0 +1,53 @@
+import { type MorType, MorTypeIndex, type ObType, ObTypeIndex } from "catlog-wasm";
+
+/** Map with object types as keys. */
+export class ObTypeMap<V> {
+    private readonly index: ObTypeIndex;
+    private readonly values: Array<V>;
+
+    constructor() {
+        this.index = new ObTypeIndex();
+        this.values = [];
+    }
+
+    get(obType: ObType): V | undefined {
+        const i = this.index.get(obType);
+        if (i !== undefined) {
+            return this.values[i];
+        }
+    }
+
+    set(obType: ObType, value: V) {
+        if (this.index.has(obType)) {
+            throw new Error(`Object type is already set: ${obType}`);
+        }
+        this.index.set(obType, this.values.length);
+        this.values.push(value);
+    }
+}
+
+/** Map with morphism types as keys. */
+export class MorTypeMap<V> {
+    private readonly index: MorTypeIndex;
+    private readonly values: Array<V>;
+
+    constructor() {
+        this.index = new MorTypeIndex();
+        this.values = [];
+    }
+
+    get(morType: MorType): V | undefined {
+        const i = this.index.get(morType);
+        if (i !== undefined) {
+            return this.values[i];
+        }
+    }
+
+    set(morType: MorType, value: V) {
+        if (this.index.has(morType)) {
+            throw new Error(`Morphism type is already set: ${morType}`);
+        }
+        this.index.set(morType, this.values.length);
+        this.values.push(value);
+    }
+}


### PR DESCRIPTION
A small refactor that replaces the `(Theory)TypeMeta` helper class in the frontend with two new helper classes of more definite scope.