### PR TITLE
Move `ModelLibrary` to app-level context

### DIFF
--- a/packages/frontend/src/model/context.ts
+++ b/packages/frontend/src/model/context.ts
@@ -1,6 +1,10 @@
 import { type Accessor, createContext } from "solid-js";
 
 import type { LiveModelDocument } from "./document";
+import type { ModelLibrary } from "./model_library";
 
-/** Context for a live model. */
+/** Context for a library of models. */
+export const ModelLibraryContext = createContext<ModelLibrary<string>>();
+
+/** Context for the active live model. */
 export const LiveModelContext = createContext<Accessor<LiveModelDocument>>();

--- a/packages/patchwork/package.json
+++ b/packages/patchwork/package.json
@@ -21,6 +21,7 @@
         "@automerge/automerge-repo": "^2.2.0",
         "@automerge/automerge-repo-react-hooks": "^2.2.0",
         "@patchwork/sdk": "link:../../../patchwork/sdk",
+        "@solid-primitives/context": "^0.3.1",
         "catlog-wasm": "link:../catlog-wasm/dist/pkg-browser",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/packages/patchwork/pnpm-lock.yaml
+++ b/packages/patchwork/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@patchwork/sdk':
         specifier: link:../../../patchwork/sdk
         version: link:../../../patchwork/sdk
+      '@solid-primitives/context':
+        specifier: ^0.3.1
+        version: 0.3.2(solid-js@1.9.9)
       catlog-wasm:
         specifier: link:../catlog-wasm/dist/pkg-browser
         version: link:../catlog-wasm/dist/pkg-browser
@@ -530,6 +533,11 @@ packages:
     resolution: {integrity: sha512-rUrqINax0TvrPBXrFKg0YbQx18NpPN3NNrgmaao9xRNbTwek7lOXObhx8tQy8gelmQ/gLaGy1WptpU2eKJZImg==}
     cpu: [x64]
     os: [win32]
+
+  '@solid-primitives/context@0.3.2':
+    resolution: {integrity: sha512-6fvTtpK17PFHnUf/UOc1TzBjd+kLFjtA62aRFEm1kDP9ufTo7FYW2kUzQAWbfbRHi30yjBJtopbR8qd6nShwyg==}
+    peerDependencies:
+      solid-js: ^1.6.12
 
   '@swc/core-darwin-arm64@1.10.14':
     resolution: {integrity: sha512-Dh4VyrhDDb05tdRmqJ/MucOPMTnrB4pRJol18HVyLlqu1HOT5EzonUniNTCdQbUXjgdv5UVJSTE1lYTzrp+myA==}
@@ -1478,6 +1486,10 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.34.2':
     optional: true
+
+  '@solid-primitives/context@0.3.2(solid-js@1.9.9)':
+    dependencies:
+      solid-js: 1.9.9
 
   '@swc/core-darwin-arm64@1.10.14':
     optional: true

--- a/packages/patchwork/src/analysis_pane.tsx
+++ b/packages/patchwork/src/analysis_pane.tsx
@@ -1,9 +1,10 @@
 import type { AutomergeUrl } from "@automerge/automerge-repo";
+import { MultiProvider } from "@solid-primitives/context";
 import { createResource, Switch, Match } from "solid-js";
 
 import { getLiveAnalysisFromRepo } from "../../frontend/src/analysis";
 import { AnalysisNotebookEditor } from "../../frontend/src/analysis/analysis_editor";
-import { createModelLibraryWithRepo } from "../../frontend/src/model";
+import { createModelLibraryWithRepo, ModelLibraryContext } from "../../frontend/src/model";
 import { TheoryLibraryContext } from "../../frontend/src/theory";
 import { stdTheories } from "../../frontend/src/stdlib";
 import type { SolidToolProps } from "./tools";
@@ -17,7 +18,12 @@ export function AnalysisPaneComponent(props: SolidToolProps) {
     );
 
     return (
-        <div>
+        <MultiProvider
+            values={[
+                [TheoryLibraryContext, stdTheories],
+                [ModelLibraryContext, models],
+            ]}
+        >
             <Switch>
                 <Match when={liveAnalysis.loading}>
                     <div>⏳ Loading analysis...</div>
@@ -28,13 +34,9 @@ export function AnalysisPaneComponent(props: SolidToolProps) {
                     </div>
                 </Match>
                 <Match when={liveAnalysis()}>
-                    {(liveAnalysis) => (
-                        <TheoryLibraryContext.Provider value={stdTheories}>
-                            <AnalysisNotebookEditor liveAnalysis={liveAnalysis()} />
-                        </TheoryLibraryContext.Provider>
-                    )}
+                    {(liveAnalysis) => <AnalysisNotebookEditor liveAnalysis={liveAnalysis()} />}
                 </Match>
             </Switch>
-        </div>
+        </MultiProvider>
     );
 }

--- a/packages/patchwork/src/model_pane.tsx
+++ b/packages/patchwork/src/model_pane.tsx
@@ -1,7 +1,8 @@
 import type { AnyDocumentId } from "@automerge/automerge-repo";
+import { MultiProvider } from "@solid-primitives/context";
 import { createResource, Switch, Match } from "solid-js";
 
-import { createModelLibraryWithRepo } from "../../frontend/src/model";
+import { createModelLibraryWithRepo, ModelLibraryContext } from "../../frontend/src/model";
 import { DocumentPane } from "../../frontend/src/page/document_page";
 import { TheoryLibraryContext } from "../../frontend/src/theory";
 import { stdTheories } from "../../frontend/src/stdlib";
@@ -25,7 +26,12 @@ export function ModelPaneComponent(props: SolidToolProps) {
     );
 
     return (
-        <div>
+        <MultiProvider
+            values={[
+                [TheoryLibraryContext, stdTheories],
+                [ModelLibraryContext, models],
+            ]}
+        >
             <Switch>
                 <Match when={liveModel.loading}>
                     <div>⏳ Loading model...</div>
@@ -34,13 +40,9 @@ export function ModelPaneComponent(props: SolidToolProps) {
                     <div>❌ Error loading model: {liveModel.error?.message || "Unknown error"}</div>
                 </Match>
                 <Match when={liveModel()}>
-                    {(liveModel) => (
-                        <TheoryLibraryContext.Provider value={stdTheories}>
-                            <DocumentPane document={liveModel()} />
-                        </TheoryLibraryContext.Provider>
-                    )}
+                    {(liveModel) => <DocumentPane document={liveModel()} />}
                 </Match>
             </Switch>
-        </div>
+        </MultiProvider>
     );
 }


### PR DESCRIPTION
A refactor extracted from #748 to address the merge conflict with #749 now rather than later.