### PR TITLE
FIX: Use document type instead of hardcoded 'model' in menu text

### DIFF
--- a/packages/frontend/src/page/menubar.tsx
+++ b/packages/frontend/src/page/menubar.tsx
@@ -127,7 +127,7 @@ export function DuplicateMenuItem(props: {
     return (
         <MenuItem onSelect={onDuplicate}>
             <Copy />
-            <MenuItemLabel>{"Duplicate model"}</MenuItemLabel>
+            <MenuItemLabel>{`Duplicate ${props.doc.type}`}</MenuItemLabel>
         </MenuItem>
     );
 }


### PR DESCRIPTION
closes #791 