### PR TITLE
Click an already open doc in the sidebar to maximize that doc

### DIFF
--- a/packages/frontend/src/page/document_page.tsx
+++ b/packages/frontend/src/page/document_page.tsx
@@ -103,7 +103,12 @@ export default function DocumentPage() {
                             closeSidePanel={closeSidePanel}
                         />
                     }
-                    sidebarContents={<DocumentSidebar liveDoc={liveDocument().liveDoc} />}
+                    sidebarContents={
+                        <DocumentSidebar
+                            primaryLiveDoc={liveDocument().liveDoc}
+                            secondaryLiveDoc={secondaryLiveDocument()?.liveDoc}
+                        />
+                    }
                 >
                     <Resizable class="growable-container">
                         {() => {


### PR DESCRIPTION
PR #797 implicitly adds some new behavior: if two documents are open in panels and you click on the primary document, then the primary document becomes maximized. However when the secondary document is clicked in the sidebar, nothing happens.

This change unifies the behavior, clicking on the primary or secondary document in the sidebar will always maximize that document.