### PR TITLE
Allow document panels to scroll independently of each other

### DIFF
--- a/packages/frontend/src/page/document_page.css
+++ b/packages/frontend/src/page/document_page.css
@@ -17,3 +17,12 @@
         color: var(--link-color);
     }
 }
+
+.resizeable-panels {
+    flex: 1;
+    overflow-y: hidden;
+
+    & > .content-panel {
+        overflow-y: auto;
+    }
+}

--- a/packages/frontend/src/page/document_page.tsx
+++ b/packages/frontend/src/page/document_page.tsx
@@ -93,7 +93,7 @@ export default function DocumentPage() {
                     }
                     sidebarContents={<DocumentSidebar liveDoc={liveDocument().liveDoc} />}
                 >
-                    <Resizable class="growable-container">
+                    <Resizable class="resizeable-panels">
                         {() => {
                             const context = Resizable.useContext();
                             setResizableContext(context);

--- a/packages/frontend/src/page/sidebar_layout.css
+++ b/packages/frontend/src/page/sidebar_layout.css
@@ -7,7 +7,7 @@
         display: flex;
         flex-direction: column;
         flex: 1;
-        overflow-x: hidden;
+        overflow: hidden;
 
         & > header {
             flex-shrink: 0;
@@ -17,6 +17,7 @@
             flex: 1;
             display: flex;
             flex-direction: column;
+            overflow: hidden;
         }
     }
 }


### PR DESCRIPTION
Previously both panels would scroll together if one of them became taller than the page.