### PR TITLE
Increase vertical real estate at end of notebook

### DIFF
--- a/packages/frontend/src/page/document_page.css
+++ b/packages/frontend/src/page/document_page.css
@@ -41,5 +41,9 @@
 
     & > .content-panel {
         overflow-y: auto;
+
+        & > .notebook-container {
+            padding-bottom: 30vh;
+        }
     }
 }


### PR DESCRIPTION
Closes #720

This adds 30% of the screen height as padding to the bottom of a notebook in the documents page. When playing around with it 50% felt like too much. But that's just like, my opinion, man.