### PR TITLE
Prevent notebook cells shifting when focussing a rich text editor cell

### DIFF
--- a/packages/frontend/src/components/rich_text_editor/link_editor.tsx
+++ b/packages/frontend/src/components/rich_text_editor/link_editor.tsx
@@ -116,7 +116,7 @@ function getLinkCoords(
 
     const editorRect = view.dom.getBoundingClientRect();
 
-    // XXX: I'm don't fully understand this math works, it doesn't make sense to add linkRect.height
+    // XXX: I don't understand why the bottom math works, it doesn't make sense to add linkRect.height
     const bottom = linkRect.bottom + linkRect.height - editorRect.top + window.scrollY;
     const left = linkRect.left - editorRect.left + window.scrollX;
 

--- a/packages/frontend/src/components/rich_text_editor/rich_text_editor.css
+++ b/packages/frontend/src/components/rich_text_editor/rich_text_editor.css
@@ -74,7 +74,7 @@
     z-index: 1;
 
     & button {
-        padding: 0;    
+        padding: 0;
         margin: 3px;
         box-sizing: border-box;
         border-radius: 5px;

--- a/packages/frontend/src/components/rich_text_editor/rich_text_editor.tsx
+++ b/packages/frontend/src/components/rich_text_editor/rich_text_editor.tsx
@@ -201,18 +201,10 @@ export const RichTextEditor = (
                 },
                 focusout: (view, event) => {
                     const relatedTarget = event.relatedTarget as Node | null;
-                    // Ignore focus shifts into the menu bar
-                    if (relatedTarget && menuRoot.contains(relatedTarget)) {
-                        // prevent the editor from losing focus and clearing the selection.
-                        view.focus();
-                        return true;
-                    }
-
-                    // Ignore focus shifts into the reopen button
+                    // Ignore focus shifts into the menu bar and reopen button
                     if (
-                        relatedTarget &&
-                        reopenButtonRoot &&
-                        reopenButtonRoot.contains(relatedTarget)
+                        (relatedTarget && menuRoot.contains(relatedTarget)) ||
+                        (relatedTarget && reopenButtonRoot.contains(relatedTarget))
                     ) {
                         // prevent the editor from losing focus and clearing the selection.
                         view.focus();


### PR DESCRIPTION
Previously on focus a notebook cell containing a rich text editor would resize to display the menubar and border, which would cause many UI elements to jump slightly.

This change prevents the resizing, but causes the menubar to possibly overlap other cells. To help ameliorate the possible problem of a menubar obscuring an element that a user wants to interact with, a button to manually hide the menubar (and defocus the RTE cell) was added.

I think the annoyance of sometimes having the menubar overlap things is less than the annoyance of the UI always jumping slightly.