### PR TITLE
Configure Vite to enable linking packages that use Solid

### DIFF
--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -22,6 +22,11 @@ export default defineConfig({
         sourcemap: true,
         target: "es2022",
     },
+    resolve: {
+        // Needed to link other packages that use Solid.js:
+        // https://github.com/solidjs/solid/issues/1472
+        dedupe: ["solid-js", "solid-js/web"],
+    },
     server: {
         proxy: {
             "/api": {


### PR DESCRIPTION
Should fix #829 and a host of other bizarre reactivity issues we've been having since #808.