### PR TITLE
Don't show "Loading" text in sidebar document list

### DIFF
--- a/packages/frontend/src/page/document_page_sidebar.tsx
+++ b/packages/frontend/src/page/document_page_sidebar.tsx
@@ -57,7 +57,7 @@ function RelatedDocuments(props: {
     );
 
     return (
-        <Show when={liveDocRoot()} fallback={<div>Loading related items...</div>}>
+        <Show when={liveDocRoot()}>
             {(liveDocRoot) => (
                 <div class="related-tree">
                     <DocumentsTreeNode
@@ -107,20 +107,16 @@ function DocumentsTreeNode(props: {
                 secondaryLiveDoc={props.secondaryLiveDoc}
                 triggerRefresh={refetch}
             />
-            <Show when={childDocs()} fallback={<div>Loading children...</div>}>
-                {(childDocs) => (
-                    <For each={childDocs()}>
-                        {(child) => (
-                            <DocumentsTreeNode
-                                liveDoc={child}
-                                indent={props.indent + 1}
-                                primaryLiveDoc={props.primaryLiveDoc}
-                                secondaryLiveDoc={props.secondaryLiveDoc}
-                            />
-                        )}
-                    </For>
+            <For each={childDocs()}>
+                {(child) => (
+                    <DocumentsTreeNode
+                        liveDoc={child}
+                        indent={props.indent + 1}
+                        primaryLiveDoc={props.primaryLiveDoc}
+                        secondaryLiveDoc={props.secondaryLiveDoc}
+                    />
                 )}
-            </Show>
+            </For>
         </>
     );
 }


### PR DESCRIPTION
I find it distracting to have this text briefly appear and disappear.

I'd be open to a more subtle loading effect but for the moment I'm just going to remove the indicators completely.