### PR TITLE
Ensure stable order of preimages in unindexed hash columns

### DIFF
--- a/packages/catlog/src/dbl/discrete/model_morphism.rs
+++ b/packages/catlog/src/dbl/discrete/model_morphism.rs
@@ -1,6 +1,6 @@
 //! Morphisms between models of a discrete double theory.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::rc::Rc;
 
 use nonempty::NonEmpty;
@@ -26,10 +26,13 @@ type DiscreteDblModelMappingData = FpFunctorData<
 impl DiscreteDblModelMapping {
     /// Constructs a model mapping from a pair of hash maps.
     pub fn new(
-        ob_map: HashMap<QualifiedName, QualifiedName>,
-        mor_map: HashMap<QualifiedName, QualifiedPath>,
+        ob_pairs: impl IntoIterator<Item = (QualifiedName, QualifiedName)>,
+        mor_pairs: impl IntoIterator<Item = (QualifiedName, QualifiedPath)>,
     ) -> Self {
-        Self(FpFunctorData::new(HashColumn::new(ob_map), HashColumn::new(mor_map)))
+        Self(FpFunctorData::new(
+            ob_pairs.into_iter().collect(),
+            mor_pairs.into_iter().collect(),
+        ))
     }
 
     /// Assigns an object generator, returning the previous assignment.
@@ -476,8 +479,8 @@ mod tests {
         let posfeed = positive_feedback(theory.clone());
 
         let f = DiscreteDblModelMapping::new(
-            [(name("x"), name("x"))].into(),
-            [(name(""), Path::Id(name("negative")))].into(),
+            [(name("x"), name("x"))],
+            [(name(""), Path::Id(name("negative")))],
         );
         let dmm = DblModelMorphism(&f, &negloop, &negloop);
         assert!(dmm.validate().is_err());
@@ -486,8 +489,8 @@ mod tests {
         // but sent to something that doesn't exist) and for the hom generator
         // (not in the map)
         let f = DiscreteDblModelMapping::new(
-            [(name("x"), name("y"))].into(),
-            [(name("y"), Path::Id(name("y")))].into(),
+            [(name("x"), name("y"))],
+            [(name("y"), Path::Id(name("y")))],
         );
         let dmm = DblModelMorphism(&f, &negloop, &negloop);
         let errs: Vec<_> = dmm.validate().unwrap_err().into();
@@ -500,8 +503,8 @@ mod tests {
 
         // A bad map that doesn't preserve dom
         let f = DiscreteDblModelMapping::new(
-            [(name("x"), name("x"))].into(),
-            [(name("loop"), Path::single(name("positive1")))].into(),
+            [(name("x"), name("x"))],
+            [(name("loop"), Path::single(name("positive1")))],
         );
         let dmm = DblModelMorphism(&f, &negloop, &posfeed);
         let errs: Vec<_> = dmm.validate().unwrap_err().into();
@@ -514,8 +517,8 @@ mod tests {
 
         // A bad map that doesn't preserve codom
         let f = DiscreteDblModelMapping::new(
-            [(name("x"), name("x"))].into(),
-            [(name("loop"), Path::single(name("positive2")))].into(),
+            [(name("x"), name("x"))],
+            [(name("loop"), Path::single(name("positive2")))],
         );
         let dmm = DblModelMorphism(&f, &negloop, &posfeed);
         let errs: Vec<_> = dmm.validate().unwrap_err().into();
@@ -534,8 +537,8 @@ mod tests {
 
         // Identity map
         let f = DiscreteDblModelMapping::new(
-            [(name("x"), name("x"))].into(),
-            [(name("loop"), Path::single(name("loop")))].into(),
+            [(name("x"), name("x"))],
+            [(name("loop"), Path::single(name("loop")))],
         );
         let dmm = DblModelMorphism(&f, &negloop, &negloop);
         assert!(dmm.validate().is_ok());
@@ -543,8 +546,8 @@ mod tests {
 
         // Send generator to identity
         let f = DiscreteDblModelMapping::new(
-            [(name("x"), name("x"))].into(),
-            [(name("loop"), Path::Id(name("x")))].into(),
+            [(name("x"), name("x"))],
+            [(name("loop"), Path::Id(name("x")))],
         );
         let dmm = DblModelMorphism(&f, &negloop, &negloop);
         assert!(dmm.validate().is_ok());

--- a/packages/catlog/src/one/functor.rs
+++ b/packages/catlog/src/one/functor.rs
@@ -321,15 +321,12 @@ mod tests {
     #[test]
     fn sch_sgraph_to_hgraph() {
         let (sch_hgraph, sch_sgraph) = (sch_hgraph(), sch_sgraph());
-        let ob_map = HashColumn::new([(name("V"), name("V")), (name("E"), name("H"))].into());
-        let mor_map = HashColumn::new(
-            [
-                (name("src"), Path::single(name("vert"))),
-                (name("tgt"), Path::pair(name("inv"), name("vert"))),
-                (name("inv"), Path::single(name("inv"))),
-            ]
-            .into(),
-        );
+        let ob_map = HashColumn::from_iter([(name("V"), name("V")), (name("E"), name("H"))]);
+        let mor_map = HashColumn::from_iter([
+            (name("src"), Path::single(name("vert"))),
+            (name("tgt"), Path::pair(name("inv"), name("vert"))),
+            (name("inv"), Path::single(name("inv"))),
+        ]);
         let data = FpFunctorData::new(ob_map, mor_map);
         let functor = data.functor_into(&sch_hgraph);
         assert_eq!(functor.apply_ob(name("E")), Some(name("H")));
@@ -344,15 +341,12 @@ mod tests {
     #[test]
     fn sch_sgraph_to_graph() {
         let (sch_graph, sch_sgraph) = (sch_graph(), sch_sgraph());
-        let ob_map = HashColumn::new([(name("V"), name("V")), (name("E"), name("E"))].into());
-        let mor_map = HashColumn::new(
-            [
-                (name("src"), Path::single(name("src"))),
-                (name("tgt"), Path::single(name("tgt"))),
-                (name("inv"), Path::empty(name("E"))),
-            ]
-            .into(),
-        );
+        let ob_map = HashColumn::from_iter([(name("V"), name("V")), (name("E"), name("E"))]);
+        let mor_map = HashColumn::from_iter([
+            (name("src"), Path::single(name("src"))),
+            (name("tgt"), Path::single(name("tgt"))),
+            (name("inv"), Path::empty(name("E"))),
+        ]);
         let data = FpFunctorData::new(ob_map, mor_map);
         let functor = data.functor_into(&sch_graph);
         // Two equations fail, namely that `inv` swaps `src` and `tgt`.

--- a/packages/catlog/src/stdlib/theory_morphisms.rs
+++ b/packages/catlog/src/stdlib/theory_morphisms.rs
@@ -16,7 +16,7 @@ type DiscreteDblTheoryMap = FpFunctorData<
 /// schema, yielding a schema with no attributes or attribute types.
 pub fn th_category_to_schema() -> DiscreteDblTheoryMap {
     FpFunctorData::new(
-        HashColumn::new([(name("Object"), name("Entity"))].into()),
+        HashColumn::from_iter([(name("Object"), name("Entity"))]),
         HashColumn::default(),
     )
 }
@@ -27,10 +27,11 @@ pub fn th_category_to_schema() -> DiscreteDblTheoryMap {
 /// attribute types, turning both into objects in a category.
 pub fn th_schema_to_category() -> DiscreteDblTheoryMap {
     FpFunctorData::new(
-        HashColumn::new(
-            [(name("Entity"), name("Object")), (name("AttrType"), name("Object"))].into(),
-        ),
-        HashColumn::new([(name("Attr"), Path::Id(name("Object")))].into()),
+        HashColumn::from_iter([
+            (name("Entity"), name("Object")),
+            (name("AttrType"), name("Object")),
+        ]),
+        HashColumn::from_iter([(name("Attr"), Path::Id(name("Object")))]),
     )
 }
 
@@ -39,17 +40,14 @@ pub fn th_schema_to_category() -> DiscreteDblTheoryMap {
 /// Sigma migration along this map forgets about the delays.
 pub fn th_delayable_signed_category_to_signed_category() -> DiscreteDblTheoryMap {
     FpFunctorData::new(
-        HashColumn::new([(name("Object"), name("Object"))].into()),
-        HashColumn::new(
-            [
-                (name("Negative"), name("Negative").into()),
-                (name("Slow"), Path::Id(name("Object"))),
-                // TODO: Shouldn't have to define on these superfluous generators.
-                (name("PositiveSlow"), Path::Id(name("Object"))),
-                (name("NegativeSlow"), name("Negative").into()),
-            ]
-            .into(),
-        ),
+        HashColumn::from_iter([(name("Object"), name("Object"))]),
+        HashColumn::from_iter([
+            (name("Negative"), name("Negative").into()),
+            (name("Slow"), Path::Id(name("Object"))),
+            // TODO: Shouldn't have to define on these superfluous generators.
+            (name("PositiveSlow"), Path::Id(name("Object"))),
+            (name("NegativeSlow"), name("Negative").into()),
+        ]),
     )
 }
 


### PR DESCRIPTION
Extracted from #830, where this problem was encountered for models of modal theories. For whatever reason, such models currently use unindexed hash columns for the object and morphism type assignments.

Closes #13.