### PR TITLE
Prevent Automerge service hanging while stopping

### DIFF
--- a/packages/automerge-doc-server/src/main.ts
+++ b/packages/automerge-doc-server/src/main.ts
@@ -24,15 +24,13 @@ async function main() {
 
     server.handleChange = (refId, content) => socket_server.autosave(refId, content);
 
-    process.once("SIGINT", () => {
+    const shutdown = () => {
         socket_server.close();
         server.close();
-    });
+    };
 
-    process.once("SIGTERM", () => {
-        socket_server.close();
-        server.close();
-    });
+    process.once("SIGINT", shutdown);
+    process.once("SIGTERM", shutdown);
 }
 
 main();

--- a/packages/automerge-doc-server/src/server.ts
+++ b/packages/automerge-doc-server/src/server.ts
@@ -164,9 +164,9 @@ export class AutomergeServer implements SocketIOHandlers {
         return { Ok: null };
     }
 
-    async close() {
-        this.wss.close();
+    close() {
         this.server.close();
+        this.wss.close();
     }
 
     private async isHeadMatching(refId: string, docId: string): Promise<boolean> {


### PR DESCRIPTION
The websocket connections were keeping the process alive. 