### PR TITLE
Use corvu's tooltip component in `IconButton`

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -20,6 +20,7 @@
         "@corvu/disclosure": "^0.2.2",
         "@corvu/popover": "^0.2.0",
         "@corvu/resizable": "^0.2.5",
+        "@corvu/tooltip": "^0.2.2",
         "@kobalte/core": "^0.13.10",
         "@solid-primitives/active-element": "^2.1.3",
         "@solid-primitives/destructure": "^0.2.1",

--- a/packages/ui-components/pnpm-lock.yaml
+++ b/packages/ui-components/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@corvu/resizable':
         specifier: ^0.2.5
         version: 0.2.5(solid-js@1.9.10)
+      '@corvu/tooltip':
+        specifier: ^0.2.2
+        version: 0.2.2(solid-js@1.9.10)
       '@kobalte/core':
         specifier: ^0.13.10
         version: 0.13.11(solid-js@1.9.10)
@@ -264,6 +267,11 @@ packages:
 
   '@corvu/resizable@0.2.5':
     resolution: {integrity: sha512-psax38DraM9SXtaNh/sfvizGO6xLCL4sqT4rWYlMZP5ZsUM05Q30tvXgnTo2roQFNOz2e06WofhDsBXTjY6g4A==}
+    peerDependencies:
+      solid-js: ^1.8
+
+  '@corvu/tooltip@0.2.2':
+    resolution: {integrity: sha512-gyOBJ43GNAecDtmWc68A5YJvifXWwK0VZZdTOcFbX0rVQUA2ihBMltRE4oj7/lKidg2gXALjmFr71Blt5s3YuQ==}
     peerDependencies:
       solid-js: ^1.8
 
@@ -1837,6 +1845,14 @@ snapshots:
     dependencies:
       '@corvu/utils': 0.4.2(solid-js@1.9.10)
       solid-js: 1.9.10
+
+  '@corvu/tooltip@0.2.2(solid-js@1.9.10)':
+    dependencies:
+      '@corvu/utils': 0.4.2(solid-js@1.9.10)
+      '@floating-ui/dom': 1.7.4
+      solid-dismissible: 0.1.1(solid-js@1.9.10)
+      solid-js: 1.9.10
+      solid-presence: 0.2.0(solid-js@1.9.10)
 
   '@corvu/utils@0.3.2(solid-js@1.9.10)':
     dependencies:

--- a/packages/ui-components/src/icon_button.css
+++ b/packages/ui-components/src/icon_button.css
@@ -9,7 +9,6 @@
     border: none;
     cursor: pointer;
     padding: 0;
-    font-size: 1rem;
 
     &:hover:enabled {
         background: whitesmoke;

--- a/packages/ui-components/src/icon_button.tsx
+++ b/packages/ui-components/src/icon_button.tsx
@@ -1,5 +1,5 @@
-import { Tooltip } from "@kobalte/core/tooltip";
-import { type ComponentProps, type JSX, Show, createSignal, splitProps } from "solid-js";
+import Tooltip from "@corvu/tooltip";
+import { type ComponentProps, type JSX, Show, splitProps } from "solid-js";
 
 import "./icon_button.css";
 
@@ -13,8 +13,6 @@ export function IconButton(
     } & ComponentProps<"button">,
 ) {
     const [props, buttonProps] = splitProps(allProps, ["children", "tooltip", "variant"]);
-
-    const [tooltipOpen, setTooltipOpen] = createSignal(false);
 
     const buttonClass = () => {
         const baseClass = "icon-button";
@@ -37,17 +35,14 @@ export function IconButton(
                 </button>
             }
         >
-            <Tooltip open={tooltipOpen()} onOpenChange={setTooltipOpen} openDelay={1000}>
-                <Tooltip.Trigger class={buttonClass()} {...buttonProps}>
-                    {props.children}
-                </Tooltip.Trigger>
+            <Tooltip hoverableContent={false} openOnFocus={false}>
+                <Tooltip.Anchor>
+                    <Tooltip.Trigger class="icon-button" {...buttonProps}>
+                        {props.children}
+                    </Tooltip.Trigger>
+                </Tooltip.Anchor>
                 <Tooltip.Portal>
-                    <Tooltip.Content
-                        class="tooltip-content"
-                        onMouseEnter={() => setTooltipOpen(false)}
-                    >
-                        {props.tooltip}
-                    </Tooltip.Content>
+                    <Tooltip.Content class="tooltip-content">{props.tooltip}</Tooltip.Content>
                 </Tooltip.Portal>
             </Tooltip>
         </Show>


### PR DESCRIPTION
Extracted from #748 to have a more focused PR. Note that #748 already adds `@corvu/tooltip` for another purpose, so this does not introduce a new dependency relative to that PR.