### PR TITLE
Fail gracefully when attempting to instantiate a non-model document

### DIFF
--- a/packages/frontend/src/analysis/document.ts
+++ b/packages/frontend/src/analysis/document.ts
@@ -124,8 +124,8 @@ export async function getLiveAnalysisFromRepo(
     repo: Repo,
     models: ModelLibrary<AnyDocumentId>,
 ): Promise<LiveAnalysisDoc> {
-    const docHandle = await findAndMigrate<AnalysisDocument>(repo, docId, "analysis");
-    const liveDoc = makeLiveDoc(docHandle);
+    const docHandle = await findAndMigrate(repo, docId);
+    const liveDoc = makeLiveDoc<AnalysisDocument>(docHandle, "analysis");
     const { doc } = liveDoc;
 
     const parentId = doc.analysisOf._id as AnyDocumentId;

--- a/packages/frontend/src/api/types.ts
+++ b/packages/frontend/src/api/types.ts
@@ -65,27 +65,20 @@ export class Api {
         refId: Uuid,
         docType?: Doc["type"],
     ): Promise<LiveDocWithRef<Doc>> {
-        const docHandle = await this.getDocHandle<Doc>(refId, docType);
+        const docHandle = await this.getDocHandle(refId);
         const docRef = await this.getDocRef(refId);
-        const liveDoc = makeLiveDoc(docHandle);
+        const liveDoc = makeLiveDoc<Doc>(docHandle, docType);
         return {
             liveDoc,
             docRef,
         };
     }
 
-    async getLiveDocFromLink<Doc extends Document>(link: Link): Promise<LiveDocWithRef<Doc>> {
-        return this.getLiveDoc(link._id);
-    }
-
     /** Gets an Automerge document handle for the given document ref. */
-    async getDocHandle<Doc extends Document>(
-        refId: Uuid,
-        docType?: Doc["type"],
-    ): Promise<DocHandle<Doc>> {
+    async getDocHandle(refId: Uuid): Promise<DocHandle<Document>> {
         const { docId, localOnly } = await this.getDocCacheEntry(refId);
         const repo = localOnly ? this.localRepo : this.repo;
-        return await findAndMigrate<Doc>(repo, docId, docType);
+        return await findAndMigrate(repo, docId);
     }
 
     /** Get a document reference from its id */

--- a/packages/frontend/src/components/document_picker.tsx
+++ b/packages/frontend/src/components/document_picker.tsx
@@ -65,7 +65,7 @@ export function DocumentPicker(
                         href={`/${liveDocWithRef().liveDoc.doc.type}/${liveDocWithRef().docRef.refId}`}
                         {...linkProps}
                     >
-                        {liveDocWithRef().liveDoc.doc.name}
+                        {liveDocWithRef().liveDoc.doc.name || "Untitled"}
                     </A>
                 )}
             </Match>

--- a/packages/frontend/src/diagram/document.ts
+++ b/packages/frontend/src/diagram/document.ts
@@ -158,8 +158,8 @@ export async function getLiveDiagramFromRepo(
     repo: Repo,
     models: ModelLibrary<AnyDocumentId>,
 ): Promise<LiveDiagramDoc> {
-    const docHandle = await findAndMigrate<DiagramDocument>(repo, docId, "diagram");
-    const liveDoc = makeLiveDoc(docHandle);
+    const docHandle = await findAndMigrate(repo, docId);
+    const liveDoc = makeLiveDoc<DiagramDocument>(docHandle, "diagram");
     const modelDocId = liveDoc.doc.diagramIn._id as AnyDocumentId;
 
     const liveModel = await models.getLiveModel(modelDocId);

--- a/packages/frontend/src/page/document_breadcrumbs.tsx
+++ b/packages/frontend/src/page/document_breadcrumbs.tsx
@@ -22,7 +22,7 @@ export function DocumentBreadcrumbs(props: { liveDoc: LiveDoc; docRefId: string 
                                 class="breadcrumb-link"
                                 href={`/${doc.liveDoc.doc.type}/${doc.docRef.refId}`}
                             >
-                                {doc.liveDoc.doc.name || "untitled"}
+                                {doc.liveDoc.doc.name || "Untitled"}
                             </a>
                         </>
                     )}

--- a/packages/frontend/src/page/document_page_sidebar.tsx
+++ b/packages/frontend/src/page/document_page_sidebar.tsx
@@ -47,7 +47,7 @@ async function getLiveDocRoot(doc: LiveDocWithRef, api: Api): Promise<LiveDocWit
             return doc;
     }
 
-    const parentDoc = await api.getLiveDocFromLink(parentLink);
+    const parentDoc = await api.getLiveDoc(parentLink._id);
     return getLiveDocRoot(parentDoc, api);
 }
 


### PR DESCRIPTION
Fixes #854. This requires deferring the check that the document is a model, which was previously asserted as an invariant early in the document fetching process.