### PR TITLE
Fix extra vertical space for long document titles

### DIFF
--- a/packages/frontend/src/page/document_page.css
+++ b/packages/frontend/src/page/document_page.css
@@ -47,6 +47,10 @@
     & .lucide {
         color: var(--link-color);
     }
+
+    & .inline-input-filler {
+        text-wrap-mode: nowrap;
+    }
 }
 
 .resizeable-panels {


### PR DESCRIPTION
Resolves #818. Even when the text in an InlineInput does not wrap, line break opportunities in the input force the hidden inline-input-filler span to account for wrapping, causing the extra space. The change prevents this from happening in document-head.