### PR TITLE
Fix 'DocHandle is not ready' error on readonly documents

### DIFF
--- a/packages/automerge-doc-server/src/server.ts
+++ b/packages/automerge-doc-server/src/server.ts
@@ -168,6 +168,14 @@ export class AutomergeServer implements SocketIOHandlers {
     }
 
     async exportDoc(docId: string): Promise<ExportDocSocketResponse> {
+        // repo.find ensures that the doc handle is available when repo.export is called below. This
+        // prevents the "DocHandle is not ready" error when exporting read-only documents that were
+        // not previously listened/connected to.
+        const handle = await this.repo.find(docId as DocumentId);
+        if (!handle) {
+            return { Err: `Failed to find doc handle in repo for doc_id '${docId}'` };
+        }
+
         const binaryData = await this.repo.export(docId as DocumentId);
         if (!binaryData) {
             return { Err: `Failed to find document in repo with ID '${docId}'` };


### PR DESCRIPTION
closes #882 

see code comment for explanation of fix.


There was a path dependency issue with automerge repo that we missed: we had never tested viewing a read-only document that we had not previously been connected to.

The chance of us catching this with better testing was quite low, and the automerge-repo docs do not indicate that this could be an issue with `repo.export`. More "correct" support for readonly documents in samod should prevent similar errors in the future (all documents would have the same access pattern, reducing the possibility of path-dependent bugs).