### PR TITLE
Don't show ownerless children under owned document

### DIFF
--- a/packages/frontend/src/page/document_page_sidebar.tsx
+++ b/packages/frontend/src/page/document_page_sidebar.tsx
@@ -97,9 +97,18 @@ function DocumentsTreeNode(props: {
                 throw new Error("couldn't load child documents!");
             }
 
-            return await Promise.all(
+            const childDocs = await Promise.all(
                 results.content.map((childStub) => api.getLiveDoc(childStub.refId)),
             );
+
+            function isDocOwnerless(doc: LiveDocWithRef) {
+                return doc.docRef.permissions.anyone === "Own";
+            }
+
+            const isParentOwnerless = isDocOwnerless(props.doc);
+
+            // Don't show ownerless children under owned document
+            return childDocs.filter((childDoc) => isParentOwnerless || !isDocOwnerless(childDoc));
         },
     );
 


### PR DESCRIPTION
closes #884

This feels a bit messy, but I couldn't think of a better way that doesn't involve the larger problem of client state management.