### PR TITLE
Hide deleted sub-docs and navigate away on delete

### DIFF
--- a/packages/frontend/src/page/document_page_sidebar.tsx
+++ b/packages/frontend/src/page/document_page_sidebar.tsx
@@ -207,10 +207,26 @@ function DocumentsTreeLeaf(props: {
                     liveDoc={props.doc.liveDoc}
                     docRef={props.doc.docRef}
                     onDocCreated={props.refetchDoc}
-                    onDocDeleted={() => {
+                    onDocDeleted={async () => {
+                        const deletedRefId = props.doc.docRef.refId;
+                        const isPrimaryDeleted = deletedRefId === primaryRefId();
+                        const isSecondaryDeleted = deletedRefId === secondaryRefId();
+
                         props.refetchDoc();
                         props.refetchPrimaryDoc();
                         props.refetchSecondaryDoc();
+
+                        // Navigate away if the deleted document is currently being viewed
+                        if (isPrimaryDeleted || isSecondaryDeleted) {
+                            const parentDoc = await getDocParent(props.doc.liveDoc.doc, api);
+
+                            if (!parentDoc) {
+                                // This is a root document: navigate to documents list
+                                navigate("/documents");
+                            } else {
+                                navigate(`/${createLinkPart(parentDoc)}`);
+                            }
+                        }
                     }}
                 />
             </div>


### PR DESCRIPTION
Remove the annoying deleted sub-documents and navigates to the parent doc or "my documents" when deleting.

<img width="203" height="226" alt="image" src="https://github.com/user-attachments/assets/9a5c0f59-7f81-4647-a87c-f9a6e8ede214" />
:arrow_right: 
<img width="198" height="75" alt="image" src="https://github.com/user-attachments/assets/a29b90c8-5a5e-48e9-8715-efc431f59f53" />


The interaction around deleting parents (i.e. "Diagram" in the example) which still have children is a little weird but I don't know how to solve that without overcomplicating things. 