### PR TITLE
Cache builds in GitHub actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,7 +112,7 @@ jobs:
         id: cache-key
         run: |
           # Get git hash of the most recent commit affecting frontend or any of its dependencies
-          hash=$(git log -1 --format="%H" -- packages/frontend packages/backend/pkg packages/catlog packages/catlog-wasm packages/notebook-types packages/ui-components Cargo.toml)
+          hash=$(git log -1 --format="%H" -- packages/frontend packages/backend/pkg packages/catlog packages/catlog-wasm packages/notebook-types packages/ui-components Cargo.toml Cargo.lock)
           echo "git-hash=${hash}" >> $GITHUB_OUTPUT
           echo "Frontend git hash: ${git_hash}"
 


### PR DESCRIPTION
This reduces time to deploy our previews by only building what is needed. These builds tend to take 1-2 minutes but I have also  noticed frequent network related intermittent failures with e.g. Math docs that this will avoid on unrelated PRs.

Downside is we need to keep the cache key computation for frontend updated when changing any in-repo dependencies but I think it's worth it. 