### PR TITLE
Resolve some build warnings around bundling

### DIFF
--- a/packages/frontend/src/help/guide.tsx
+++ b/packages/frontend/src/help/guide.tsx
@@ -2,7 +2,7 @@ import { useParams } from "@solidjs/router";
 import { createResource, Show } from "solid-js";
 import { Dynamic } from "solid-js/web";
 
-import { guidesList } from "./guides";
+import { guidesList } from "./guides_list";
 
 /** Help page of a guide */
 export default function GuideHelpPage() {

--- a/packages/frontend/src/help/guides.tsx
+++ b/packages/frontend/src/help/guides.tsx
@@ -2,27 +2,7 @@ import { A } from "@solidjs/router";
 import { For } from "solid-js";
 
 import GuidesContent from "./guides.mdx";
-
-export type Guide = {
-    id: string;
-    title: string;
-    description: string;
-};
-
-export const guidesList: Guide[] = [
-    {
-        id: "fundamentals",
-        title: "Fundamentals of CatColab",
-        description:
-            'What do we mean by "formal, interoperable, conceptual modeling", and how does CatColab implement this?',
-    },
-    {
-        id: "example-models",
-        title: "Ready-made models",
-        description:
-            "Some ready-made models in various logics, of various complexity, and from various domains",
-    },
-];
+import { type Guide, guidesList } from "./guides_list";
 
 /** Help page for all guides */
 export default function GuidesHelpPage() {

--- a/packages/frontend/src/help/guides_list.ts
+++ b/packages/frontend/src/help/guides_list.ts
@@ -1,0 +1,20 @@
+export type Guide = {
+    id: string;
+    title: string;
+    description: string;
+};
+
+export const guidesList: Guide[] = [
+    {
+        id: "fundamentals",
+        title: "Fundamentals of CatColab",
+        description:
+            'What do we mean by "formal, interoperable, conceptual modeling", and how does CatColab implement this?',
+    },
+    {
+        id: "example-models",
+        title: "Ready-made models",
+        description:
+            "Some ready-made models in various logics, of various complexity, and from various domains",
+    },
+];

--- a/packages/frontend/src/help/logic_help_detail.tsx
+++ b/packages/frontend/src/help/logic_help_detail.tsx
@@ -4,7 +4,6 @@ import { Dynamic } from "solid-js/web";
 import invariant from "tiny-invariant";
 
 import { type Theory, TheoryLibraryContext } from "../theory";
-import LogicHelpNotFound from "./logics/logic-help-not-found.mdx";
 
 /** Help page for a theory in the standard library. */
 export default function LogicHelpPage() {
@@ -28,7 +27,8 @@ function LogicHelpDetail(props: { theory: Theory }) {
             try {
                 return await import(`./logics/${theoryId}.mdx`);
             } catch {
-                return { default: LogicHelpNotFound };
+                const fallback = await import("./logics/logic-help-not-found.mdx");
+                return fallback;
             }
         },
     );

--- a/packages/frontend/src/help/routes.ts
+++ b/packages/frontend/src/help/routes.ts
@@ -3,7 +3,7 @@ import { lazy } from "solid-js";
 
 import { stdTheories } from "../stdlib";
 import { lazyMdx } from "../util/mdx";
-import { guidesList } from "./guides";
+import { guidesList } from "./guides_list";
 
 const theoryWithIdFilter = {
     id: (id: string) => stdTheories.has(id),


### PR DESCRIPTION
Resolves these warnings from frontend `pnpm build`:

```
 [plugin vite:reporter] 
(!) /home/runner/work/CatColab/CatColab/packages/frontend/src/help/logics/logic-help-not-found.mdx is dynamically imported by /home/runner/work/CatColab/CatColab/packages/frontend/src/help/logic_help_detail.tsx but also statically imported by /home/runner/work/CatColab/CatColab/packages/frontend/src/help/logic_help_detail.tsx, dynamic import will not move module into another chunk.

[plugin vite:reporter] 
(!) /home/runner/work/CatColab/CatColab/packages/frontend/src/help/guides.tsx is dynamically imported by /home/runner/work/CatColab/CatColab/packages/frontend/src/help/routes.ts but also statically imported by /home/runner/work/CatColab/CatColab/packages/frontend/src/help/guide.tsx, /home/runner/work/CatColab/CatColab/packages/frontend/src/help/routes.ts, dynamic import will not move module into another chunk.

```