### PR TITLE
Remove restore button on banner when doc not owned

### DIFF
--- a/packages/frontend/src/page/document_page.tsx
+++ b/packages/frontend/src/page/document_page.tsx
@@ -368,20 +368,24 @@ export function DocumentPane(props: {
         }
     };
 
+    const canRestore = () => props.docRef.permissions.user === "Own";
+
     return (
         <>
             <Show when={isDeleted()}>
                 <WarningBanner
                     actions={
-                        <Button
-                            variant="utility"
-                            onClick={(e) => {
-                                e.preventDefault();
-                                handleRestore();
-                            }}
-                        >
-                            <RotateCcw size={16} /> Restore it
-                        </Button>
+                        <Show when={canRestore()}>
+                            <Button
+                                variant="utility"
+                                onClick={(e) => {
+                                    e.preventDefault();
+                                    handleRestore();
+                                }}
+                            >
+                                <RotateCcw size={16} /> Restore it
+                            </Button>
+                        </Show>
                     }
                 >
                     This {props.doc.type} has been deleted and will not be listed in your documents.


### PR DESCRIPTION
This was an oversight when I made the banner. You shouldn't be offered to restore when you don't own the document (so can't restore it). 