### PR TITLE
Upgrade to automerge-prosemirror v0.2.0-alpha.0

### DIFF
--- a/packages/frontend/default.nix
+++ b/packages/frontend/default.nix
@@ -36,7 +36,7 @@ let
 
     pnpmDeps = pkgs.fetchPnpmDeps {
       # see ../../dev-docs/fixing-hash-mismatches.md
-      hash = "sha256-TsNHNmsn925wku+yZWIFgyakvpn1luzPlBjD53OSZqI=";
+      hash = "sha256-RwTk7APvWetobkZQPka6ZOyh8le2YVfIKhdugDBYBNk=";
       pname = name;
       fetcherVersion = 2;
       # Only includes package.json and pnpm-lock.yaml files to ensure consistent hashing in different

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -26,7 +26,7 @@
         "@automerge/automerge-repo": "^2.2.0",
         "@automerge/automerge-repo-network-websocket": "^2.2.0",
         "@automerge/automerge-repo-storage-indexeddb": "^2.2.0",
-        "@automerge/prosemirror": "v0.1.0",
+        "@automerge/prosemirror": "v0.2.0-alpha.0",
         "@benrbray/prosemirror-math": "^1.0.0",
         "@corvu/dialog": "^0.2.4",
         "@corvu/popover": "^0.2.0",

--- a/packages/frontend/pnpm-lock.yaml
+++ b/packages/frontend/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       '@automerge/prosemirror':
-        specifier: v0.1.0
-        version: 0.1.0
+        specifier: v0.2.0-alpha.0
+        version: 0.2.0-alpha.0
       '@benrbray/prosemirror-math':
         specifier: ^1.0.0
         version: 1.0.0(katex@0.16.22)(prosemirror-commands@1.7.1)(prosemirror-history@1.4.1)(prosemirror-inputrules@1.5.0)(prosemirror-keymap@1.2.3)(prosemirror-model@1.25.2)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.4)(prosemirror-view@1.40.1)
@@ -235,8 +235,8 @@ packages:
   '@automerge/automerge@3.1.1':
     resolution: {integrity: sha512-x7tZiMBLk4/SKYimVEVl1/wPntT9buGvLOWCey9ZcH8JUsB0dgm49C0S7Ojzgvflcs2hc/YjiXRPcFeFkinIgw==}
 
-  '@automerge/prosemirror@0.1.0':
-    resolution: {integrity: sha512-1VDuVzey6/UksmenUv3pbUH+kaEhboVDpqgo3RC1bd6Tztk3ZjxJ2hBSuKaVRfl+4q4v+VysI4oHGgNhrBv5Xg==}
+  '@automerge/prosemirror@0.2.0-alpha.0':
+    resolution: {integrity: sha512-ho0ghRZxpWoVs0RPJV3a1b6AhZeMfXJhmWGAjrftGeg0JuZFJ0kyLol5TnNslLwyKCfBG42cLiciH/9ztSpFKQ==}
 
   '@babel/code-frame@7.25.7':
     resolution: {integrity: sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==}
@@ -3100,7 +3100,7 @@ snapshots:
 
   '@automerge/automerge@3.1.1': {}
 
-  '@automerge/prosemirror@0.1.0':
+  '@automerge/prosemirror@0.2.0-alpha.0':
     dependencies:
       '@automerge/automerge': 3.1.1
       ordered-map: 0.1.0


### PR DESCRIPTION
Stacked on top of #875 

When upgrading automerge-prosemirror on main the Nix integration tests failed. I did not find a cause after ~5min of investigation. The Nix integration tests do not fail when run again the samod branch.