### PR TITLE
Remove unnecessary `nix_path` argument in GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,8 +134,6 @@ jobs:
     
     - name: Install Nix
       uses: cachix/install-nix-action@v25
-      with:
-        nix_path: nixpkgs=channel:25.05
 
     - name: Configure Cachix
       uses: cachix/cachix-action@v14

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -509,8 +509,6 @@ jobs:
     
     - name: Install Nix
       uses: cachix/install-nix-action@v25
-      with:
-        nix_path: nixpkgs=channel:25.05
 
     - name: Configure Cachix
       uses: cachix/cachix-action@v14


### PR DESCRIPTION
First I noticed this was out of date. `nix_path` is only necessary for non-flake nix configs, `install-nix-action` will get everything it needs from out flake.nix/flake.lock.