### PR TITLE
Pretty-printing models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 name = "catlog"
 version = "0.1.0"
 dependencies = [
+ "ansi_term",
  "bwd",
  "clap",
  "derivative",

--- a/packages/catlog/Cargo.toml
+++ b/packages/catlog/Cargo.toml
@@ -38,6 +38,7 @@ ustr = "1"
 uuid = { version = "1.18" }
 wasm-bindgen = { version = "0.2.100", optional = true }
 notebook-types = { version = "0.1.0", path = "../notebook-types" }
+ansi_term = "0.12.1"
 
 [dev-dependencies]
 clap = { version = "4.5.47", features = ["derive"] }

--- a/packages/catlog/src/dbl/discrete/model.rs
+++ b/packages/catlog/src/dbl/discrete/model.rs
@@ -1,7 +1,9 @@
 //! Models of discrete double theories.
 
+use std::fmt::{Display, Formatter};
 use std::rc::Rc;
 
+use ansi_term::Style;
 use derivative::Derivative;
 
 use super::theory::DiscreteDblTheory;
@@ -248,6 +250,31 @@ impl Validate for DiscreteDblModel {
 
     fn validate(&self) -> Result<(), nonempty::NonEmpty<Self::ValidationError>> {
         validate::wrap_errors(self.iter_invalid())
+    }
+}
+
+impl Display for DiscreteDblModel {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "{}", Style::new().bold().paint("Obs:"))?;
+        for (left, right) in self.ob_types.clone() {
+            writeln!(f, "{left}::{right}")?
+        }
+        writeln!(f, "{}", Style::new().bold().paint("Mors:"))?;
+        for (left, right) in self.mor_types.clone() {
+            let (dom, cod) =
+                (self.get_dom(&left.clone()).unwrap(), self.get_cod(&left.clone()).unwrap());
+            let val = right
+                .clone()
+                .into_iter()
+                .map(|m| m.to_string())
+                .reduce(|mut cur, nxt| {
+                    cur.push_str(&nxt);
+                    cur
+                })
+                .unwrap();
+            writeln!(f, "({left}: {dom} -|-> {cod})::{val}")?
+        }
+        Ok(())
     }
 }
 

--- a/packages/catlog/src/dbl/discrete_tabulator/theory.rs
+++ b/packages/catlog/src/dbl/discrete_tabulator/theory.rs
@@ -21,6 +21,16 @@ pub enum TabObType {
     Tabulator(Box<TabMorType>),
 }
 
+impl std::fmt::Display for TabObType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let _ = match self {
+            TabObType::Basic(x) => write!(f, "{x}"),
+            TabObType::Tabulator(mor) => write!(f, "{mor}"),
+        };
+        Ok(())
+    }
+}
+
 /// Morphism type in a discrete tabulator theory.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, From)]
 pub enum TabMorType {
@@ -30,6 +40,16 @@ pub enum TabMorType {
 
     /// Hom type on an object type.
     Hom(Box<TabObType>),
+}
+
+impl std::fmt::Display for TabMorType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let _ = match self {
+            TabMorType::Basic(x) => write!(f, "{x}"),
+            TabMorType::Hom(mor) => write!(f, "{mor}"),
+        };
+        Ok(())
+    }
 }
 
 /// Projection onto object type in a discrete tabulator theory.

--- a/packages/catlog/src/dbl/modal/theory.rs
+++ b/packages/catlog/src/dbl/modal/theory.rs
@@ -18,6 +18,7 @@
 //! 2-category or monoidal category. Instead, the mode theory is implicit and baked
 //! in at the type level.
 
+use std::fmt::{Display, Formatter};
 use std::hash::Hash;
 use std::iter::repeat_n;
 
@@ -148,6 +149,13 @@ impl<T> ModeApp<T> {
 ///
 /// These are (object or morphism) types that cannot be built out of others.
 pub type ModalType = ModeApp<QualifiedName>;
+
+impl Display for ModalType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.arg)?;
+        Ok(())
+    }
+}
 
 /// A basic operation in a modal double theory.
 ///

--- a/packages/catlog/src/stdlib/models.rs
+++ b/packages/catlog/src/stdlib/models.rs
@@ -199,12 +199,14 @@ mod tests {
     #[test]
     fn schemas() {
         let th = Rc::new(th_schema());
+        println!("{}", walking_attr(th.clone()));
         assert!(walking_attr(th).validate().is_ok());
     }
 
     #[test]
     fn categories_with_links() {
         let th = Rc::new(th_category_links());
+        println!("{}", backward_link(th.clone()));
         assert!(backward_link(th).validate().is_ok());
     }
 
@@ -218,6 +220,14 @@ mod tests {
     #[test]
     fn sym_monoidal_categories() {
         let th = Rc::new(th_sym_monoidal_category());
+        println!("{}", catalyzed_reaction(th.clone()));
         assert!(catalyzed_reaction(th).validate().is_ok());
+    }
+
+    #[test]
+    fn sir() {
+        let th = Rc::new(th_sym_monoidal_category());
+        println!("{}", sir_petri(th.clone()));
+        assert!(sir_petri(th).validate().is_ok());
     }
 }


### PR DESCRIPTION
I usually debug in the terminal and want a pretty-printed Display method for Models. I'm in the process of playing with designs, and will sand down the code with a more modular design over time.

For "schemas",
<img width="334" height="129" alt="image" src="https://github.com/user-attachments/assets/68ef374c-e942-4191-b57c-006790fe92cf" /> 

For "categories_with_links",
<img width="260" height="139" alt="image" src="https://github.com/user-attachments/assets/4f6d6999-4c55-418c-a3a5-bd224db51941" />

For "sym_monoidal_categories",
<img width="340" height="115" alt="image" src="https://github.com/user-attachments/assets/50fdf4ac-24f8-42bc-a84c-6ed86cebfda2" />
