### PR TITLE
Validate object and morphism types in frontend theories against Wasm

### DIFF
--- a/packages/catlog-wasm/src/theory.rs
+++ b/packages/catlog-wasm/src/theory.rs
@@ -291,6 +291,26 @@ impl DblTheory {
 
 #[wasm_bindgen]
 impl DblTheory {
+    /// Returns whether the theory contains the object type.
+    #[wasm_bindgen(js_name = "hasObType")]
+    pub fn has_ob_type(&self, ob_type: ObType) -> Result<bool, String> {
+        all_the_same!(match &self.0 {
+            DblTheoryBox::[Discrete, DiscreteTab, Modal](th) => {
+                Ok(th.has_ob_type(&Elaborator.elab(&ob_type)?))
+            }
+        })
+    }
+
+    /// Returns whether the theory contains the morphism type.
+    #[wasm_bindgen(js_name = "hasMorType")]
+    pub fn has_mor_type(&self, mor_type: MorType) -> Result<bool, String> {
+        all_the_same!(match &self.0 {
+            DblTheoryBox::[Discrete, DiscreteTab, Modal](th) => {
+                Ok(th.has_mor_type(&Elaborator.elab(&mor_type)?))
+            }
+        })
+    }
+
     /// Gets the source of a morphism type.
     #[wasm_bindgen]
     pub fn src(&self, mor_type: MorType) -> Result<ObType, String> {

--- a/packages/frontend/src/stdlib/theories.test.ts
+++ b/packages/frontend/src/stdlib/theories.test.ts
@@ -1,4 +1,4 @@
-import { assert, describe, expect, test } from "vitest";
+import { assert, describe, test } from "vitest";
 
 import { stdTheories } from "./theories.ts";
 
@@ -29,38 +29,27 @@ describe("Standard library of theories", () => {
         }
     });
 
-    test.sequential("mor and ob types in modelTypes should exist in WASM theory", async () => {
+    test.sequential("types bound for models should exist in theory", async () => {
         for (const meta of theories.allMetadata()) {
             const theory = await theories.get(meta.id);
-            for (const mt of theory.modelTypes) {
-                if (mt.tag === "MorType") {
-                    expect(() => theory.theory.src(mt.morType)).not.toThrow();
+            for (const meta of theory.modelTypes) {
+                if (meta.tag === "MorType") {
+                    assert(theory.theory.hasMorType(meta.morType));
                 } else {
-                    // ObType
-                    expect(() =>
-                        theory.theory.src({
-                            tag: "Hom",
-                            content: mt.obType,
-                        }),
-                    ).not.toThrow();
+                    assert(theory.theory.hasObType(meta.obType));
                 }
             }
         }
     });
 
-    test.sequential("mor and ob types in instanceTypes should exist in WASM theory", async () => {
+    test.sequential("types bound for instances should exist in theory", async () => {
         for (const meta of theories.allMetadata()) {
             const theory = await theories.get(meta.id);
-            for (const mt of theory.instanceTypes) {
-                if (mt.tag === "MorType") {
-                    expect(() => theory.theory.src(mt.morType)).not.toThrow();
+            for (const meta of theory.instanceTypes) {
+                if (meta.tag === "MorType") {
+                    assert(theory.theory.hasMorType(meta.morType));
                 } else {
-                    expect(() =>
-                        theory.theory.src({
-                            tag: "Hom",
-                            content: mt.obType,
-                        }),
-                    ).not.toThrow();
+                    assert(theory.theory.hasObType(meta.obType));
                 }
             }
         }


### PR DESCRIPTION
Add tests that verify `modelTypes` and `instanceTypes` defined in frontend theories refer to actual types in the WASM-bound theories

Closes #784
