### PR TITLE
Add cascading updates/deletes users table foreign keys

### DIFF
--- a/packages/migrator/src/migrations/m20260124120000_add_user_fk_cascade.rs
+++ b/packages/migrator/src/migrations/m20260124120000_add_user_fk_cascade.rs
@@ -1,0 +1,74 @@
+use sqlx::{Acquire, PgConnection, Postgres};
+use sqlx_migrator::Operation;
+use sqlx_migrator::error::Error;
+use sqlx_migrator::migration;
+use sqlx_migrator::vec_box;
+
+pub(crate) struct AddUserFkCascade;
+
+migration!(
+    Postgres,
+    AddUserFkCascade,
+    "backend",
+    "20260124120000_add_user_fk_cascade",
+    vec_box![],
+    vec_box![MigrationOperation]
+);
+
+struct MigrationOperation;
+#[async_trait::async_trait]
+impl Operation<Postgres> for MigrationOperation {
+    async fn up(&self, conn: &mut PgConnection) -> Result<(), Error> {
+        let mut tx = conn.begin().await?;
+
+        sqlx::query(
+            "
+            ALTER TABLE permissions
+            DROP CONSTRAINT permissions_subject_fkey;
+            ",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "
+            ALTER TABLE permissions
+            ADD CONSTRAINT permissions_subject_fkey
+            FOREIGN KEY (subject) REFERENCES users (id)
+            ON UPDATE CASCADE
+            ON DELETE CASCADE;
+            ",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    async fn down(&self, conn: &mut PgConnection) -> Result<(), Error> {
+        let mut tx = conn.begin().await?;
+
+        sqlx::query(
+            "
+            ALTER TABLE permissions
+            DROP CONSTRAINT permissions_subject_fkey;
+            ",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "
+            ALTER TABLE permissions
+            ADD CONSTRAINT permissions_subject_fkey
+            FOREIGN KEY (subject) REFERENCES users (id);
+            ",
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(())
+    }
+}

--- a/packages/migrator/src/migrations/mod.rs
+++ b/packages/migrator/src/migrations/mod.rs
@@ -9,6 +9,7 @@ mod m20250516154702_automerge_storage;
 mod m20250805230408_fix_automerge_storage;
 mod m20250924133640_add_refs_deleted_at;
 mod m20251006141026_get_ref_stubs;
+mod m20260124120000_add_user_fk_cascade;
 
 pub fn migrations() -> Vec<Box<dyn Migration<Postgres>>> {
     vec_box![
@@ -19,5 +20,6 @@ pub fn migrations() -> Vec<Box<dyn Migration<Postgres>>> {
         m20250805230408_fix_automerge_storage::FixAutomergeStorage,
         m20251006141026_get_ref_stubs::GetRefStubs,
         m20250924133640_add_refs_deleted_at::AddRefsDeletedAt,
+        m20260124120000_add_user_fk_cascade::AddUserFkCascade,
     ]
 }


### PR DESCRIPTION
When debugging problems I often like to fiddle with user IDs to "impersonate" the user locally. The lack of cascading changes on the foreign keys referencing the users table (currently only permissions) makes this painful.

I would be in favor of adding cascades to all of the other foreign keys as well. While we generally shouldn't need them for business logic, they are nice to have in place when things are going wrong and I see little downside to having them.