### PR TITLE
Fix default `AnnouncePolicy` causing CPU usage spike

### DIFF
--- a/packages/backend/src/main.rs
+++ b/packages/backend/src/main.rs
@@ -107,6 +107,7 @@ async fn main() {
 
             let repo = samod::Repo::builder(tokio::runtime::Handle::current())
                 .with_storage(storage::PostgresStorage::new(db.clone()))
+                .with_announce_policy(|_doc_id, _peer_id| false)
                 .load()
                 .await;
 


### PR DESCRIPTION
This restores the policy [we had with automerge-doc-server](https://github.com/ToposInstitute/CatColab/blob/77171037de8e1cd62e654e9e4911378c764a0e8e/packages/automerge-doc-server/src/server.ts#L64) of not announcing _all_ DocHandles. Not setting this, when more than a few documents have been opened by users (normal state on next it seems) it causes a CPU usage spike on first load, locking up the main JS thread for a good 10 seconds or so.

I don't yet know why processing ~100 DocHandles causes automerge-repo to lock up the main JS thread like that and whether it's intended behaviour in some sense, but we can investigate that problem if we ever actually want to process ~100 DocHandles.