### PR TITLE
Add sudo password to catcolab account

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -210,7 +210,7 @@ jobs:
 
     - name: Deploy to catcolab-next
       run: |
-       nix run github:serokell/deploy-rs -- --skip-checks .#catcolab-next
+       nix run github:serokell/deploy-rs -- --skip-checks .#catcolab-next-ci
 
     - name: Verify deployment
       run: |

--- a/flake.nix
+++ b/flake.nix
@@ -330,6 +330,7 @@
           profiles.system = {
             sshUser = "catcolab";
             user = "root";
+            interactiveSudo = true;
             path = deploy-rs.lib.${linuxSystem}.activate.nixos self.nixosConfigurations.catcolab;
           };
         };
@@ -338,6 +339,14 @@
           profiles.system = {
             sshUser = "catcolab";
             user = "root";
+            interactiveSudo = true;
+            path = deploy-rs.lib.${linuxSystem}.activate.nixos self.nixosConfigurations.catcolab-next;
+          };
+        };
+        catcolab-next-ci = {
+          hostname = "backend-next.catcolab.org";
+          profiles.system = {
+            sshUser = "root";
             path = deploy-rs.lib.${linuxSystem}.activate.nixos self.nixosConfigurations.catcolab-next;
           };
         };
@@ -350,8 +359,9 @@
               "2221"
             ];
             sshUser = "catcolab";
-            path = deploy-rs.lib.${linuxSystem}.activate.nixos self.nixosConfigurations.catcolab-vm;
             user = "root";
+            interactiveSudo = true;
+            path = deploy-rs.lib.${linuxSystem}.activate.nixos self.nixosConfigurations.catcolab-vm;
           };
         };
       };

--- a/infrastructure/hosts/catcolab-next/default.nix
+++ b/infrastructure/hosts/catcolab-next/default.nix
@@ -38,6 +38,7 @@ in
     host = {
       enable = true;
       userKeys = keys.hosts.catcolab-next.userKeys;
+      sudoPasswordHash = "$y$j9T$Gvhb3z8dNG2Gzk5STLY2q0$w8hilnb9bC2aNuH8Vx4FpgRzotKpFJeF2oFQ24MGMK8";
       backup = {
         enable = true;
         rcloneConfigFile = config.age.secrets.rcloneConf.path;

--- a/infrastructure/hosts/catcolab-vm/default.nix
+++ b/infrastructure/hosts/catcolab-vm/default.nix
@@ -34,6 +34,7 @@ in
     host = {
       enable = true;
       userKeys = keys.allUserKeys;
+      sudoPasswordHash = "$y$j9T$Gvhb3z8dNG2Gzk5STLY2q0$w8hilnb9bC2aNuH8Vx4FpgRzotKpFJeF2oFQ24MGMK8";
     };
   };
 

--- a/infrastructure/hosts/catcolab/default.nix
+++ b/infrastructure/hosts/catcolab/default.nix
@@ -36,6 +36,7 @@ in
     host = {
       enable = true;
       userKeys = keys.hosts.catcolab.userKeys;
+      sudoPasswordHash = "$y$j9T$Gvhb3z8dNG2Gzk5STLY2q0$w8hilnb9bC2aNuH8Vx4FpgRzotKpFJeF2oFQ24MGMK8";
       backup = {
         enable = true;
         rcloneConfigFile = config.age.secrets.rcloneConf.path;


### PR DESCRIPTION
In CI we deploy using the `root` user, when deploying from local machines we deploy using the `catcolab` user with an interactive prompt for the new sudo password.