### PR TITLE
Consolidate ssh key management into single file

### DIFF
--- a/infrastructure/hosts/catcolab-next/default.nix
+++ b/infrastructure/hosts/catcolab-next/default.nix
@@ -5,11 +5,7 @@
   ...
 }:
 let
-  owen = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIF2sBTuqGoEXRWpBRqTBwZZPDdLGGJ0GQcuX5dfIZKb4 o@red-special";
-  epatters = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAKXx6wMJSeYKCHNmbyR803RQ72uto9uYsHhAPPWNl2D evan@epatters.org";
-  jmoggr = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMiaHaeJ5PQL0mka/lY1yGXIs/bDK85uY1O3mLySnwHd j@jmoggr.com";
-  kasbah = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM1K/FB6dCjo1/xfddi9VoHEGchFo/bcz6v7SC7wAuFQ kaspar@topos";
-  catcolab-next-deployuser = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM7AYg1fZM0zMxb/BuZTSwK4O3ycUIHruApr1tKoO8nJ deployuser@next.catcolab.org";
+  keys = import ../../ssh-keys.nix;
 in
 {
   imports = [
@@ -41,13 +37,7 @@ in
     environmentFile = config.age.secrets.catcolabSecrets.path;
     host = {
       enable = true;
-      userKeys = [
-        owen
-        epatters
-        jmoggr
-        catcolab-next-deployuser
-        kasbah
-      ];
+      userKeys = keys.hosts.catcolab-next.userKeys;
       sudoPasswordHash = "$y$j9T$Gvhb3z8dNG2Gzk5STLY2q0$w8hilnb9bC2aNuH8Vx4FpgRzotKpFJeF2oFQ24MGMK8";
       backup = {
         enable = true;

--- a/infrastructure/hosts/catcolab-vm/default.nix
+++ b/infrastructure/hosts/catcolab-vm/default.nix
@@ -6,6 +6,9 @@
   self,
   ...
 }:
+let
+  keys = import ../../ssh-keys.nix;
+in
 {
   imports = [
     (modulesPath + "/profiles/qemu-guest.nix")
@@ -31,10 +34,7 @@
     host = {
       enable = true;
       sudoPasswordHash = "$y$j9T$Gvhb3z8dNG2Gzk5STLY2q0$w8hilnb9bC2aNuH8Vx4FpgRzotKpFJeF2oFQ24MGMK8";
-      userKeys = [
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMiaHaeJ5PQL0mka/lY1yGXIs/bDK85uY1O3mLySnwHd j@jmoggr.com"
-        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM1K/FB6dCjo1/xfddi9VoHEGchFo/bcz6v7SC7wAuFQ kaspar@topos"
-      ];
+      userKeys = keys.allUserKeys;
     };
   };
 

--- a/infrastructure/hosts/catcolab/default.nix
+++ b/infrastructure/hosts/catcolab/default.nix
@@ -5,10 +5,7 @@
   ...
 }:
 let
-  owen = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIF2sBTuqGoEXRWpBRqTBwZZPDdLGGJ0GQcuX5dfIZKb4 o@red-special";
-  epatters = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAKXx6wMJSeYKCHNmbyR803RQ72uto9uYsHhAPPWNl2D evan@epatters.org";
-  jmoggr = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMiaHaeJ5PQL0mka/lY1yGXIs/bDK85uY1O3mLySnwHd j@jmoggr.com";
-  kasbah = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM1K/FB6dCjo1/xfddi9VoHEGchFo/bcz6v7SC7wAuFQ kaspar@topos";
+  keys = import ../../ssh-keys.nix;
 in
 {
   imports = [
@@ -38,11 +35,7 @@ in
     environmentFile = config.age.secrets.catcolabSecrets.path;
     host = {
       enable = true;
-      userKeys = [
-        epatters
-        jmoggr
-        kasbah
-      ];
+      userKeys = keys.hosts.catcolab.userKeys;
       sudoPasswordHash = "$y$j9T$Gvhb3z8dNG2Gzk5STLY2q0$w8hilnb9bC2aNuH8Vx4FpgRzotKpFJeF2oFQ24MGMK8";
       backup = {
         enable = true;

--- a/infrastructure/secrets/secrets.nix
+++ b/infrastructure/secrets/secrets.nix
@@ -1,39 +1,17 @@
 let
-  catcolab = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPyxORhhfO+9F2hQZ3I/EiSpfg+caWpG6c8AuG5u1XtK root@ip-172-31-14-38.us-east-2.compute.internal";
-  catcolab-next = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJEyUzs+ymd6YFKnPTi6cfoWuNI/fhBGgcx0YELTzWJI root@ip-172-31-9-115.us-east-2.compute.internal";
-  owen = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIF2sBTuqGoEXRWpBRqTBwZZPDdLGGJ0GQcuX5dfIZKb4 o@red-special";
-  epatters = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAKXx6wMJSeYKCHNmbyR803RQ72uto9uYsHhAPPWNl2D evan@epatters.org";
-  jmoggr = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMiaHaeJ5PQL0mka/lY1yGXIs/bDK85uY1O3mLySnwHd j@jmoggr.com";
-  kasbah = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM1K/FB6dCjo1/xfddi9VoHEGchFo/bcz6v7SC7wAuFQ kaspar@topos";
-  catcolab-next-deployuser = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM7AYg1fZM0zMxb/BuZTSwK4O3ycUIHruApr1tKoO8nJ deployuser@next.catcolab.org";
+  keys = import ../ssh-keys.nix;
 in
-builtins.mapAttrs (_: publicKeys: { inherit publicKeys; }) ({
-  "env.next.age" = [
-    catcolab-next
-    owen
-    epatters
-    jmoggr
-    catcolab-next-deployuser
-    kasbah
-  ];
-  "env.prod.age" = [
-    catcolab
-    epatters
-    jmoggr
-    kasbah
-  ];
-  "rclone.conf.next.age" = [
-    catcolab-next
-    owen
-    epatters
-    jmoggr
-    catcolab-next-deployuser
-    kasbah
-  ];
-  "rclone.conf.prod.age" = [
-    catcolab
-    epatters
-    jmoggr
-    kasbah
-  ];
-})
+{
+  "env.next.age" = {
+    publicKeys = keys.hosts.catcolab-next.allKeys;
+  };
+  "rclone.conf.next.age" = {
+    publicKeys = keys.hosts.catcolab-next.allKeys;
+  };
+  "env.prod.age" = {
+    publicKeys = keys.hosts.catcolab.allKeys;
+  };
+  "rclone.conf.prod.age" = {
+    publicKeys = keys.hosts.catcolab.allKeys;
+  };
+}

--- a/infrastructure/ssh-keys.nix
+++ b/infrastructure/ssh-keys.nix
@@ -1,0 +1,38 @@
+let
+  allUserKeys = {
+    owen = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIF2sBTuqGoEXRWpBRqTBwZZPDdLGGJ0GQcuX5dfIZKb4 o@red-special";
+    epatters = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAKXx6wMJSeYKCHNmbyR803RQ72uto9uYsHhAPPWNl2D evan@epatters.org";
+    jmoggr = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMiaHaeJ5PQL0mka/lY1yGXIs/bDK85uY1O3mLySnwHd j@jmoggr.com";
+    kasbah = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM1K/FB6dCjo1/xfddi9VoHEGchFo/bcz6v7SC7wAuFQ kaspar@topos";
+    catcolab-next-deployuser = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM7AYg1fZM0zMxb/BuZTSwK4O3ycUIHruApr1tKoO8nJ deployuser@next.catcolab.org";
+  };
+
+  # hostKey comes frome the /etc/ssh/ssh_host_ed25519_key.pub file on each host after the host is first
+  # provisioned
+  hosts = {
+    catcolab = rec {
+      hostKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPyxORhhfO+9F2hQZ3I/EiSpfg+caWpG6c8AuG5u1XtK root@ip-172-31-14-38.us-east-2.compute.internal";
+      userKeys = with allUserKeys; [
+        epatters
+        jmoggr
+        kasbah
+      ];
+      allKeys = [ hostKey ] ++ userKeys;
+    };
+    catcolab-next = rec {
+      hostKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJEyUzs+ymd6YFKnPTi6cfoWuNI/fhBGgcx0YELTzWJI root@ip-172-31-9-115.us-east-2.compute.internal";
+      userKeys = with allUserKeys; [
+        owen
+        epatters
+        jmoggr
+        kasbah
+        catcolab-next-deployuser
+      ];
+      allKeys = [ hostKey ] ++ userKeys;
+    };
+  };
+in
+{
+  inherit hosts;
+  allUserKeys = builtins.attrValues allUserKeys;
+}


### PR DESCRIPTION
Previously we frequently misunderstood and made mistakes about which public keys needed to be defined in which places. This new declarative structure for the public keys should make it much easier to understand what keys are needed where and make adding/editing keys/hosts less error prone.

Stacked on top of #970 due to skill issues with git.