### PR TITLE
Add a `pnpm` `minimumReleaseAge` of  9 days

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+# 9 days, in minutes
+minimumReleaseAge: 12960
 packages:
   - "dev-docs"
   - "packages/backend/pkg"


### PR DESCRIPTION
I've seen 1 week mentioned a lot, so 9 days lets those guys find out if stuff is safe first. It's a tragedy of the commons, but it's not our fault the whole world isn't using Nix yet.