### PR TITLE
Remove redundant `Display` impl for morphim types in DoubleTT

### DIFF
--- a/packages/catlog/examples/test.dbltt.snapshot
+++ b/packages/catlog/examples/test.dbltt.snapshot
@@ -27,9 +27,9 @@ generate WeightedGraph
 #/   E : Entity
 #/   Weight : AttrType
 #/ morphism generators:
-#/   src : E -> V (Id Entity)
-#/   tgt : E -> V (Id Entity)
-#/   weight : E -> Weight (Attr)
+#/   src : E -> V : (Id Entity)
+#/   tgt : E -> V : (Id Entity)
+#/   weight : E -> Weight : Attr
 
 
 type EntityArr := [
@@ -162,10 +162,10 @@ generate Graph2
 #/   g1.E : Entity
 #/   g2.E : Entity
 #/ morphism generators:
-#/   g1.src : g1.E -> V (Id Entity)
-#/   g1.tgt : g1.E -> V (Id Entity)
-#/   g2.src : g2.E -> V (Id Entity)
-#/   g2.tgt : g2.E -> V (Id Entity)
+#/   g1.src : g1.E -> V : (Id Entity)
+#/   g1.tgt : g1.E -> V : (Id Entity)
+#/   g2.src : g2.E -> V : (Id Entity)
+#/   g2.tgt : g2.E -> V : (Id Entity)
 
 
 type ProfunctorGraph := [
@@ -183,11 +183,11 @@ generate ProfunctorGraph
 #/   g2.V : Entity
 #/   g2.E : Entity
 #/ morphism generators:
-#/   g1.src : g1.E -> g1.V (Id Entity)
-#/   g1.tgt : g1.E -> g1.V (Id Entity)
-#/   g2.src : g2.E -> g2.V (Id Entity)
-#/   g2.tgt : g2.E -> g2.V (Id Entity)
-#/   het : g1.V -> g2.V (Id Entity)
+#/   g1.src : g1.E -> g1.V : (Id Entity)
+#/   g1.tgt : g1.E -> g1.V : (Id Entity)
+#/   g2.src : g2.E -> g2.V : (Id Entity)
+#/   g2.tgt : g2.E -> g2.V : (Id Entity)
+#/   het : g1.V -> g2.V : (Id Entity)
 
 
 type WeightedGraph2 := [
@@ -206,12 +206,12 @@ generate WeightedGraph2
 #/   g2.E : Entity
 #/   g2.Weight : AttrType
 #/ morphism generators:
-#/   g1.src : g1.E -> V (Id Entity)
-#/   g1.tgt : g1.E -> V (Id Entity)
-#/   g1.weight : g1.E -> g1.Weight (Attr)
-#/   g2.src : g2.E -> V (Id Entity)
-#/   g2.tgt : g2.E -> V (Id Entity)
-#/   g2.weight : g2.E -> g2.Weight (Attr)
+#/   g1.src : g1.E -> V : (Id Entity)
+#/   g1.tgt : g1.E -> V : (Id Entity)
+#/   g1.weight : g1.E -> g1.Weight : Attr
+#/   g2.src : g2.E -> V : (Id Entity)
+#/   g2.tgt : g2.E -> V : (Id Entity)
+#/   g2.weight : g2.E -> g2.Weight : Attr
 
 
 set_theory ThCategory
@@ -256,8 +256,8 @@ generate NegFeedback
 #/   X : Object
 #/   Y : Object
 #/ morphism generators:
-#/   f : X -> Y (Id Object)
-#/   g : Y -> X (Negative)
+#/   f : X -> Y : (Id Object)
+#/   g : Y -> X : Negative
 
 
 #(should_fail)

--- a/packages/catlog/src/tt/modelgen.rs
+++ b/packages/catlog/src/tt/modelgen.rs
@@ -103,7 +103,7 @@ pub fn model_output(
     for morgen in model.mor_generators() {
         writeln!(
             out,
-            "{prefix}  {} : {} -> {} ({})",
+            "{prefix}  {} : {} -> {} : {}",
             name_translation.label(&morgen).unwrap(),
             name_translation.label(&model.mor_generator_dom(&morgen)).unwrap(),
             name_translation.label(&model.mor_generator_cod(&morgen)).unwrap(),

--- a/packages/catlog/src/tt/notebook_elab.rs
+++ b/packages/catlog/src/tt/notebook_elab.rs
@@ -378,9 +378,9 @@ mod test {
                   V : Entity
                   Weight : AttrType
                 morphism generators:
-                  weight : E -> Weight (Attr)
-                  src : E -> V (Id Entity)
-                  tgt : E -> V (Id Entity)
+                  weight : E -> Weight : Attr
+                  src : E -> V : (Id Entity)
+                  tgt : E -> V : (Id Entity)
             "#]],
         );
     }
@@ -398,7 +398,7 @@ mod test {
                   A : Entity
                   B : Entity
                 morphism generators:
-                  f : A -> B (Id Entity)
+                  f : A -> B : (Id Entity)
             "#]],
         );
     }

--- a/packages/catlog/src/tt/stx.rs
+++ b/packages/catlog/src/tt/stx.rs
@@ -20,18 +20,7 @@ pub struct MorphismType(pub Path<QualifiedName, QualifiedName>);
 
 impl fmt::Display for MorphismType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.0 {
-            Path::Id(ot) => write!(f, "Id {ot}"),
-            Path::Seq(non_empty) => {
-                for (i, segment) in non_empty.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, " · ")?;
-                    }
-                    write!(f, "{segment}")?;
-                }
-                Ok(())
-            }
-        }
+        write!(f, "{}", self.to_doc().group().pretty())
     }
 }
 


### PR DESCRIPTION
This required tweaking the pretty-printer for morphism generators in models, but IMO the new format is also a slight improvement over the old one.