### PR TITLE
Enable scrolling in sidebar

### DIFF
--- a/packages/frontend/src/page/sidebar_layout.css
+++ b/packages/frontend/src/page/sidebar_layout.css
@@ -39,6 +39,8 @@
 
 .sidebar.open {
     width: 240px;
+    display: flex;
+    flex-direction: column;
 }
 
 .sidebar.open .collapse-button {
@@ -58,6 +60,11 @@
     flex-direction: column;
     margin-left: 8px;
     margin-right: 8px;
+    min-height: 0;
+}
+
+.related-tree {
+    overflow-y: auto;
 }
 
 .sidebar-header {


### PR DESCRIPTION
done with assistance from claude code, mostly as an experiment to get to know both the code base and LLM capabilities. in testing it seems to work and be minimal for the behaviour i was aiming for. to be clear i'm not fluent with CSS and don't know whether this is the best solution (or that it is indeed a general solution). would love to know whether this sort of activity is/isn't useful. 

sorry in advance if this is junk.

observations: 
1. the height of the header element of the sidebar is slightly smaller than the height of the headers on the other panes. perhaps it would look nice to make it uniform, but perhaps it doesn't matter. 
2. I didn't add horizontal scrolling, unsure whether that's desired. possibly it is useful for documents that have long titles.

closes #939 