### PR TITLE
Increase maximum width of struct bodies in Rust code

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,3 +1,5 @@
 array_width = 80
 chain_width = 80
 fn_call_width = 80
+struct_lit_width = 40
+struct_variant_width = 40

--- a/packages/backend/src/auth.rs
+++ b/packages/backend/src/auth.rs
@@ -183,11 +183,7 @@ pub async fn permissions(ctx: &AppCtx, ref_id: Uuid) -> Result<Permissions, AppE
         );
     }
 
-    Ok(Permissions {
-        anyone,
-        user,
-        users,
-    })
+    Ok(Permissions { anyone, user, users })
 }
 
 /// A new set of permissions to assign to a document.

--- a/packages/backend/src/document.rs
+++ b/packages/backend/src/document.rs
@@ -416,11 +416,7 @@ pub async fn search_ref_stubs(
         })
         .collect();
 
-    Ok(Paginated {
-        total,
-        offset,
-        items,
-    })
+    Ok(Paginated { total, offset, items })
 }
 
 /// Gets ref stubs for children, where a child is defined as any document which

--- a/packages/backend/src/rpc.rs
+++ b/packages/backend/src/rpc.rs
@@ -56,11 +56,7 @@ async fn get_doc(ctx: AppCtx, ref_id: Uuid) -> RpcResult<RefDoc> {
             })
         } else if max_level >= Some(PermissionLevel::Read) {
             let binary_data = doc::head_snapshot_binary(ctx.state, ref_id).await?;
-            Ok(RefDoc::Readonly {
-                binary_data,
-                is_deleted,
-                permissions,
-            })
+            Ok(RefDoc::Readonly { binary_data, is_deleted, permissions })
         } else {
             Err(AppError::Forbidden(ref_id))
         }

--- a/packages/backend/src/user.rs
+++ b/packages/backend/src/user.rs
@@ -166,14 +166,7 @@ mod tests {
 
     #[test]
     fn validate_user_profile() {
-        assert!(
-            UserProfile {
-                username: None,
-                display_name: None
-            }
-            .validate()
-            .is_ok()
-        );
+        assert!(UserProfile { username: None, display_name: None }.validate().is_ok());
 
         assert!(
             UserProfile {

--- a/packages/catlog-wasm/src/model.rs
+++ b/packages/catlog-wasm/src/model.rs
@@ -93,17 +93,14 @@ impl CanElaborate<Mor, TabMor> for Elaborator {
                     path.try_map(|ob| Elaborator.elab(&ob), |mor| Elaborator.elab(&mor))
                 })
                 .map(|path| path.flatten()),
-            Mor::TabulatorSquare {
-                dom,
-                cod,
-                pre,
-                post,
-            } => Ok(Path::single(dbl_model::TabEdge::Square {
-                dom: Box::new(Elaborator.elab(dom.as_ref())?),
-                cod: Box::new(Elaborator.elab(cod.as_ref())?),
-                pre: Box::new(Elaborator.elab(pre.as_ref())?),
-                post: Box::new(Elaborator.elab(post.as_ref())?),
-            })),
+            Mor::TabulatorSquare { dom, cod, pre, post } => {
+                Ok(Path::single(dbl_model::TabEdge::Square {
+                    dom: Box::new(Elaborator.elab(dom.as_ref())?),
+                    cod: Box::new(Elaborator.elab(cod.as_ref())?),
+                    pre: Box::new(Elaborator.elab(pre.as_ref())?),
+                    post: Box::new(Elaborator.elab(post.as_ref())?),
+                }))
+            }
         }
     }
 }
@@ -112,12 +109,7 @@ impl CanElaborate<Mor, TabEdge> for Elaborator {
     fn elab(&self, mor: &Mor) -> Result<TabEdge, String> {
         match mor {
             Mor::Basic(name) => Ok(TabEdge::Basic(QualifiedName::deserialize_str(name)?)),
-            Mor::TabulatorSquare {
-                dom,
-                cod,
-                pre,
-                post,
-            } => Ok(TabEdge::Square {
+            Mor::TabulatorSquare { dom, cod, pre, post } => Ok(TabEdge::Square {
                 dom: Box::new(Elaborator.elab(dom.as_ref())?),
                 cod: Box::new(Elaborator.elab(cod.as_ref())?),
                 pre: Box::new(Elaborator.elab(pre.as_ref())?),
@@ -215,12 +207,7 @@ impl CanQuote<TabEdge, Mor> for Quoter {
     fn quote(&self, ob: &TabEdge) -> Mor {
         match ob {
             TabEdge::Basic(name) => Mor::Basic(name.serialize_string()),
-            TabEdge::Square {
-                dom,
-                cod,
-                pre,
-                post,
-            } => Mor::TabulatorSquare {
+            TabEdge::Square { dom, cod, pre, post } => Mor::TabulatorSquare {
                 dom: Box::new(self.quote(dom.as_ref())),
                 cod: Box::new(self.quote(cod.as_ref())),
                 pre: Box::new(self.quote(pre.as_ref())),
@@ -576,13 +563,7 @@ impl DblModel {
                  Quoter.quote(model.get_cod(&id)?))
             }
         });
-        Some(MorGenerator {
-            id,
-            label,
-            mor_type,
-            dom,
-            cod,
-        })
+        Some(MorGenerator { id, label, mor_type, dom, cod })
     }
 
     /// Constructs a serializable presentation of the model.

--- a/packages/catlog-wasm/src/model_diagram.rs
+++ b/packages/catlog-wasm/src/model_diagram.rs
@@ -196,12 +196,7 @@ impl DblModelDiagram {
                  Quoter.quote(mapping.0.ob_generator_map.get(&id)?))
             }
         });
-        Some(DiagramObGenerator {
-            id,
-            label,
-            ob_type,
-            over,
-        })
+        Some(DiagramObGenerator { id, label, ob_type, over })
     }
 
     /// Gets a morphism generator as it appears in the diagram's presentation.
@@ -216,13 +211,7 @@ impl DblModelDiagram {
                  Quoter.quote(model.get_cod(&id)?))
             }
         });
-        Some(DiagramMorGenerator {
-            id,
-            mor_type,
-            over,
-            dom,
-            cod,
-        })
+        Some(DiagramMorGenerator { id, mor_type, over, dom, cod })
     }
 
     /// Constructs a serializable presentation of the diagram.

--- a/packages/catlog-wasm/src/model_morphism.rs
+++ b/packages/catlog-wasm/src/model_morphism.rs
@@ -44,10 +44,7 @@ impl MotifOccurrence {
                 mor_generators.insert(e);
             }
         }
-        Self {
-            ob_generators,
-            mor_generators,
-        }
+        Self { ob_generators, mor_generators }
     }
 }
 

--- a/packages/catlog/src/dbl/discrete_tabulator/model.rs
+++ b/packages/catlog/src/dbl/discrete_tabulator/model.rs
@@ -108,12 +108,7 @@ impl Graph for DiscreteTabGenerators {
             TabEdge::Basic(e) => {
                 self.morphisms.contains(e) && self.dom.is_set(e) && self.cod.is_set(e)
             }
-            TabEdge::Square {
-                dom,
-                cod,
-                pre,
-                post,
-            } => {
+            TabEdge::Square { dom, cod, pre, post } => {
                 if !(dom.contained_in(self) && cod.contained_in(self)) {
                     return false;
                 }
@@ -371,12 +366,9 @@ impl PrintableDblModel for DiscreteTabModel {
 fn edge_to_doc<'a>(edge: &TabEdge, mor_ns: &Namespace) -> D<'a> {
     match edge {
         TabEdge::Basic(name) => t(mor_ns.label_string(name)),
-        TabEdge::Square {
-            dom: _,
-            cod: _,
-            pre,
-            post,
-        } => tuple([edge_to_doc(pre, mor_ns), edge_to_doc(post, mor_ns)]),
+        TabEdge::Square { dom: _, cod: _, pre, post } => {
+            tuple([edge_to_doc(pre, mor_ns), edge_to_doc(post, mor_ns)])
+        }
     }
 }
 

--- a/packages/catlog/src/dbl/discrete_tabulator/theory.rs
+++ b/packages/catlog/src/dbl/discrete_tabulator/theory.rs
@@ -316,10 +316,7 @@ impl VDCWithComposites for DiscreteTabTheory {
     }
 
     fn composite_ext(&self, path: Path<Self::Ob, Self::Pro>) -> Option<Self::Cell> {
-        Some(TabMorOp {
-            dom: path,
-            projections: vec![],
-        })
+        Some(TabMorOp { dom: path, projections: vec![] })
     }
 
     fn through_composite(&self, cell: Self::Cell, range: Range<usize>) -> Option<Self::Cell> {

--- a/packages/catlog/src/dbl/modal/theory.rs
+++ b/packages/catlog/src/dbl/modal/theory.rs
@@ -117,10 +117,7 @@ pub struct ModeApp<T> {
 impl<T> ModeApp<T> {
     /// Constructs a new term with no modalities applied.
     pub fn new(arg: T) -> Self {
-        Self {
-            arg,
-            modalities: Default::default(),
-        }
+        Self { arg, modalities: Default::default() }
     }
 
     /// Converts from `&ModeApp<T>` to `ModeApp<&T>`.
@@ -154,10 +151,7 @@ impl<T> ModeApp<T> {
     /// Maps over the argument.
     pub fn map<S, F: FnOnce(T) -> S>(self, f: F) -> ModeApp<S> {
         let ModeApp { arg, modalities } = self;
-        ModeApp {
-            arg: f(arg),
-            modalities,
-        }
+        ModeApp { arg: f(arg), modalities }
     }
 
     /// Maps over the argument, flattening nested applications.

--- a/packages/catlog/src/one/fp_category.rs
+++ b/packages/catlog/src/one/fp_category.rs
@@ -413,10 +413,7 @@ impl<V, E> CategoryProgramBuilder<V, E> {
             span!(),
             Box::new(Schedule::Run(
                 span!(),
-                GenericRunConfig {
-                    ruleset: self.sym.axioms,
-                    until: None,
-                },
+                GenericRunConfig { ruleset: self.sym.axioms, until: None },
             )),
         )
     }
@@ -450,30 +447,21 @@ impl<V, E> CategoryProgramBuilder<V, E> {
             Command::Constructor {
                 span: span!(),
                 name: sym.dom,
-                schema: Schema {
-                    input: vec![sym.mor],
-                    output: sym.ob,
-                },
+                schema: Schema { input: vec![sym.mor], output: sym.ob },
                 cost: Some(1),
                 unextractable: false,
             },
             Command::Constructor {
                 span: span!(),
                 name: sym.cod,
-                schema: Schema {
-                    input: vec![sym.mor],
-                    output: sym.ob,
-                },
+                schema: Schema { input: vec![sym.mor], output: sym.ob },
                 cost: Some(1),
                 unextractable: false,
             },
             Command::Constructor {
                 span: span!(),
                 name: sym.id,
-                schema: Schema {
-                    input: vec![sym.ob],
-                    output: sym.mor,
-                },
+                schema: Schema { input: vec![sym.ob], output: sym.mor },
                 cost: Some(1),
                 unextractable: false,
             },

--- a/packages/catlog/src/one/tree_algorithms.rs
+++ b/packages/catlog/src/one/tree_algorithms.rs
@@ -33,11 +33,7 @@ impl<'a, T: 'a> BreadthFirstTraversal<'a, T> {
         let tree = root.tree();
         let mut queue = VecDeque::new();
         queue.push_back((root.id(), 1));
-        Self {
-            tree,
-            queue,
-            current_level: 0,
-        }
+        Self { tree, queue, current_level: 0 }
     }
 
     /// Peeks at the next node, if it's at the same level as the previous one.

--- a/packages/catlog/src/simulate/ode/lotka_volterra.rs
+++ b/packages/catlog/src/simulate/ode/lotka_volterra.rs
@@ -20,10 +20,7 @@ pub struct LotkaVolterraSystem {
 impl LotkaVolterraSystem {
     /// Constructs a new Lokta-Volterra system with the given parameters.
     pub fn new(A: DMatrix<f32>, b: DVector<f32>) -> Self {
-        Self {
-            interaction_coeffs: A,
-            growth_rates: b,
-        }
+        Self { interaction_coeffs: A, growth_rates: b }
     }
 }
 

--- a/packages/catlog/src/simulate/ode/polynomial.rs
+++ b/packages/catlog/src/simulate/ode/polynomial.rs
@@ -111,10 +111,7 @@ where
                     var
                 };
                 let lhs = format!("\\frac{{\\mathrm{{d}}}}{{\\mathrm{{d}}t}} {var}");
-                LatexEquation {
-                    lhs,
-                    rhs: poly.to_latex(),
-                }
+                LatexEquation { lhs, rhs: poly.to_latex() }
             })
             .collect()
     }

--- a/packages/catlog/src/stdlib/analyses/ode/kuramoto.rs
+++ b/packages/catlog/src/stdlib/analyses/ode/kuramoto.rs
@@ -150,10 +150,7 @@ impl KuramotoAnalysis {
             ob_ids().map(|id| common.initial_phases.get(id).copied().unwrap_or_default());
         let initial_values = match data {
             KuramotoProblemData::FirstOrder(_) => DVector::from_iterator(n, initial_phases),
-            KuramotoProblemData::SecondOrder {
-                initial_frequencies,
-                ..
-            } => {
+            KuramotoProblemData::SecondOrder { initial_frequencies, .. } => {
                 let initial_frequencies =
                     ob_ids().map(|id| initial_frequencies.get(id).copied().unwrap_or_default());
                 DVector::from_iterator(2 * n, initial_phases.chain(initial_frequencies))

--- a/packages/catlog/src/tt/context.rs
+++ b/packages/catlog/src/tt/context.rs
@@ -44,10 +44,7 @@ impl Default for Context {
 impl Context {
     /// Create an empty context.
     pub fn new() -> Self {
-        Self {
-            env: Env::Nil,
-            scope: Vec::new(),
-        }
+        Self { env: Env::Nil, scope: Vec::new() }
     }
 
     /// Create a checkpoint from the current state of the context.

--- a/packages/catlog/src/tt/eval.rs
+++ b/packages/catlog/src/tt/eval.rs
@@ -35,10 +35,7 @@ impl<'a> Evaluator<'a> {
 
     /// Return a new [Evaluator] with environment `env`
     pub fn with_env(&self, env: Env) -> Self {
-        Self {
-            env,
-            ..self.clone()
-        }
+        Self { env, ..self.clone() }
     }
 
     /// Evaluate type syntax to produce a type value

--- a/packages/catlog/src/tt/modelgen.rs
+++ b/packages/catlog/src/tt/modelgen.rs
@@ -182,11 +182,7 @@ impl<'a> ModelGenerator<'a> {
         let eval = Evaluator::new(toplevel, Env::Nil, 0);
         let theory = theory.clone();
         let model = Model::new(&theory);
-        Self {
-            eval,
-            theory,
-            model,
-        }
+        Self { eval, theory, model }
     }
 
     fn generate(&mut self, ty: &TyV) -> Namespace {

--- a/packages/catlog/src/tt/notebook_elab.rs
+++ b/packages/catlog/src/tt/notebook_elab.rs
@@ -67,9 +67,7 @@ impl<'a> Elaborator<'a> {
     }
 
     fn checkpoint(&self) -> ElaboratorCheckpoint {
-        ElaboratorCheckpoint {
-            ctx: self.ctx.checkpoint(),
-        }
+        ElaboratorCheckpoint { ctx: self.ctx.checkpoint() }
     }
 
     fn reset_to(&mut self, c: ElaboratorCheckpoint) {

--- a/packages/catlog/src/tt/text_elab.rs
+++ b/packages/catlog/src/tt/text_elab.rs
@@ -44,10 +44,7 @@ pub struct TopElaborator {
 impl TopElaborator {
     /// Constructs a context for top-level elaboration.
     pub fn new(reporter: Reporter) -> Self {
-        Self {
-            current_theory: None,
-            reporter,
-        }
+        Self { current_theory: None, reporter }
     }
 
     fn bare_def<'c>(&self, n: &FNtn<'c>) -> Option<(TopVarName, &'c FNtn<'c>)> {

--- a/packages/catlog/src/zero/column.rs
+++ b/packages/catlog/src/zero/column.rs
@@ -267,10 +267,7 @@ impl<T> IntoIterator for VecColumn<T> {
     type IntoIter = VecColumnIter<T>;
 
     fn into_iter(self) -> Self::IntoIter {
-        VecColumnIter {
-            vec: self.0,
-            index: 0,
-        }
+        VecColumnIter { vec: self.0, index: 0 }
     }
 }
 

--- a/packages/notebook-types/src/v1/notebook.rs
+++ b/packages/notebook-types/src/v1/notebook.rs
@@ -51,9 +51,6 @@ impl<T> Notebook<T> {
             cell_contents.insert(id, old_cell);
         }
 
-        Notebook {
-            cell_contents,
-            cell_order,
-        }
+        Notebook { cell_contents, cell_order }
     }
 }


### PR DESCRIPTION
Fixing a longstanding annoyance for me. The default value of 18 characters for [`struct_lit_width`](https://rust-lang.github.io/rustfmt/?version=v1.8.0&search=#struct_lit_width) in `rustfmt` causes far too many line breaks for my taste.