### PR TITLE
Configure lints from `Cargo.toml` instead of top-level module

### DIFF
--- a/packages/backend/Cargo.toml
+++ b/packages/backend/Cargo.toml
@@ -47,3 +47,6 @@ tower-http = { version = "0.6.1", features = ["cors", "trace", "fs"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 uuid = { version = "1.10.0", features = ["v7", "serde"] }
+
+[lints.rust]
+missing_docs = "warn"

--- a/packages/backend/src/lib.rs
+++ b/packages/backend/src/lib.rs
@@ -1,1 +1,3 @@
+//! Reusable components of the backend.
+
 pub mod storage;

--- a/packages/backend/src/main.rs
+++ b/packages/backend/src/main.rs
@@ -1,5 +1,6 @@
-use axum::extract::Request;
+//! Main entry point for the CatColab backend.
 
+use axum::extract::Request;
 use axum::extract::ws::WebSocketUpgrade;
 use axum::middleware::from_fn_with_state;
 use axum::{Router, routing::get};

--- a/packages/backend/src/storage/mod.rs
+++ b/packages/backend/src/storage/mod.rs
@@ -1,4 +1,7 @@
+//! Storage adapters for Automerge.
+
 mod postgres;
+#[allow(missing_docs)]
 pub mod testing;
 
 pub use postgres::PostgresStorage;

--- a/packages/backend/src/storage/postgres.rs
+++ b/packages/backend/src/storage/postgres.rs
@@ -19,6 +19,7 @@ pub struct PostgresStorage {
 }
 
 impl PostgresStorage {
+    /// Constructs a new PostgreSQL storage adapter.
     pub fn new(pool: PgPool) -> Self {
         Self { pool }
     }

--- a/packages/backend/tests/postgres_storage_tests.rs
+++ b/packages/backend/tests/postgres_storage_tests.rs
@@ -1,3 +1,5 @@
+//! Tests the Postgres storage adapter for Automerge.
+
 use backend::storage::{PostgresStorage, testing};
 use sqlx::PgPool;
 

--- a/packages/catlog-wasm/Cargo.toml
+++ b/packages/catlog-wasm/Cargo.toml
@@ -28,3 +28,6 @@ wasm-bindgen = "0.2.106"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.50"
+
+[lints.rust]
+missing_docs = "warn"

--- a/packages/catlog-wasm/src/lib.rs
+++ b/packages/catlog-wasm/src/lib.rs
@@ -9,8 +9,6 @@
 //! same is true for other structures, such as models of theories and diagrams in
 //! models.
 
-#![warn(missing_docs)]
-
 pub mod notation;
 pub mod result;
 

--- a/packages/catlog/Cargo.toml
+++ b/packages/catlog/Cargo.toml
@@ -50,3 +50,8 @@ serde_json = "1.0.145"
 
 [[example]]
 name = "tt"
+
+[lints.rust]
+missing_docs = "warn"
+mixed_script_confusables = "allow"
+confusable_idents = "allow"

--- a/packages/catlog/examples/tt/main.rs
+++ b/packages/catlog/examples/tt/main.rs
@@ -1,3 +1,5 @@
+//! Command-line program to run DoubleTT in interactive mode.
+
 use catlog::tt::batch::{self, BatchOutput};
 
 use notify::RecursiveMode;

--- a/packages/catlog/src/lib.rs
+++ b/packages/catlog/src/lib.rs
@@ -16,11 +16,6 @@
 //! sufficiently useful in their own right, they may be spun off into their own
 //! crates.
 
-// Unicode identifiers.
-#![allow(mixed_script_confusables)]
-#![allow(confusable_idents)]
-#![warn(missing_docs)]
-
 #[cfg(doc)]
 pub mod refs;
 

--- a/packages/catlog/src/tt/batch.rs
+++ b/packages/catlog/src/tt/batch.rs
@@ -122,7 +122,6 @@ impl BatchOutput {
         }
     }
 
-    #[allow(unused)]
     /// Get the result of a snapshot test
     pub fn result<'a>(&'a self) -> Ref<'a, String> {
         match self {


### PR DESCRIPTION
This seems cleaner and more idiomatic.