### PR TITLE
Enable clippy lint `doc_paragraphs_missing_punctuation`

### DIFF
--- a/packages/backend/Cargo.toml
+++ b/packages/backend/Cargo.toml
@@ -50,3 +50,6 @@ uuid = { version = "1.10.0", features = ["v7", "serde"] }
 
 [lints.rust]
 missing_docs = "warn"
+
+[lints.clippy]
+doc_paragraphs_missing_punctuation = "warn"

--- a/packages/backend/src/app.rs
+++ b/packages/backend/src/app.rs
@@ -15,10 +15,10 @@ pub struct AppState {
     /// Connection to the Postgres database.
     pub db: PgPool,
 
-    /// Automerge-repo provider
+    /// Automerge-repo provider.
     pub repo: samod::Repo,
 
-    /// Tracks which ref_ids have active autosave listeners to prevent duplicates
+    /// Tracks which ref_ids have active autosave listeners to prevent duplicates.
     pub active_listeners: Arc<RwLock<HashSet<Uuid>>>,
 }
 

--- a/packages/backend/src/auth.rs
+++ b/packages/backend/src/auth.rs
@@ -51,9 +51,9 @@ impl Permissions {
     }
 }
 
-/// Returns an error if the user_id in the session does not exist in the DB, returns None otherwise
+/// Returns an error if the user_id in the session does not exist in the DB, returns None otherwise.
 ///
-/// Used by the client to gracefully handle stale sessions
+/// Used by the client to gracefully handle stale sessions.
 pub async fn validate_session(ctx: AppCtx) -> Result<(), AppError> {
     let user_id = match ctx.user.as_ref().map(|u| u.user_id.clone()) {
         Some(id) => id,

--- a/packages/backend/src/automerge_json.rs
+++ b/packages/backend/src/automerge_json.rs
@@ -9,7 +9,7 @@ use samod::DocHandle;
 use serde_json::Value;
 use uuid::Uuid;
 
-/// Insert a JSON value into a map property
+/// Insert a JSON value into a map property.
 fn insert_value_into_map<'a>(
     tx: &mut automerge::transaction::Transaction<'a>,
     parent: &automerge::ObjId,
@@ -51,7 +51,7 @@ fn insert_value_into_map<'a>(
     Ok(())
 }
 
-/// Insert a JSON value into a list at index
+/// Insert a JSON value into a list at index.
 fn insert_value_into_list<'a>(
     tx: &mut automerge::transaction::Transaction<'a>,
     parent: &automerge::ObjId,
@@ -122,7 +122,7 @@ pub(crate) fn populate_automerge_from_json<'a>(
     Ok(())
 }
 
-/// Convert automerge hydrate::Value to serde_json::Value
+/// Convert automerge hydrate::Value to serde_json::Value.
 pub(crate) fn hydrate_to_json(value: &hydrate::Value) -> Value {
     match value {
         hydrate::Value::Scalar(s) => scalar_to_json(s),

--- a/packages/backend/src/document.rs
+++ b/packages/backend/src/document.rs
@@ -270,7 +270,7 @@ pub struct RefStub {
     pub created_at: DateTime<Utc>,
 }
 
-/// Parameters for filtering a search of refs
+/// Parameters for filtering a search of refs.
 #[qubit::ts]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RefQueryParams {
@@ -290,7 +290,7 @@ pub struct RefQueryParams {
 }
 
 /// Searches for `RefStub`s that the current user has permission to access,
-/// returning lightweight metadata about each matching ref
+/// returning lightweight metadata about each matching ref.
 pub async fn search_ref_stubs(
     ctx: AppCtx,
     search_params: RefQueryParams,

--- a/packages/backend/src/main.rs
+++ b/packages/backend/src/main.rs
@@ -43,11 +43,11 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Command {
-    /// Run database migrations (proxied to sqlx_migrator)
+    /// Run database migrations (proxied to sqlx_migrator).
     Migrator(MigrationCommand),
-    /// Start the web server (default)
+    /// Start the web server (default).
     Serve,
-    /// Generate TypeScript bindings for the RPC API
+    /// Generate TypeScript bindings for the RPC API.
     GenerateBindings,
 }
 

--- a/packages/backend/src/storage/postgres.rs
+++ b/packages/backend/src/storage/postgres.rs
@@ -2,7 +2,7 @@ use samod::storage::{Storage, StorageKey};
 use sqlx::PgPool;
 use std::collections::HashMap;
 
-/// A PostgreSQL-backed storage adapter for samod
+/// A PostgreSQL-backed storage adapter for samod.
 ///
 /// ## Database Schema
 ///

--- a/packages/backend/src/storage/testing.rs
+++ b/packages/backend/src/storage/testing.rs
@@ -1,7 +1,7 @@
-//! Storage adapter testing utilities
+//! Storage adapter testing utilities.
 //!
-//! rewritten from:
-//! automerge-repo/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts
+//! Rewritten from:
+//! `automerge-repo/packages/automerge-repo/src/helpers/tests/storage-adapter-tests.ts`.
 //!
 //! Provides a test suite for any implementation of the `Storage` trait.
 //! Based on the TypeScript `runStorageAdapterTests` from automerge-repo.
@@ -36,24 +36,24 @@ pub fn large_payload() -> Vec<u8> {
     LARGE_PAYLOAD.clone()
 }
 
-/// Trait for storage test fixtures
+/// Trait for storage test fixtures.
 pub trait StorageTestFixture: Sized + Send {
-    /// The storage type being tested
+    /// The storage type being tested.
     type Storage: Storage + Send + Sync + 'static;
 
-    /// Setup the test fixture
+    /// Setup the test fixture.
     fn setup() -> impl std::future::Future<Output = Self> + Send;
 
-    /// Get reference to the storage adapter
+    /// Get reference to the storage adapter.
     fn storage(&self) -> &Self::Storage;
 
-    /// Optional cleanup
+    /// Optional cleanup.
     fn teardown(self) -> impl std::future::Future<Output = ()> + Send {
         async {}
     }
 }
 
-/// Helper to run a single test with setup and teardown
+/// Helper to run a single test with setup and teardown.
 async fn run_test<F, TestFn>(test_fn: TestFn)
 where
     F: StorageTestFixture,
@@ -64,7 +64,7 @@ where
     fixture.teardown().await;
 }
 
-/// Run all storage adapter acceptance tests
+/// Run all storage adapter acceptance tests.
 pub async fn run_storage_adapter_tests<F: StorageTestFixture>() {
     run_test::<F, _>(|a| Box::pin(test_load_should_return_none_if_no_data(a))).await;
     run_test::<F, _>(|a| Box::pin(test_save_and_load_should_return_data_that_was_saved(a))).await;

--- a/packages/backend/src/user.rs
+++ b/packages/backend/src/user.rs
@@ -142,7 +142,7 @@ impl UserProfile {
 
 /// Is the proposed user name valid?
 ///
-/// A username is **valid** when it
+/// A username is **valid** when it:
 ///
 /// - is nonempty
 /// - comprises ASCII alphanumeric characters, dashes, dots, and underscores

--- a/packages/catlog-wasm/Cargo.toml
+++ b/packages/catlog-wasm/Cargo.toml
@@ -31,3 +31,6 @@ wasm-bindgen-test = "0.3.50"
 
 [lints.rust]
 missing_docs = "warn"
+
+[lints.clippy]
+doc_paragraphs_missing_punctuation = "warn"

--- a/packages/catlog-wasm/src/analyses.rs
+++ b/packages/catlog-wasm/src/analyses.rs
@@ -12,13 +12,13 @@ use catlog::stdlib::analyses;
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub struct ODEResult(pub JsResult<analyses::ode::ODESolution, String>);
 
-/// The result of an ODE analysis including equations in LaTex with subsititutions
+/// The result of an ODE analysis including equations in LaTex with subsititutions.
 #[derive(Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub struct ODEResultWithEquations {
-    /// The result of the simulation
+    /// The result of the simulation.
     pub solution: JsResult<analyses::ode::ODESolution, String>,
-    /// The equations in LaTeX format with parameters substituted
+    /// The equations in LaTeX format with parameters substituted.
     #[serde(rename = "latexEquations")]
     pub latex_equations: Vec<LatexEquation>,
 }

--- a/packages/catlog-wasm/src/result.rs
+++ b/packages/catlog-wasm/src/result.rs
@@ -5,10 +5,9 @@ use tsify::Tsify;
 
 /// A `Result`-like type that translates to/from JavaScript.
 ///
-/// In `wasm-bindgen`, returning a [`Result`] raises an exception in JavaScript when
-/// the `Err` variant is given:
-///
-/// <https://rustwasm.github.io/docs/wasm-bindgen/reference/types/result.html>
+/// In `wasm-bindgen`, returning a [`Result`] raises an exception in JavaScript
+/// when the `Err` variant is given:
+/// <https://rustwasm.github.io/docs/wasm-bindgen/reference/types/result.html>.
 ///
 /// When an error should be handled in the UI, it is more convenient to return an
 /// error value than to raise an exception. That's what this enum does. It is
@@ -17,10 +16,10 @@ use tsify::Tsify;
 #[serde(tag = "tag", content = "content")]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub enum JsResult<T, E> {
-    /// Contains the success value
+    /// Contains the success value.
     Ok(T),
 
-    /// Contains the error value
+    /// Contains the error value.
     Err(E),
 }
 

--- a/packages/catlog/Cargo.toml
+++ b/packages/catlog/Cargo.toml
@@ -55,3 +55,6 @@ name = "tt"
 missing_docs = "warn"
 mixed_script_confusables = "allow"
 confusable_idents = "allow"
+
+[lints.clippy]
+doc_paragraphs_missing_punctuation = "warn"

--- a/packages/catlog/src/dbl/category.rs
+++ b/packages/catlog/src/dbl/category.rs
@@ -63,7 +63,7 @@ pub trait VDblCategory {
     /// Type of proarrows (loose morphisms) in the VDC.
     type Pro: Eq + Clone;
 
-    /// Type of cells in the VDC;
+    /// Type of cells in the VDC.
     type Cell: Eq + Clone;
 
     /// Does the object belong to the VDC?

--- a/packages/catlog/src/dbl/discrete/theory.rs
+++ b/packages/catlog/src/dbl/discrete/theory.rs
@@ -14,7 +14,7 @@ use crate::zero::QualifiedName;
 ///
 /// A **discrete double theory** is a double theory with no nontrivial operations on
 /// either object or morphism types. Viewed as a double category, such a theory is
-/// indeed **discrete**, which can equivalently be defined as
+/// indeed **discrete**, which can equivalently be defined as:
 ///
 /// - a discrete object in the 2-category of double categories
 /// - a double category whose underlying categories are both discrete categories

--- a/packages/catlog/src/dbl/discrete_tabulator/theory.rs
+++ b/packages/catlog/src/dbl/discrete_tabulator/theory.rs
@@ -102,7 +102,7 @@ impl TabMorProj {
         }
     }
 
-    /// Target projection
+    /// Target projection.
     fn tgt(self) -> TabObProj {
         match self {
             TabMorProj::Src(m) => TabObProj::Src(m),

--- a/packages/catlog/src/dbl/model.rs
+++ b/packages/catlog/src/dbl/model.rs
@@ -292,24 +292,24 @@ pub enum InvalidDblModel {
     /// Equation between morphisms has one or more errors.
     Eq(usize, NonEmpty<InvalidPathEq>),
 
-    /// Tried to us a feature not yet supported by the elaborator
+    /// Tried to us a feature not yet supported by the elaborator.
     UnsupportedFeature(Feature),
 
-    /// No link provided for instantiation cell, or wrong type of link
+    /// No link provided for instantiation cell, or wrong type of link.
     InvalidLink(QualifiedName),
 }
 
-/// Various features that the new elaboration does not yet support
+/// Various features that the new elaboration does not yet support.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(tag = "tag", content = "content"))]
 #[cfg_attr(feature = "serde-wasm", derive(Tsify))]
 #[cfg_attr(feature = "serde-wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum Feature {
-    /// Modal theories
+    /// Modal theories.
     Modal,
-    /// Tabulator theories
+    /// Tabulator theories.
     Tabulator,
-    /// Morphism types given by composites of generators
+    /// Morphism types given by composites of generators.
     CompositeMorType,
 }

--- a/packages/catlog/src/one/category.rs
+++ b/packages/catlog/src/one/category.rs
@@ -192,7 +192,7 @@ pub trait FgCategory: Category {
     /// In simple cases, `Ob = ObGen`.
     type ObGen: Eq + Clone + Into<Self::Ob>;
 
-    /// Type of a morphism generator
+    /// Type of a morphism generator.
     ///
     /// Often `Mor = Path<Ob, MorGen>`.
     type MorGen: Eq + Clone + Into<Self::Mor>;
@@ -203,10 +203,10 @@ pub trait FgCategory: Category {
     /// Iterates over morphism generators.
     fn mor_generators(&self) -> impl Iterator<Item = Self::MorGen>;
 
-    /// The domain of a morphism generator
+    /// The domain of a morphism generator.
     fn mor_generator_dom(&self, f: &Self::MorGen) -> Self::Ob;
 
-    /// The codomain of a morphism generator
+    /// The codomain of a morphism generator.
     fn mor_generator_cod(&self, f: &Self::MorGen) -> Self::Ob;
 
     /// Iterates over basic objects.

--- a/packages/catlog/src/one/functor.rs
+++ b/packages/catlog/src/one/functor.rs
@@ -317,7 +317,7 @@ mod tests {
 
     /// Isomorphism b/w the schemas for half-edge graphs and symmetric graphs.
     ///
-    /// Reference: https://blog.algebraicjulia.org/post/2020/09/cset-graphs-2/
+    /// Reference: <https://blog.algebraicjulia.org/post/2020/09/cset-graphs-2/>.
     #[test]
     fn sch_sgraph_to_hgraph() {
         let (sch_hgraph, sch_sgraph) = (sch_hgraph(), sch_sgraph());

--- a/packages/catlog/src/one/graph_algorithms.rs
+++ b/packages/catlog/src/one/graph_algorithms.rs
@@ -167,7 +167,7 @@ where
 /// Computes a topological sorting for a given graph.
 ///
 /// This toposort algorithm was borrowed from the crate `petgraph`, found
-/// [here](https://github.com/petgraph/petgraph/blob/4d807c19304c02c9dd687c68577f75aefcb98491/src/algo/mod.rs#L204)
+/// [here](https://github.com/petgraph/petgraph/blob/4d807c19304c02c9dd687c68577f75aefcb98491/src/algo/mod.rs#L204).
 pub fn toposort<G>(graph: &G) -> Result<Vec<G::V>, String>
 where
     G: FinGraph,

--- a/packages/catlog/src/one/tree_algorithms.rs
+++ b/packages/catlog/src/one/tree_algorithms.rs
@@ -66,7 +66,7 @@ impl<'a, T: 'a> std::iter::FusedIterator for BreadthFirstTraversal<'a, T> {}
 
 impl<'a, T: 'a> TreeTraversal<T> for NodeRef<'a, T> {
     /// Uses the built-in traversal algorithm, which is depth-first, though that
-    /// is not documented: <https://github.com/rust-scraper/ego-tree/issues/38>
+    /// is not documented: <https://github.com/rust-scraper/ego-tree/issues/38>.
     fn dfs(&self) -> Descendants<'a, T> {
         self.descendants()
     }

--- a/packages/catlog/src/stdlib/analyses/ode/mass_action.rs
+++ b/packages/catlog/src/stdlib/analyses/ode/mass_action.rs
@@ -43,7 +43,7 @@ pub struct MassActionProblemData {
     pub duration: f32,
 }
 
-/// Data defining the stochastic mass-action ODE problem
+/// Data defining the stochastic mass-action ODE problem.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde-wasm", derive(Tsify))]
 #[cfg_attr(

--- a/packages/catlog/src/stdlib/analyses/reachability.rs
+++ b/packages/catlog/src/stdlib/analyses/reachability.rs
@@ -126,7 +126,9 @@ mod tests {
     use crate::zero::name;
     use std::rc::Rc;
 
-    /// The example petri net has the following structure
+    /// The example Petri net has the following structure:
+    ///
+    /// ```text
     ///                      t1 t2  t3   
     /// let i_mat = vec![vec![0, 1, 0],  p1
     ///                  vec![0, 1, 0],  p2
@@ -135,18 +137,21 @@ mod tests {
     /// let o_mat = vec![vec![1, 0, 0],  p1
     ///                  vec![0, 0, 1],  p2
     ///                  vec![0, 1, 0]]; p3
+    /// ```
     ///
-    /// (WARNING: the petri net is drawn incorrectly in Handbook of Model Checking)
+    /// **Warning**: the Petri net is drawn incorrectly in Handbook of Model
+    /// Checking.
     ///
     /// Let the forbidden state be (0,0,2).
     ///
     /// The algorithm terminates in four steps:
     /// [(0,0,2)] -> [(0,0,2),(1,1,1)] -> [(0,0,2),(0,1,1),(2,2,0)]
-    /// -> [(0,0,2),(0,1,1),(0,2,0)]
+    /// -> [(0,0,2),(0,1,1),(0,2,0)].
+    ///
     /// So the three ways one can reach the forbidden state are:
-    /// 1.) starting in the forbidden state (or any superset)
-    /// 2.) having two tokens in p2
-    /// 3.) having one token in each p2 and p3
+    /// 1. starting in the forbidden state (or any superset)
+    /// 2. having two tokens in p2
+    /// 3. having one token in each p2 and p3
     ///
     /// Consider using algorithm from "Minimal Coverability Tree Construction
     /// Made Complete and Efficient" for a more efficient algorithm which allows

--- a/packages/catlog/src/stdlib/theories.rs
+++ b/packages/catlog/src/stdlib/theories.rs
@@ -122,7 +122,7 @@ pub fn th_category_links() -> DiscreteTabTheory {
 /// The theory of categories with signed links.
 ///
 /// It can be useful to consider a version of stock and flow diagrams where the
-/// links are labelled with a sign: positive or negative
+/// links are labelled with a sign: positive or negative.
 pub fn th_category_signed_links() -> DiscreteTabTheory {
     let mut th = DiscreteTabTheory::new();
     th.add_ob_type(name("Object"));

--- a/packages/catlog/src/tt/batch.rs
+++ b/packages/catlog/src/tt/batch.rs
@@ -16,11 +16,11 @@ use crate::zero::NameSegment;
 
 declare_error!(TOP_ERROR, "top", "an error at the top-level");
 
-/// An enum to configure the output of batch processing
+/// An enum to configure the output of batch processing.
 pub enum BatchOutput {
-    /// Snapshot mode: save to string
+    /// Snapshot mode: save to string.
     Snapshot(RefCell<String>),
-    /// Interactive mode: print to console
+    /// Interactive mode: print to console.
     Interactive,
 }
 
@@ -122,7 +122,7 @@ impl BatchOutput {
         }
     }
 
-    /// Get the result of a snapshot test
+    /// Get the result of a snapshot test.
     pub fn result<'a>(&'a self) -> Ref<'a, String> {
         match self {
             BatchOutput::Snapshot(out) => out.borrow(),
@@ -131,7 +131,7 @@ impl BatchOutput {
     }
 }
 
-/// Read from path and elaborate
+/// Read from path and elaborate.
 pub fn run(path: &str, output: &BatchOutput) -> io::Result<bool> {
     let src = match fs::read_to_string(path) {
         Ok(s) => s,

--- a/packages/catlog/src/tt/context.rs
+++ b/packages/catlog/src/tt/context.rs
@@ -21,9 +21,9 @@ pub struct VarInContext {
     pub ty: Option<TyV>,
 }
 
-/// The variable context during elaboration
+/// The variable context during elaboration.
 pub struct Context {
-    /// Stores the value of each of the variables in context
+    /// Stores the value of each of the variables in context.
     pub env: Env,
     /// Stores the names and types of each of the variables in context.
     pub scope: Vec<VarInContext>,
@@ -61,12 +61,12 @@ impl Context {
         self.scope.truncate(c.scope);
     }
 
-    /// Add a new variable to scope (note: does not add it to the environment)
+    /// Add a new variable to scope (note: does not add it to the environment).
     pub fn push_scope(&mut self, name: VarName, label: LabelSegment, ty: Option<TyV>) {
         self.scope.push(VarInContext::new(name, label, ty))
     }
 
-    /// Lookup a variable by name
+    /// Lookup a variable by name.
     pub fn lookup(&self, name: VarName) -> Option<(BwdIdx, LabelSegment, Option<TyV>)> {
         self.scope
             .iter()

--- a/packages/catlog/src/tt/eval.rs
+++ b/packages/catlog/src/tt/eval.rs
@@ -1,4 +1,4 @@
-//! Evaluation, quoting, and conversion/equality checking
+//! Evaluation, quoting, and conversion/equality checking.
 //!
 //! At a high level, this module implements three operations:
 //!
@@ -13,7 +13,7 @@ use crate::{
     zero::LabelSegment,
 };
 
-/// The context used in evaluation, quoting, and conversion checking
+/// The context used in evaluation, quoting, and conversion checking.
 ///
 /// We bundle this all together because conversion checking and quoting
 /// sometimes need to evaluate terms. For instance, quoting a lambda
@@ -33,15 +33,15 @@ impl<'a> Evaluator<'a> {
         RecordV::new(self.env.clone(), r.fields.clone(), Dtry::empty())
     }
 
-    /// Return a new [Evaluator] with environment `env`
+    /// Return a new [Evaluator] with environment `env`.
     pub fn with_env(&self, env: Env) -> Self {
         Self { env, ..self.clone() }
     }
 
-    /// Evaluate type syntax to produce a type value
+    /// Evaluate type syntax to produce a type value.
     ///
     /// Assumes that the type syntax is well-formed and well-scoped with respect
-    /// to self.env
+    /// to self.env.
     pub fn eval_ty(&self, ty: &TyS) -> TyV {
         match &**ty {
             TyS_::TopVar(tv) => self.toplevel.declarations.get(tv).unwrap().clone().unwrap_ty().val,
@@ -61,10 +61,10 @@ impl<'a> Evaluator<'a> {
         }
     }
 
-    /// Evaluate term syntax to produce a term value
+    /// Evaluate term syntax to produce a term value.
     ///
     /// Assumes that the term syntax is well-formed and well-scoped with respect
-    /// to self.env
+    /// to self.env.
     pub fn eval_tm(&self, tm: &TmS) -> TmV {
         match &**tm {
             TmS_::TopVar(tv) => {
@@ -88,7 +88,7 @@ impl<'a> Evaluator<'a> {
         }
     }
 
-    /// Compute the projection of a field from a term value
+    /// Compute the projection of a field from a term value.
     pub fn proj(&self, tm: &TmV, field_name: FieldName, field_label: LabelSegment) -> TmV {
         match &**tm {
             TmV_::Neu(n, ty) => TmV::neu(
@@ -116,7 +116,7 @@ impl<'a> Evaluator<'a> {
         }
     }
 
-    /// Bind a new neutral of type `ty`
+    /// Bind a new neutral of type `ty`.
     pub fn bind_neu(&self, name: VarName, label: LabelSegment, ty: TyV) -> (TmN, Self) {
         let n = TmN::var(self.scope_length.into(), name, label);
         let v = TmV::neu(n.clone(), ty);
@@ -130,7 +130,7 @@ impl<'a> Evaluator<'a> {
         )
     }
 
-    /// Bind a variable called "self" to `ty`
+    /// Bind a variable called "self" to `ty`.
     pub fn bind_self(&self, ty: TyV) -> (TmN, Self) {
         self.bind_neu("self".into(), "self".into(), ty)
     }
@@ -309,7 +309,7 @@ impl<'a> Evaluator<'a> {
         }
     }
 
-    /// Performs eta-expansion of the term `n` at type `ty`
+    /// Performs eta-expansion of the term `n` at type `ty`.
     pub fn eta(&self, v: &TmV, ty: Option<&TyV>) -> TmV {
         match &**v {
             TmV_::Neu(tm_n, ty_v) => self.eta_neu(tm_n, ty_v),
@@ -429,7 +429,7 @@ impl<'a> Evaluator<'a> {
         }
     }
 
-    /// Try to specialize the record `r` with the subtype `ty` at `path`
+    /// Try to specialize the record `r` with the subtype `ty` at `path`.
     ///
     /// Precondition: `path` is non-empty.
     pub fn try_specialize(

--- a/packages/catlog/src/tt/mod.rs
+++ b/packages/catlog/src/tt/mod.rs
@@ -160,7 +160,7 @@
 //! /# result: g.g1.V : @sing g.V
 //! ```
 //!
-//! We can also normalize `g.g1.V` in the context of a variable `g: Graph2`
+//! We can also normalize `g.g1.V` in the context of a variable `g: Graph2`:
 //!
 //! ```text
 //! norm [g: Graph2] g.g1.V

--- a/packages/catlog/src/tt/notebook_elab.rs
+++ b/packages/catlog/src/tt/notebook_elab.rs
@@ -45,7 +45,7 @@ struct ElaboratorCheckpoint {
 }
 
 impl<'a> Elaborator<'a> {
-    /// Create a new notebook elaborator
+    /// Create a new notebook elaborator.
     pub fn new(theory: Theory, toplevel: &'a Toplevel, ref_id: Ustr) -> Self {
         Self {
             theory,
@@ -61,7 +61,7 @@ impl<'a> Elaborator<'a> {
         &self.theory.definition
     }
 
-    /// Get all of the errors from elaboration
+    /// Get all of the errors from elaboration.
     pub fn errors(&self) -> &[InvalidDblModel] {
         &self.errors
     }

--- a/packages/catlog/src/tt/prelude.rs
+++ b/packages/catlog/src/tt/prelude.rs
@@ -1,4 +1,4 @@
-//! Common imports for [`tt`](crate::tt)
+//! Common imports for [`tt`](crate::tt).
 
 pub use crate::tt::util::*;
 pub use crate::zero::{
@@ -12,9 +12,9 @@ pub use std::rc::Rc;
 pub use tattle::{Loc, Reporter};
 pub use ustr::{Ustr, ustr};
 
-/// The type of local variable names
+/// The type of local variable names.
 pub type VarName = NameSegment;
-/// The type of global variable names
+/// The type of global variable names.
 pub type TopVarName = NameSegment;
-/// The type of field names in record types
+/// The type of field names in record types.
 pub type FieldName = NameSegment;

--- a/packages/catlog/src/tt/stx.rs
+++ b/packages/catlog/src/tt/stx.rs
@@ -9,7 +9,7 @@ use std::fmt::Write as _;
 use super::{prelude::*, theory::*};
 use crate::zero::LabelSegment;
 
-/// A metavariable
+/// A metavariable.
 ///
 /// Metavariables are emitted on elaboration error or when explicitly
 /// requested with `@hole`.
@@ -36,7 +36,7 @@ pub struct RecordS {
 
 /// Inner enum for [TyS].
 pub enum TyS_ {
-    /// A reference to a top-level declaration
+    /// A reference to a top-level declaration.
     TopVar(TopVarName),
     /// Type constructor for object types.
     ///
@@ -190,9 +190,9 @@ impl fmt::Display for TyS {
 
 /// Inner enum for [TmS].
 pub enum TmS_ {
-    /// A reference to a top-level constant def
+    /// A reference to a top-level constant def.
     TopVar(TopVarName),
-    /// An application of a top-level term judgment to arguments
+    /// An application of a top-level term judgment to arguments.
     TopApp(TopVarName, Vec<TmS>),
     /// Variable syntax.
     ///
@@ -205,7 +205,7 @@ pub enum TmS_ {
     Proj(TmS, FieldName, LabelSegment),
     /// Unit introduction.
     ///
-    /// Note that eta-expansion takes care of elimination for units
+    /// Note that eta-expansion takes care of elimination for units.
     Tt,
     /// Identity morphism at an object.
     Id(TmS),
@@ -217,11 +217,11 @@ pub enum TmS_ {
     List(Vec<TmS>),
     /// An opaque term.
     ///
-    /// This only appears when we quote a value
+    /// This only appears when we quote a value.
     Opaque,
-    /// A metavar
+    /// A metavar.
     ///
-    /// This only appears when we have an error in elaboration
+    /// This only appears when we have an error in elaboration.
     Meta(MetaVar),
 }
 
@@ -284,7 +284,7 @@ impl TmS {
         Self(Rc::new(TmS_::List(elems)))
     }
 
-    /// An opaque term
+    /// An opaque term.
     pub fn opaque() -> Self {
         Self(Rc::new(TmS_::Opaque))
     }

--- a/packages/catlog/src/tt/text_elab.rs
+++ b/packages/catlog/src/tt/text_elab.rs
@@ -27,13 +27,13 @@ pub const TT_PARSE_CONFIG: ParseConfig = ParseConfig::new(
 
 /// The result of elaborating a top-level statement.
 pub enum TopElabResult {
-    /// A new declaration
+    /// A new declaration.
     Declaration(TopVarName, TopDecl),
-    /// Output that should be logged
+    /// Output that should be logged.
     Output(String),
 }
 
-/// Context for top-level elaboration
+/// Context for top-level elaboration.
 ///
 /// Top-level elaboration is elaboration of declarations.
 pub struct TopElaborator {
@@ -100,7 +100,7 @@ impl TopElaborator {
         None
     }
 
-    /// Elaborate a single top-level declaration
+    /// Elaborate a single top-level declaration.
     pub fn elab(&mut self, toplevel: &Toplevel, tn: &FNtnTop) -> Option<TopElabResult> {
         match tn.name {
             "set_theory" => match tn.body.ast0() {

--- a/packages/catlog/src/tt/theory.rs
+++ b/packages/catlog/src/tt/theory.rs
@@ -246,7 +246,7 @@ pub enum ObOp {
     Modal(modal::ModalObOp),
 }
 
-/// Construct a library of standard theories
+/// Construct a library of standard theories.
 pub fn std_theories() -> HashMap<QualifiedName, Theory> {
     [
         (name("ThSchema"), TheoryDef::discrete(theories::th_schema())),

--- a/packages/catlog/src/tt/toplevel.rs
+++ b/packages/catlog/src/tt/toplevel.rs
@@ -10,11 +10,11 @@ use crate::zero::QualifiedName;
 /// A toplevel declaration.
 #[derive(Clone)]
 pub enum TopDecl {
-    /// See [Type]
+    /// See [Type].
     Type(Type),
-    /// See [DefConst]
+    /// See [DefConst].
     DefConst(DefConst),
-    /// See [Def]
+    /// See [Def].
     Def(Def),
 }
 
@@ -24,11 +24,11 @@ pub enum TopDecl {
 /// the empty context, this is OK to use in any other context as well.
 #[derive(Constructor, Clone)]
 pub struct Type {
-    /// The theory for the type
+    /// The theory for the type.
     pub theory: Theory,
-    /// The syntax of the type (unnormalized)
+    /// The syntax of the type (unnormalized).
     pub stx: TyS,
-    /// The value of the type (normalized)
+    /// The value of the type (normalized).
     pub val: TyV,
 }
 
@@ -39,28 +39,28 @@ pub struct Type {
 /// context, this is OK to use in any other context as well.
 #[derive(Constructor, Clone)]
 pub struct DefConst {
-    /// The theory that the constant is defined in
+    /// The theory that the constant is defined in.
     pub theory: Theory,
-    /// The syntax of the constant (unnormalized)
+    /// The syntax of the constant (unnormalized).
     pub stx: TmS,
-    /// The value of the constant (normalized)
+    /// The value of the constant (normalized).
     pub val: TmV,
-    /// The type of the constant
+    /// The type of the constant.
     pub ty: TyV,
 }
 
-/// A toplevel declaration of a term judgment
+/// A toplevel declaration of a term judgment.
 #[derive(Constructor, Clone)]
 pub struct Def {
-    /// The theory that the definition is defined in
+    /// The theory that the definition is defined in.
     pub theory: Theory,
-    /// The arguments for the definition
+    /// The arguments for the definition.
     pub args: Row<TyS>,
     /// The return type of the definition (to be evaluated in an environment
-    /// with values for the arguments)
+    /// with values for the arguments).
     pub ret_ty: TyS,
     /// The body of the definition (to be evaluated in an environment with
-    /// values for the arguments)
+    /// values for the arguments).
     pub body: TmS,
 }
 
@@ -98,7 +98,7 @@ impl TopDecl {
 
 /// Storage for toplevel declarations.
 pub struct Toplevel {
-    /// Library of theories, indexed by name
+    /// Library of theories, indexed by name.
     pub theory_library: HashMap<QualifiedName, Theory>,
     /// The toplevel declarations, indexed by their name.
     pub declarations: HashMap<TopVarName, TopDecl>,

--- a/packages/catlog/src/tt/util/dtry.rs
+++ b/packages/catlog/src/tt/util/dtry.rs
@@ -80,22 +80,22 @@ impl<T> Dtry<T> {
         Dtry(Row::empty())
     }
 
-    /// Returns whether the directory is empty
+    /// Returns whether the directory is empty.
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 
-    /// Iterate through the entries of the directory
+    /// Iterate through the entries of the directory.
     pub fn entries(&self) -> impl Iterator<Item = (&FieldName, &(LabelSegment, DtryEntry<T>))> {
         self.0.iter()
     }
 
-    /// Get the entry for `field` if it exists
+    /// Get the entry for `field` if it exists.
     pub fn entry(&self, field: &FieldName) -> Option<&DtryEntry<T>> {
         self.0.get(*field)
     }
 
-    /// Create a singleton directory with just one entry at the given path
+    /// Create a singleton directory with just one entry at the given path.
     pub fn singleton(path: &[(FieldName, LabelSegment)], val: T) -> Self {
         assert!(!path.is_empty());
         let ((field, label), path) = (path[0], &path[1..]);
@@ -105,7 +105,7 @@ impl<T> Dtry<T> {
 
 impl<T: Clone> Dtry<T> {
     /// Produce the list of paths in `self` that refer to files, along with the
-    /// value of the files that they refer to
+    /// value of the files that they refer to.
     pub fn flatten(&self) -> Vec<(QualifiedName, QualifiedLabel, T)> {
         let mut out = Vec::new();
         self.flatten_into(vec![].into(), vec![].into(), &mut out);

--- a/packages/catlog/src/tt/util/idx.rs
+++ b/packages/catlog/src/tt/util/idx.rs
@@ -18,13 +18,13 @@ use derive_more::{Deref, From};
 pub struct FwdIdx(usize);
 
 impl FwdIdx {
-    /// The forward index refering the the next variable in the scope
+    /// The forward index refering the the next variable in the scope.
     pub fn next(&self) -> Self {
         Self(self.0 + 1)
     }
 
     /// Convert into a backward index, assuming that the scope is of
-    /// length `scope_length`
+    /// length `scope_length`.
     pub fn as_bwd(&self, scope_length: usize) -> BwdIdx {
         BwdIdx(scope_length - self.0 - 1)
     }
@@ -35,7 +35,7 @@ impl FwdIdx {
 pub struct BwdIdx(usize);
 
 impl BwdIdx {
-    /// The backwards index refering to the previous variable in the scope
+    /// The backwards index refering to the previous variable in the scope.
     pub fn prev(&self) -> Self {
         Self(self.0 + 1)
     }

--- a/packages/catlog/src/tt/util/pretty.rs
+++ b/packages/catlog/src/tt/util/pretty.rs
@@ -49,7 +49,7 @@ pub fn binop<'a>(op: D<'a>, l: D<'a>, r: D<'a>) -> D<'a> {
     ((l + s() + op).group() + (s() + r).indented()).group()
 }
 
-/// Creates a tuple in [fnotation]: (`[x, y, z, ...]`)
+/// Creates a tuple in [fnotation]: (`[x, y, z, ...]`).
 pub fn tuple<'a, I: IntoIterator<Item = D<'a>>>(i: I) -> D<'a> {
     D(RcDoc::intersperse(i.into_iter().map(|d| d.0.group()), (t(",") + s()).0))
         .brackets()
@@ -62,27 +62,27 @@ pub fn intersperse<'a, I: IntoIterator<Item = D<'a>>>(i: I, sep: D<'a>) -> D<'a>
 }
 
 impl<'a> D<'a> {
-    /// Try to lay out this document as a group; either on one line or uniformly split
+    /// Try to lay out this document as a group; either on one line or uniformly split.
     pub fn group(self) -> D<'a> {
         D(self.0.group())
     }
 
-    /// Surround this document with parentheses
+    /// Surround this document with parentheses.
     pub fn parens(self) -> D<'a> {
         t("(") + self.group() + t(")")
     }
 
-    /// Increase the indentation level
+    /// Increase the indentation level.
     pub fn indented(self) -> Self {
         D(self.0.nest(2))
     }
 
-    /// Surround this document with brackets
+    /// Surround this document with brackets.
     pub fn brackets(self) -> D<'a> {
         t("[") + self.indented() + t("]")
     }
 
-    /// Use this to print a document
+    /// Use this to print a document.
     pub fn pretty(&self) -> impl fmt::Display {
         self.0.pretty(80)
     }

--- a/packages/catlog/src/tt/util/row.rs
+++ b/packages/catlog/src/tt/util/row.rs
@@ -49,7 +49,7 @@ impl<T> Row<T> {
         self.0.is_empty()
     }
 
-    /// Return whether the row contains the given field
+    /// Return whether the row contains the given field.
     pub fn has(&self, field_name: FieldName) -> bool {
         self.0.contains_key(&field_name)
     }
@@ -66,7 +66,7 @@ impl<T> Row<T> {
 }
 
 impl<T: Clone> Row<T> {
-    ///  Insert a new field
+    ///  Insert a new field.
     ///
     /// Uses [Rc::make_mut] to mutate in place if there are no other references to self,
     /// otherwise performs a clone.

--- a/packages/catlog/src/tt/val.rs
+++ b/packages/catlog/src/tt/val.rs
@@ -8,10 +8,10 @@ use derive_more::{Constructor, Deref};
 use super::{prelude::*, stx::*, theory::*};
 use crate::zero::LabelSegment;
 
-/// A way of resolving [BwdIdx] found in [TmS_::Var] to values
+/// A way of resolving [BwdIdx] found in [TmS_::Var] to values.
 pub type Env = Bwd<TmV>;
 
-/// The content of a record type value
+/// The content of a record type value.
 #[derive(Clone, Constructor)]
 pub struct RecordV {
     /// The closed-over environment.
@@ -26,7 +26,7 @@ pub struct RecordV {
 }
 
 impl RecordV {
-    /// Add a specialization a path `path` to type `ty`
+    /// Add a specialization a path `path` to type `ty`.
     ///
     /// Precondition: assumes that this produces a subtype.
     pub fn add_specialization(&self, path: &[(FieldName, LabelSegment)], ty: TyV) -> Self {
@@ -39,7 +39,7 @@ impl RecordV {
         }
     }
 
-    /// Merge in the specializations in `specializations`
+    /// Merge in the specializations in `specializations`.
     ///
     /// Precondition: assumes that this produces a subtype.
     pub fn specialize(&self, specializations: &Dtry<TyV>) -> Self {
@@ -50,7 +50,7 @@ impl RecordV {
     }
 }
 
-/// Merge new specializations with old specializations
+/// Merge new specializations with old specializations.
 pub fn merge_specializations(old: &Dtry<TyV>, new: &Dtry<TyV>) -> Dtry<TyV> {
     let mut result: IndexMap<FieldName, (LabelSegment, DtryEntry<TyV>)> =
         old.entries().map(|(name, e)| (*name, e.clone())).collect();
@@ -68,7 +68,7 @@ pub fn merge_specializations(old: &Dtry<TyV>, new: &Dtry<TyV>) -> Dtry<TyV> {
     result.into()
 }
 
-/// Inner enum for [TyV]
+/// Inner enum for [TyV].
 pub enum TyV_ {
     /// Type constructor for object types, also see [TyS_::Object].
     Object(ObType),
@@ -86,7 +86,7 @@ pub enum TyV_ {
     Sing(TyV, TmV),
     /// Type constructor for unit types, also see [TyS_::Unit].
     Unit,
-    /// A metavariable, also see [TyS_::Meta]
+    /// A metavariable, also see [TyS_::Meta].
     Meta(MetaVar),
 }
 
@@ -143,7 +143,7 @@ impl TyV {
         }
     }
 
-    /// Specializes the field at `path` to `ty`
+    /// Specializes the field at `path` to `ty`.
     ///
     /// Precondition: assumes that this produces a subtype.
     pub fn add_specialization(&self, path: &[(FieldName, LabelSegment)], ty: TyV) -> Self {
@@ -204,9 +204,9 @@ pub enum TmV_ {
     Cons(Row<TmV>),
     /// The unique element of the unit type.
     Tt,
-    /// An element of a type that is opaque to conversion checking
+    /// An element of a type that is opaque to conversion checking.
     Opaque,
-    /// A metavariable
+    /// A metavariable.
     Meta(MetaVar),
 }
 

--- a/packages/catlog/src/zero/alg.rs
+++ b/packages/catlog/src/zero/alg.rs
@@ -152,7 +152,7 @@ where
     Coef: Display + PartialEq + One + Neg<Output = Coef>,
     Exp: Display + PartialEq + One,
 {
-    /// Convert to a LaTeX string
+    /// Convert to a LaTeX string.
     pub fn to_latex(&self) -> String {
         self.0.to_latex()
     }

--- a/packages/catlog/src/zero/qualified.rs
+++ b/packages/catlog/src/zero/qualified.rs
@@ -76,7 +76,7 @@ impl NameSegment {
 ///
 /// A qualified name is a sequence of segments that unambiguously names an element
 /// in a set, or a family of sets, or a family of family of sets, and so on. For
-/// example, a qualified name with three segments can be constructed as
+/// example, a qualified name with three segments can be constructed as:
 ///
 /// ```
 /// # use catlog::zero::qualified::*;
@@ -373,7 +373,7 @@ impl QualifiedLabel {
         self.0.iter()
     }
 
-    /// Add another segment onto the end
+    /// Add another segment onto the end.
     pub fn snoc(&self, segment: LabelSegment) -> Self {
         let mut segments = self.0.clone();
         segments.push(segment);

--- a/packages/catlog/src/zero/rig.rs
+++ b/packages/catlog/src/zero/rig.rs
@@ -173,7 +173,7 @@ where
     Var: Display,
     Coef: Display + PartialEq + One + Neg<Output = Coef>,
 {
-    /// Convert to a LaTeX string
+    /// Convert to a LaTeX string.
     pub fn to_latex(&self) -> String {
         let is_simple = |s: &str| {
             // Numeric: digits and dots

--- a/packages/notebook-types/Cargo.toml
+++ b/packages/notebook-types/Cargo.toml
@@ -18,3 +18,6 @@ tsify = { version = "0.5", features = ["js"] }
 ustr = { version = "1.1.0", features = ["serde"] }
 uuid = { version = "1.18", features = ["serde"] }
 wasm-bindgen = "0.2.106"
+
+[lints.clippy]
+doc_paragraphs_missing_punctuation = "warn"


### PR DESCRIPTION
A pleasing new feature in Rust v1.93.