### PR TITLE
Adjust `vee` arrow style

### DIFF
--- a/packages/frontend/src/visualization/graph_svg.tsx
+++ b/packages/frontend/src/visualization/graph_svg.tsx
@@ -156,7 +156,7 @@ const VeeMarker = (props: { id: string; offset?: number }) => (
         markerHeight="10"
         orient="auto-start-reverse"
     >
-        <path d="M 0 0 L 5 5 L 0 10" />
+        <path d="M 0 2 L 5 5 L 0 8" />
     </marker>
 );
 


### PR DESCRIPTION
This is mainly to look better in the new ELK layouts but I think it looks better overall.

Before:

![export(11)](https://github.com/user-attachments/assets/344f6319-ffb5-49c8-b48f-437fffeffb40)

After:
![export(12)](https://github.com/user-attachments/assets/5d198f61-6fb1-45f8-81ad-320a10eef50e)

Before:

![export(10)](https://github.com/user-attachments/assets/4c351c0f-7a1b-4fb4-b9fa-6cf44944b058)

After:
![export(9)](https://github.com/user-attachments/assets/9c0f12ee-b10c-4c9d-b71c-aa7f077f65c4)



