### PR TITLE
Use CSS custom properties to get the ELK font width

### DIFF
--- a/packages/frontend/src/visualization/elk.ts
+++ b/packages/frontend/src/visualization/elk.ts
@@ -29,6 +29,8 @@ interface StyledElkEdge extends ElkExtendedEdge {
     arrowStyle?: ArrowStyle;
 }
 
+const nodePadding = 10;
+
 /** Convert a graph specification into an ELK node.
 
 List of layout options supported by ELK:
@@ -36,6 +38,13 @@ List of layout options supported by ELK:
  */
 export function graphToElk(graph: GraphSpec.Graph, layoutOptions?: LayoutOptions): ElkNode {
     const canvas = document.createElement("canvas");
+
+    const defaultFont = `1rem ${getComputedStyle(document.documentElement)
+        .getPropertyValue("--main-font")
+        .trim()}`;
+    const monospaceFont = `1rem ${getComputedStyle(document.documentElement)
+        .getPropertyValue("--mono-font")
+        .trim()}`;
 
     const children: StyledElkNode[] = graph.nodes.map((node) => {
         let width = node.minimumWidth ?? nodePadding;
@@ -74,12 +83,6 @@ export function graphToElk(graph: GraphSpec.Graph, layoutOptions?: LayoutOptions
 
     return { id: "root", children, edges, layoutOptions };
 }
-
-const nodePadding = 10;
-
-// XXX: How do we properly set these?
-const defaultFont = "1rem sans-serif";
-const monospaceFont = "1rem monospace";
 
 /** Asynchronously import and load ELK. */
 export async function loadElk() {


### PR DESCRIPTION
Before:

<img width="918" height="170" alt="image" src="https://github.com/user-attachments/assets/d24b3a01-2af1-4a32-aee4-cae6c88fd42e" />

After:

<img width="924" height="164" alt="image" src="https://github.com/user-attachments/assets/905b9d81-3273-4af2-a8f7-6dae9ef4b112" />
