### PR TITLE
Configure separation parameter in undirected graph layouts

### DIFF
--- a/packages/frontend/src/visualization/graph_layout_config.ts
+++ b/packages/frontend/src/visualization/graph_layout_config.ts
@@ -9,11 +9,19 @@ export type Config = {
     /** Primary layout direction, when applicable. */
     direction?: Direction;
 
-    /** Separation parameter for undirected graph layout (Graphviz neato). */
-    sep?: number;
+    /** Separation margin for undirected graph layout (Graphviz neato), in points.
+     * Can be:
+     * - Single value: "1.0" (uniform margin)
+     * - Point value: "0.5,1.0" (separate X and Y margins)
+     * - Absolute: "+1.0" or "+0.5,1.0" (not scaled by node size)
+     * Default: "0.25"
+     */
+    sep?: string;
 
-    /** Overlap parameter for undirected graph layout (Graphviz neato). */
-    overlap?: Overlap;
+    /** Overlap removal algorithm for undirected graph layout (Graphviz neato).
+     * Default: OverlapRemoval.Prism ("false")
+     */
+    overlap?: OverlapRemoval;
 };
 
 /** Engines supported for graph layout. */
@@ -32,18 +40,18 @@ export enum Direction {
     Vertical = "vertical",
 }
 
-/** Overlap removal methods for undirected graph layouts (Graphviz neato). */
-export enum Overlap {
-    /** Remove overlaps (Graphviz default). */
-    False = "false",
+/** Overlap removal algorithms for undirected graph layouts (Graphviz neato). */
+export enum OverlapRemoval {
+    /** Prism algorithm for overlap removal (via "false" value). */
+    Prism = "false",
     /** Scale layout uniformly to remove overlaps. */
     Scale = "scale",
-    /** Scale layout separately in x and y to remove overlaps. */
+    /** Scale layout separately in X and Y to remove overlaps. */
     ScaleXY = "scalexy",
-    /** Allow overlaps. */
-    True = "true",
-    /** Prism algorithm for overlap removal. */
-    Prism = "prism",
+    /** Ortho-based overlap removal (X then Y). Good for bipartite graphs. */
+    OrthoXY = "orthoxy",
+    /** No overlap removal (fastest, allows overlaps). */
+    None = "true",
 }
 
 /** Construct the default graph layout configuration. */
@@ -58,8 +66,8 @@ export const graphvizOptions = (config: Config): Viz.RenderOptions => {
         engine: graphvizEngine(config.layout),
         graphAttributes: {
             rankdir: graphvizRankdir(config.direction ?? Direction.Vertical),
-            ...(isUndirected && { sep: config.sep ?? 1.0 }),
-            ...(isUndirected && { overlap: config.overlap ?? Overlap.False }),
+            ...(isUndirected && { sep: config.sep ?? "0.25" }),
+            ...(isUndirected && { overlap: config.overlap ?? OverlapRemoval.Prism }),
         },
     };
 };

--- a/packages/frontend/src/visualization/graph_layout_config_form.tsx
+++ b/packages/frontend/src/visualization/graph_layout_config_form.tsx
@@ -1,7 +1,7 @@
 import { Show } from "solid-js";
 
 import { FormGroup, InputField, SelectField } from "catcolab-ui-components";
-import { type Config, Direction, Engine, Overlap } from "./graph_layout_config";
+import { type Config, Direction, Engine, OverlapRemoval } from "./graph_layout_config";
 
 /** Form to configure a graph layout algorithm. */
 export function GraphLayoutConfigForm(props: {
@@ -42,31 +42,28 @@ export function GraphLayoutConfigForm(props: {
             <Show when={layout() === Engine.VizUndirected}>
                 <SelectField
                     label="Overlap"
-                    value={props.config.overlap ?? Overlap.False}
+                    value={props.config.overlap ?? OverlapRemoval.Prism}
                     onChange={(evt) => {
                         props.changeConfig((content) => {
-                            content.overlap = evt.currentTarget.value as Overlap;
+                            content.overlap = evt.currentTarget.value as OverlapRemoval;
                         });
                     }}
                 >
-                    <option value={Overlap.False}>{"Remove overlaps"}</option>
-                    <option value={Overlap.Scale}>{"Scale uniformly"}</option>
-                    <option value={Overlap.ScaleXY}>{"Scale independently"}</option>
-                    <option value={Overlap.True}>{"Allow overlaps"}</option>
-                    <option value={Overlap.Prism}>{"Prism algorithm"}</option>
+                    <option value={OverlapRemoval.Prism}>{"Prism (default)"}</option>
+                    <option value={OverlapRemoval.Scale}>{"Scale uniformly"}</option>
+                    <option value={OverlapRemoval.ScaleXY}>{"Scale independently"}</option>
+                    <option value={OverlapRemoval.OrthoXY}>{"Orthogonalize"}</option>
+                    <option value={OverlapRemoval.None}>{"No removal"}</option>
                 </SelectField>
-                <Show when={(props.config.overlap ?? Overlap.False) !== Overlap.True}>
+                <Show when={(props.config.overlap ?? OverlapRemoval.Prism) !== OverlapRemoval.None}>
                     <InputField
                         label="Separation"
-                        type="number"
-                        min="0"
-                        max="10"
-                        step="0.1"
-                        value={props.config.sep ?? 1.0}
+                        type="text"
+                        placeholder="0.25"
+                        value={props.config.sep ?? "0.25"}
                         onInput={(evt) => {
                             props.changeConfig((content) => {
-                                const value = evt.currentTarget.value;
-                                content.sep = value === "" ? 1.0 : Number.parseFloat(value);
+                                content.sep = evt.currentTarget.value;
                             });
                         }}
                     />


### PR DESCRIPTION
## Description

Added configurable `sep` and `overlap` parameters for undirected graph layouts using Graphviz's neato algorithm. These parameters were previously hard-coded (using Graphviz defaults), making it difficult to achieve acceptable layout results for certain graphs. The changes expose these parameters in the UI through input fields that appear when the undirected layout engine is selected.

The `sep` parameter controls the separation between nodes, while `overlap` controls how node overlaps are handled. Both parameters are optional and default to Graphviz's standard behavior when left empty.

Closes #709.

## Checklist if Applicable

- [x] The tests passed – `pnpm --filter ./packages/frontend run test` 
- [x] Linting passed – `pnpm --filter ./packages/frontend run lint` (no issues found)
- [ ] Documentation has been added
- [ ] CHANGELOG.md has been updated