### PR TITLE
Add plus button to instantiation cells

### DIFF
--- a/packages/frontend/src/model/instantiation_cell_editor.css
+++ b/packages/frontend/src/model/instantiation_cell_editor.css
@@ -31,3 +31,8 @@
         color: var(--color-gray-750);
     }
 }
+
+.add-specialization-button {
+    margin-left: 1.5rem;
+    margin-top: 0.25rem;
+}

--- a/packages/frontend/src/model/instantiation_cell_editor.tsx
+++ b/packages/frontend/src/model/instantiation_cell_editor.tsx
@@ -1,7 +1,8 @@
+import Plus from "lucide-solid/icons/plus";
 import { batch, createSignal, Index, Show, splitProps, useContext } from "solid-js";
 import invariant from "tiny-invariant";
 
-import { NameInput, type TextInputOptions } from "catcolab-ui-components";
+import { IconButton, NameInput, type TextInputOptions } from "catcolab-ui-components";
 import type { DblModel, InstantiatedModel, Ob, SpecializeModel } from "catlog-wasm";
 import { useApi } from "../api";
 import { DocumentPicker, IdInput } from "../components";
@@ -44,6 +45,14 @@ export function InstantiationCellEditor(props: {
             inst.specializations.unshift({ id: null, ob: null });
         });
         activateIndex(0);
+    };
+
+    const addSpecializationAtEnd = () => {
+        const newIndex = props.instantiation.specializations.length;
+        props.modifyInstantiation((inst) => {
+            inst.specializations.push({ id: null, ob: null });
+        });
+        activateIndex(newIndex);
     };
 
     const exitDownFromTop = () => {
@@ -149,6 +158,11 @@ export function InstantiationCellEditor(props: {
                     )}
                 </Index>
             </ul>
+            <div class="add-specialization-button">
+                <IconButton onClick={addSpecializationAtEnd} tooltip="Add new assignment">
+                    <Plus size={16} />
+                </IconButton>
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Description

This change improves the discoverability of adding new assignment lines in instantiation cells by introducing a visible "+" button. Previously, users could only add new assignments by pressing "Return" from an existing assignment line, which was not intuitive. The implementation adds an IconButton with a Plus icon below the specializations list that, when clicked, adds a new assignment at the end and automatically focuses it.

The solution follows the existing UI patterns in the codebase by:
- Using the `Plus` icon from `lucide-solid/icons/plus`
- Using the `IconButton` component from `catcolab-ui-components`
- Providing a tooltip "Add new assignment" for discoverability
- Using consistent styling aligned with the left margin of the specializations list

Closes #891.

## Checklist if Applicable

- [x] The tests passed – `pnpm --filter ./packages/frontend run test`
- [x] Linting passed – `pnpm --filter ./packages/frontend run lint` 
- [ ] Documentation has been added
- [ ] CHANGELOG.md has been updated