### PR TITLE
Upgrade Automerge to fix document corruption bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,9 +180,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "automerge"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c51597d92d370bfaed45068412dfa06f3c6dc35eef987119f6e4e0da96bb3d"
+checksum = "3f4f9b5e81602f033fac828dafb4fef91742f6f01adfdb8ee5b8bc804cfac7bb"
 dependencies = [
  "cfg-if",
  "flate2",
@@ -2216,7 +2216,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/packages/backend/Cargo.toml
+++ b/packages/backend/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 async-trait = "0.1.88"
-automerge = "0.7.1"
+automerge = "0.7.4"
 axum = "0.8.4"
 base64 = "0.22"
 chrono = { version = "0.4.40", features = ["serde"] }

--- a/packages/frontend/default.nix
+++ b/packages/frontend/default.nix
@@ -36,7 +36,7 @@ let
 
     pnpmDeps = pkgs.fetchPnpmDeps {
       # see ../../dev-docs/fixing-hash-mismatches.md
-      hash = "sha256-IANGjncveW0QoLHNE5B5EWws+fxXeudVj1M7CbFpE6Y=";
+      hash = "sha256-S7k6oZHDBFCj4FsNuVoITB3nQdxABXAYRsZaK2Xbzvs=";
       pname = name;
       fetcherVersion = 2;
       # Only includes package.json and pnpm-lock.yaml files to ensure consistent hashing in different

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -22,7 +22,7 @@
     "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.3.0",
         "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
-        "@automerge/automerge": "^3.1.1",
+        "@automerge/automerge": "^3.2.4",
         "@automerge/automerge-repo": "^2.2.0",
         "@automerge/automerge-repo-network-websocket": "^2.2.0",
         "@automerge/automerge-repo-storage-indexeddb": "^2.2.0",
@@ -70,6 +70,11 @@
         "tiny-invariant": "^1.3.3",
         "ts-pattern": "^5.2.0",
         "uuid": "^13.0.0"
+    },
+    "pnpm": {
+        "overrides": {
+            "@automerge/automerge": "^3.2.4"
+        }
     },
     "devDependencies": {
         "@biomejs/biome": "^2.3.8",

--- a/packages/frontend/pnpm-lock.yaml
+++ b/packages/frontend/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@automerge/automerge': ^3.2.4
+
 importers:
 
   .:
@@ -15,8 +18,8 @@ importers:
         specifier: ^1.0.3
         version: 1.0.3
       '@automerge/automerge':
-        specifier: ^3.1.1
-        version: 3.1.1
+        specifier: ^3.2.4
+        version: 3.2.4
       '@automerge/automerge-repo':
         specifier: ^2.2.0
         version: 2.2.0
@@ -238,8 +241,8 @@ packages:
   '@automerge/automerge-repo@2.5.0':
     resolution: {integrity: sha512-bdxuMuKmxw0ZjwQXecrIX1VrHXf445bYCftNJJ5vqgGWVvINB5ZKFYAbtgPIyu1Y0TXQKvc6eqESaDeL+g8MmA==}
 
-  '@automerge/automerge@3.1.1':
-    resolution: {integrity: sha512-x7tZiMBLk4/SKYimVEVl1/wPntT9buGvLOWCey9ZcH8JUsB0dgm49C0S7Ojzgvflcs2hc/YjiXRPcFeFkinIgw==}
+  '@automerge/automerge@3.2.4':
+    resolution: {integrity: sha512-/IAShHSxme5d4ZK0Vs4A0P+tGaR/bSz6KtIJSCIPfwilCxsIqfRHAoNjmsXip6TGouadmbuw3WfLop6cal8pPQ==}
 
   '@automerge/prosemirror@0.2.0-alpha.0':
     resolution: {integrity: sha512-ho0ghRZxpWoVs0RPJV3a1b6AhZeMfXJhmWGAjrftGeg0JuZFJ0kyLol5TnNslLwyKCfBG42cLiciH/9ztSpFKQ==}
@@ -3088,7 +3091,7 @@ snapshots:
 
   '@automerge/automerge-repo@2.2.0':
     dependencies:
-      '@automerge/automerge': 3.1.1
+      '@automerge/automerge': 3.2.4
       bs58check: 3.0.1
       cbor-x: 1.6.0
       debug: 4.4.1
@@ -3101,7 +3104,7 @@ snapshots:
 
   '@automerge/automerge-repo@2.5.0':
     dependencies:
-      '@automerge/automerge': 3.1.1
+      '@automerge/automerge': 3.2.4
       bs58check: 3.0.1
       cbor-x: 1.6.0
       debug: 4.4.3
@@ -3112,11 +3115,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@automerge/automerge@3.1.1': {}
+  '@automerge/automerge@3.2.4': {}
 
   '@automerge/prosemirror@0.2.0-alpha.0':
     dependencies:
-      '@automerge/automerge': 3.1.1
+      '@automerge/automerge': 3.2.4
       ordered-map: 0.1.0
       prosemirror-changeset: 2.3.1
       prosemirror-history: 1.4.1


### PR DESCRIPTION
[release notes](https://github.com/automerge/automerge/releases/tag/js/automerge-3.2.4)

The js package changes were just bumping the rust version number, so I figured the rust should be upgraded at the same time.

I needed to include a pnpm override because the `automerge-prosemirror` has a dependency on Automerge v3.1.1. The `atuomerge-prosemirror` package has not been updated, but I assume that it would be important for that package to get the bug fix as well. This could potentially lead to problems in the rich text editor, but I haven't seen any issues so far.