### PR TITLE
Revert sudo password requirement for catcolab account

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -210,7 +210,7 @@ jobs:
 
     - name: Deploy to catcolab-next
       run: |
-       nix run github:serokell/deploy-rs -- --skip-checks .#catcolab-next-ci
+       nix run github:serokell/deploy-rs -- --skip-checks .#catcolab-next
 
     - name: Verify deployment
       run: |

--- a/flake.nix
+++ b/flake.nix
@@ -330,7 +330,6 @@
           profiles.system = {
             sshUser = "catcolab";
             user = "root";
-            interactiveSudo = true;
             path = deploy-rs.lib.${linuxSystem}.activate.nixos self.nixosConfigurations.catcolab;
           };
         };
@@ -339,14 +338,6 @@
           profiles.system = {
             sshUser = "catcolab";
             user = "root";
-            interactiveSudo = true;
-            path = deploy-rs.lib.${linuxSystem}.activate.nixos self.nixosConfigurations.catcolab-next;
-          };
-        };
-        catcolab-next-ci = {
-          hostname = "backend-next.catcolab.org";
-          profiles.system = {
-            sshUser = "root";
             path = deploy-rs.lib.${linuxSystem}.activate.nixos self.nixosConfigurations.catcolab-next;
           };
         };
@@ -359,9 +350,8 @@
               "2221"
             ];
             sshUser = "catcolab";
-            user = "root";
-            interactiveSudo = true;
             path = deploy-rs.lib.${linuxSystem}.activate.nixos self.nixosConfigurations.catcolab-vm;
+            user = "root";
           };
         };
       };

--- a/infrastructure/hosts/catcolab-next/default.nix
+++ b/infrastructure/hosts/catcolab-next/default.nix
@@ -38,7 +38,6 @@ in
     host = {
       enable = true;
       userKeys = keys.hosts.catcolab-next.userKeys;
-      sudoPasswordHash = "$y$j9T$Gvhb3z8dNG2Gzk5STLY2q0$w8hilnb9bC2aNuH8Vx4FpgRzotKpFJeF2oFQ24MGMK8";
       backup = {
         enable = true;
         rcloneConfigFile = config.age.secrets.rcloneConf.path;

--- a/infrastructure/hosts/catcolab-vm/default.nix
+++ b/infrastructure/hosts/catcolab-vm/default.nix
@@ -34,7 +34,6 @@ in
     host = {
       enable = true;
       userKeys = keys.allUserKeys;
-      sudoPasswordHash = "$y$j9T$Gvhb3z8dNG2Gzk5STLY2q0$w8hilnb9bC2aNuH8Vx4FpgRzotKpFJeF2oFQ24MGMK8";
     };
   };
 

--- a/infrastructure/hosts/catcolab/default.nix
+++ b/infrastructure/hosts/catcolab/default.nix
@@ -36,7 +36,6 @@ in
     host = {
       enable = true;
       userKeys = keys.hosts.catcolab.userKeys;
-      sudoPasswordHash = "$y$j9T$Gvhb3z8dNG2Gzk5STLY2q0$w8hilnb9bC2aNuH8Vx4FpgRzotKpFJeF2oFQ24MGMK8";
       backup = {
         enable = true;
         rcloneConfigFile = config.age.secrets.rcloneConf.path;

--- a/infrastructure/modules/catcolab/host.nix
+++ b/infrastructure/modules/catcolab/host.nix
@@ -17,15 +17,6 @@ with lib;
       description = "SSH public keys to access the catcolab user.";
       default = [ ];
     };
-    sudoPasswordHash = mkOption {
-      type = types.str;
-      description = "Hashed password for sudo authentication. Generate with: mkpasswd";
-    };
-    rootKeys = mkOption {
-      type = types.listOf types.str;
-      description = "SSH public keys for root access only (e.g., for CI deployment).";
-      default = [ ];
-    };
   };
 
   config = lib.mkIf config.catcolab.host.enable {
@@ -35,22 +26,20 @@ with lib;
           isNormalUser = true;
           extraGroups = [ "wheel" ];
           openssh.authorizedKeys.keys = config.catcolab.host.userKeys;
-          hashedPassword = config.catcolab.host.sudoPasswordHash;
         };
-
-        # Used for deploying from CI to bypass sudo passowrd on catcolab user
-        root.openssh.authorizedKeys.keys = config.catcolab.host.rootKeys;
+        # TODO: root access can be dropped after the next prod deploy
+        root.openssh.authorizedKeys.keys = config.catcolab.host.userKeys;
       };
 
       groups.catcolab = { };
       mutableUsers = false;
     };
 
-    services.openssh = {
-      enable = true;
-      settings.PasswordAuthentication = false;
+    security.sudo = {
+      wheelNeedsPassword = false;
     };
 
+    services.openssh.enable = true;
     nix = {
       settings.trusted-users = [
         "catcolab"


### PR DESCRIPTION
Deploys were failing with this error:

```
⭐ ❌ [activate] [ERROR] Failed to get activation confirmation: Error waiting for confirmation event: Timeout elapsed for confirmation
```

I'm not sure why this is an issue. Reverts #970 for now.