### PR TITLE
Set backend opt-level=3 in production

### DIFF
--- a/packages/backend/default.nix
+++ b/packages/backend/default.nix
@@ -13,7 +13,7 @@ in
 craneLib.buildPackage {
   inherit cargoArtifacts pname version;
 
-  cargoExtraArgs = "-p backend";
+  cargoExtraArgs = "-p backend --config profile.release.opt-level=3";
 
   nativeBuildInputs = [
     pkgs.pkg-config


### PR DESCRIPTION
We currently set `opt-level=s` repo wide since we need to set it in the root Cargo.toml and that's what we want for WASM. We probably don't want to optimize for size in our server in next/production though so I suggest we set this flag here.