### PR TITLE
Use initial content of analysis also as the default content

### DIFF
--- a/packages/frontend/src/analysis/analysis_editor.tsx
+++ b/packages/frontend/src/analysis/analysis_editor.tsx
@@ -45,7 +45,7 @@ export function AnalysisNotebookEditor(props: { liveAnalysis: LiveAnalysisDoc })
 }
 
 /** Editor for a notebook cell in an analysis notebook. */
-function AnalysisCellEditor(props: FormalCellEditorProps<Analysis<unknown>>) {
+function AnalysisCellEditor(props: FormalCellEditorProps<Analysis<Record<string, unknown>>>) {
     const liveAnalysis = useContext(LiveAnalysisContext);
     invariant(liveAnalysis, "Live analysis should be provided as context for cell editor");
 
@@ -61,8 +61,8 @@ function AnalysisCellEditor(props: FormalCellEditorProps<Analysis<unknown>>) {
                     <Dynamic
                         component={analysis().component}
                         liveModel={(liveAnalysis() as LiveModelAnalysisDoc).liveModel}
-                        content={props.content.content}
-                        changeContent={(f: (c: unknown) => void) =>
+                        content={{ ...analysis().initialContent(), ...props.content.content }}
+                        changeContent={(f: (c: Record<string, unknown>) => void) =>
                             props.changeContent((content) => f(content.content))
                         }
                     />
@@ -78,8 +78,8 @@ function AnalysisCellEditor(props: FormalCellEditorProps<Analysis<unknown>>) {
                     <Dynamic
                         component={analysis().component}
                         liveDiagram={(liveAnalysis() as LiveDiagramAnalysisDoc).liveDiagram}
-                        content={props.content.content}
-                        changeContent={(f: (c: unknown) => void) =>
+                        content={{ ...analysis().initialContent(), ...props.content.content }}
+                        changeContent={(f: (c: Record<string, unknown>) => void) =>
                             props.changeContent((content) => f(content.content))
                         }
                     />
@@ -89,7 +89,9 @@ function AnalysisCellEditor(props: FormalCellEditorProps<Analysis<unknown>>) {
     );
 }
 
-function analysisCellConstructor<T>(meta: AnalysisMeta<T>): CellConstructor<Analysis<T>> {
+function analysisCellConstructor(
+    meta: AnalysisMeta<unknown>,
+): CellConstructor<Analysis<Record<string, unknown>>> {
     const { id, name, description, initialContent } = meta;
     return {
         name,
@@ -97,7 +99,7 @@ function analysisCellConstructor<T>(meta: AnalysisMeta<T>): CellConstructor<Anal
         construct: () =>
             newFormalCell({
                 id,
-                content: initialContent(),
+                content: initialContent() as Record<string, unknown>,
             }),
     };
 }

--- a/packages/notebook-types/src/v0/analysis.rs
+++ b/packages/notebook-types/src/v0/analysis.rs
@@ -1,10 +1,11 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashMap;
 use tsify::Tsify;
 
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
+#[tsify(into_wasm_abi, from_wasm_abi, hashmap_as_object)]
 pub struct Analysis {
     id: String,
-    content: Value,
+    content: HashMap<String, Value>,
 }


### PR DESCRIPTION
This is relevant only when new fields are added to the analysis content, in which case it will help with backwards compatibility.

@tim-at-topos, this should fix #1065 while also making it easier to make such changes in the future. Can you confirm that this works for you?

This PR assumes that `initialContent` is cheap to call, which seems safe enough, certainly for all our existing analyses.