### PR TITLE
Fix balanced mass-action for Petri nets and add tests

### DIFF
--- a/packages/catlog/src/stdlib/analyses/ode/mass_action.rs
+++ b/packages/catlog/src/stdlib/analyses/ode/mass_action.rs
@@ -238,6 +238,10 @@ impl PetriNetMassActionAnalysis {
                     for input in inputs {
                         sys.add_term(input.unwrap_generator(), -term.clone());
                     }
+
+                    for output in outputs {
+                        sys.add_term(output.unwrap_generator(), term.clone());
+                    }
                 }
 
                 MassConservationType::Unbalanced(granularity) => {


### PR DESCRIPTION
Closes #1072 (thankfully with a very simple fix that was easy to catch... once the relevant test had been un-deleted 😉)
