### PR TITLE
Upgrade to automerge-prosemirror v0.2.0

### DIFF
--- a/packages/frontend/default.nix
+++ b/packages/frontend/default.nix
@@ -36,7 +36,7 @@ let
 
     pnpmDeps = pkgs.fetchPnpmDeps {
       # see ../../dev-docs/fixing-hash-mismatches.md
-      hash = "sha256-bId9YUkRZ0oPAl1Skj+sVaFQENUps1G1C6ifIK6lfm0=";
+      hash = "sha256-vuBwhtNTTRbpgPZS+AQDybASYM9rwWYG8l0bscVQUso=";
       pname = name;
       fetcherVersion = 2;
       # Only includes package.json and pnpm-lock.yaml files to ensure consistent hashing in different

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -26,7 +26,7 @@
         "@automerge/automerge-repo": "^2.2.0",
         "@automerge/automerge-repo-network-websocket": "^2.2.0",
         "@automerge/automerge-repo-storage-indexeddb": "^2.2.0",
-        "@automerge/prosemirror": "v0.2.0-alpha.0",
+        "@automerge/prosemirror": "^v0.2.0",
         "@benrbray/prosemirror-math": "^1.0.0",
         "@corvu/dialog": "^0.2.4",
         "@corvu/popover": "^0.2.0",
@@ -69,11 +69,6 @@
         "tiny-invariant": "^1.3.3",
         "ts-pattern": "^5.2.0",
         "uuid": "^13.0.0"
-    },
-    "pnpm": {
-        "overrides": {
-            "@automerge/automerge": "^3.2.4"
-        }
     },
     "devDependencies": {
         "@biomejs/biome": "^2.3.8",

--- a/packages/frontend/pnpm-lock.yaml
+++ b/packages/frontend/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@automerge/automerge': ^3.2.4
-
 importers:
 
   .:
@@ -30,8 +27,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       '@automerge/prosemirror':
-        specifier: v0.2.0-alpha.0
-        version: 0.2.0-alpha.0
+        specifier: ^v0.2.0
+        version: 0.2.0
       '@benrbray/prosemirror-math':
         specifier: ^1.0.0
         version: 1.0.0(katex@0.16.22)(prosemirror-commands@1.7.1)(prosemirror-history@1.4.1)(prosemirror-inputrules@1.5.0)(prosemirror-keymap@1.2.3)(prosemirror-model@1.25.2)(prosemirror-state@1.4.3)(prosemirror-transform@1.10.4)(prosemirror-view@1.40.1)
@@ -241,8 +238,8 @@ packages:
   '@automerge/automerge@3.2.4':
     resolution: {integrity: sha512-/IAShHSxme5d4ZK0Vs4A0P+tGaR/bSz6KtIJSCIPfwilCxsIqfRHAoNjmsXip6TGouadmbuw3WfLop6cal8pPQ==}
 
-  '@automerge/prosemirror@0.2.0-alpha.0':
-    resolution: {integrity: sha512-ho0ghRZxpWoVs0RPJV3a1b6AhZeMfXJhmWGAjrftGeg0JuZFJ0kyLol5TnNslLwyKCfBG42cLiciH/9ztSpFKQ==}
+  '@automerge/prosemirror@0.2.0':
+    resolution: {integrity: sha512-Mixxftvfs12tKi7DsStobrQxFayoLJXhEjbrnmNnaQbMzwHrUzuwac+OUvw6ujbtXaulWX+JE8hAuHFAGRDsvQ==}
 
   '@babel/code-frame@7.25.7':
     resolution: {integrity: sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==}
@@ -2951,7 +2948,7 @@ snapshots:
 
   '@automerge/automerge@3.2.4': {}
 
-  '@automerge/prosemirror@0.2.0-alpha.0':
+  '@automerge/prosemirror@0.2.0':
     dependencies:
       '@automerge/automerge': 3.2.4
       ordered-map: 0.1.0


### PR DESCRIPTION
With this upstream fix, we no longer need any package overrides in `package.json`.