### PR TITLE
Allow setting separation on undirected graphviz graphs

### DIFF
--- a/packages/frontend/src/visualization/graph_layout_config.ts
+++ b/packages/frontend/src/visualization/graph_layout_config.ts
@@ -8,6 +8,9 @@ export type Config = {
 
     /** Primary layout direction, when applicable. */
     direction?: Direction;
+
+    /** Node separation for undirected (neato) layout, in inches. Defaults to 1.0. */
+    separation?: number;
 };
 
 /** Engines supported for graph layout. */
@@ -34,9 +37,10 @@ export const defaultConfig = (): Config => ({
 /** Generates a set of Graphviz options from a layout config. */
 export const graphvizOptions = (config: Config): Viz.RenderOptions => ({
     engine: graphvizEngine(config.layout),
-    graphAttributes: {
-        rankdir: graphvizRankdir(config.direction ?? Direction.Vertical),
-    },
+    graphAttributes:
+        config.layout === Engine.VizUndirected
+            ? { overlap: "prism", sep: `${config.separation ?? 1.0}` }
+            : { rankdir: graphvizRankdir(config.direction ?? Direction.Vertical) },
 });
 
 function graphvizEngine(layout: Engine): Viz.RenderOptions["engine"] {

--- a/packages/frontend/src/visualization/graph_layout_config_form.tsx
+++ b/packages/frontend/src/visualization/graph_layout_config_form.tsx
@@ -1,6 +1,6 @@
 import { Show } from "solid-js";
 
-import { FormGroup, SelectField } from "catcolab-ui-components";
+import { FormGroup, InputField, SelectField } from "catcolab-ui-components";
 import { type Config, Direction, Engine } from "./graph_layout_config";
 
 /** Form to configure a graph layout algorithm. */
@@ -38,6 +38,23 @@ export function GraphLayoutConfigForm(props: {
                     <option value={Direction.Horizontal}>{"Horizontal"}</option>
                     <option value={Direction.Vertical}>{"Vertical"}</option>
                 </SelectField>
+            </Show>
+            <Show when={layout() === Engine.VizUndirected}>
+                <InputField
+                    label="Separation"
+                    type="number"
+                    min={0}
+                    step={0.1}
+                    value={props.config.separation ?? 1.0}
+                    onInput={(evt) => {
+                        const value = evt.currentTarget.valueAsNumber;
+                        if (!Number.isNaN(value)) {
+                            props.changeConfig((content) => {
+                                content.separation = value;
+                            });
+                        }
+                    }}
+                />
             </Show>
         </FormGroup>
     );


### PR DESCRIPTION
Fixes #709  and supersedes https://github.com/ToposInstitute/CatColab/pull/1040 

Defaulting to prevent overlaps definitely improves all the graphs I checked. Tweaking the separation as a single number seems like a reasonable thing to do. I chose not to expose:

-  All the different undirected algorithms, they don't seem that interesting.
- Setting things like  `+1,4` for the separation. This would allow separation by absolute value (default is scaled by node size) and on X and Y separately, but I don't think it's that useful. 