### PR TITLE
Do not return model from text if parser has errors

### DIFF
--- a/packages/catlog/src/stdlib/analyses/sql.rs
+++ b/packages/catlog/src/stdlib/analyses/sql.rs
@@ -244,7 +244,7 @@ mod tests {
                 has : Attr[Person, Hair],
             ]",
         );
-        let model = model.and_then(|m| m.as_discrete()).unwrap();
+        let model = model.ok().and_then(|m| m.as_discrete()).unwrap();
 
         let expected = expect![[
             r#"CREATE TABLE IF NOT EXISTS `Dog` (`id` int NOT NULL AUTO_INCREMENT PRIMARY KEY);

--- a/packages/catlog/src/tt/modelgen.rs
+++ b/packages/catlog/src/tt/modelgen.rs
@@ -2,7 +2,7 @@
 
 use all_the_same::all_the_same;
 use derive_more::{From, TryInto};
-use tattle::reporter::Message::Error;
+use tattle::reporter::Message;
 
 use super::{eval::*, prelude::*, text_elab, theory::*, toplevel::*, val::*};
 use crate::dbl::{
@@ -54,22 +54,25 @@ impl Model {
         }
     }
 
-    /// Parses and generates a model from plain text. If there is an error in
-    /// the parsing, `None` is returned.
-    pub fn from_text(th: &TheoryDef, s: &str) -> Option<Self> {
+    /// Parses and generates a model from plain text.
+    ///
+    /// If there is an error in parsing, returns a list of error messages.
+    pub fn from_text(th: &TheoryDef, s: &str) -> Result<Self, Vec<Message>> {
         let theory = Theory::new("_".into(), th.clone());
         let reporter = Reporter::new();
         let toplevel: Toplevel = Default::default();
-        text_elab::TT_PARSE_CONFIG.with_parsed(s, reporter.clone(), |fntn| {
-            let mut elaborator = text_elab::Elaborator::new(theory, reporter, &toplevel);
-            let (_, ty_v) = elaborator.ty(fntn);
-            if elaborator.reporter.poll().iter().any(|msg| matches!(msg, Error(_))) {
-                None
-            } else {
-                let (model, _) = Self::from_ty(&toplevel, th, &ty_v);
-                Some(model)
-            }
-        })
+        let maybe_elab = text_elab::TT_PARSE_CONFIG.with_parsed(s, reporter.clone(), |fntn| {
+            let mut elaborator = text_elab::Elaborator::new(theory, reporter.clone(), &toplevel);
+            Some(elaborator.ty(fntn))
+        });
+        if let Some((_, ty_v)) = maybe_elab
+            && !reporter.errored()
+        {
+            let (model, _) = Self::from_ty(&toplevel, th, &ty_v);
+            Ok(model)
+        } else {
+            Err(reporter.poll())
+        }
     }
 
     /// Generates a model from a type.

--- a/packages/catlog/src/tt/text_elab.rs
+++ b/packages/catlog/src/tt/text_elab.rs
@@ -240,8 +240,7 @@ impl TopElaborator {
 /// Text-based elaborator of types.
 pub struct Elaborator<'a> {
     theory: Theory,
-    /// Reporter used during elaboration.
-    pub reporter: Reporter,
+    reporter: Reporter,
     toplevel: &'a Toplevel,
     loc: Option<Loc>,
     ctx: Context,
@@ -764,7 +763,8 @@ impl<'a> Elaborator<'a> {
 mod tests {
     use std::rc::Rc;
 
-    use crate::{stdlib, tt};
+    use crate::stdlib;
+    use crate::tt::{modelgen::Model, theory::TheoryDef};
 
     #[test]
     fn generate_model_from_text() {
@@ -773,7 +773,8 @@ mod tests {
             x : Object,
             loop : Negative[x, x]
         ]";
-        let model = tt::modelgen::Model::from_text(&th.clone().into(), source)
+        let model = Model::from_text(&th.clone().into(), source)
+            .ok()
             .and_then(|m| m.as_discrete())
             .unwrap();
         assert_eq!(model, stdlib::models::negative_loop(th));
@@ -782,7 +783,7 @@ mod tests {
     /// Check that a commutative square really produces a model with exactly one equation.
     #[test]
     fn generate_model_with_eqn() {
-        let th = Rc::new(stdlib::th_schema());
+        let th: TheoryDef = Rc::new(stdlib::th_schema()).into();
         let source = "[
             NW : Entity,
             NE : Entity,
@@ -794,37 +795,23 @@ mod tests {
             b : (Hom Entity)[SW, SE],
             comm : (t * r == l * b)
         ]";
-        let model = tt::modelgen::Model::from_text(&th.clone().into(), source)
-            .and_then(|m| m.as_discrete())
-            .unwrap();
+        let model = Model::from_text(&th, source).ok().and_then(|m| m.as_discrete()).unwrap();
         let eqns: Vec<_> = model.category.equations().collect();
         assert_eq!(eqns.len(), 1);
     }
 
-    /// Check error handling.
+    /// Check error reporting when parsing a model from text.
     #[test]
     fn test_error_object_type() {
-        let th = Rc::new(stdlib::th_schema());
-        assert!(tt::modelgen::Model::from_text(&th.clone().into(), "[x : Entit]").is_none());
-    }
+        let th: TheoryDef = Rc::new(stdlib::th_schema()).into();
 
-    /// Check error handling.
-    #[test]
-    fn test_error_hom_type() {
-        let th = Rc::new(stdlib::th_schema());
-        assert!(
-            tt::modelgen::Model::from_text(&th.clone().into(), "[x : Entity, f : Hom(Entit)[x,x]")
-                .is_none()
-        );
-    }
+        let result = Model::from_text(&th, "[ : Entit]");
+        assert!(result.is_err_and(|msgs| !msgs.is_empty()));
 
-    /// Check error handling.
-    #[test]
-    fn test_error_hom_src() {
-        let th = Rc::new(stdlib::th_schema());
-        assert!(
-            tt::modelgen::Model::from_text(&th.clone().into(), "[x : Entity, f : Hom(Entity)[x,y]")
-                .is_none()
-        );
+        let result = Model::from_text(&th, "[x : Entity, f : Hom(Entit)[x,x]");
+        assert!(result.is_err_and(|msgs| !msgs.is_empty()));
+
+        let result = Model::from_text(&th, "[x : Entity, f : Hom(Entity)[x,y]");
+        assert!(result.is_err_and(|msgs| !msgs.is_empty()));
     }
 }


### PR DESCRIPTION
the `Model::from_text` function in `tt` presently has inconsistent behavior with errors in parsing. Some errors will result `None`, whereas others will result in silently ignoring an error. E.g. 

```rust 
    fn test_error_object_type() {
        let th = Rc::new(stdlib::th_schema());
        assert!(tt::modelgen::Model::from_text(&th.clone().into(), "[x : Entit]").is_none());
    }
```

Will actually return `Some(_)` with an empty model; `x` is just ignored (this happens because `Entit` is treated as a `MetaVar`). This PR addresses this - this requires looking at the `reporter` field of an `Elaborator`. My present solution simply makes this field public. Closes #1033