### PR TITLE
Allow auth headers for CORS to backend

### DIFF
--- a/packages/backend/src/main.rs
+++ b/packages/backend/src/main.rs
@@ -7,6 +7,7 @@ use axum::{Router, routing::get};
 use axum::{extract::State, response::IntoResponse};
 use clap::{Parser, Subcommand};
 use firebase_auth::FirebaseAuth;
+use http::header::AUTHORIZATION;
 use sqlx::postgres::PgPoolOptions;
 use sqlx_migrator::cli::MigrationCommand;
 use sqlx_migrator::migrator::{Migrate, Migrator};
@@ -211,7 +212,7 @@ async fn run_web_server(
         app = app.route("/", get(|| async { "Hello! The CatColab server is running" }));
     }
 
-    app = app.layer(CorsLayer::permissive());
+    app = app.layer(CorsLayer::permissive().allow_headers([AUTHORIZATION]));
 
     info!("Web server listening at port {port}");
 


### PR DESCRIPTION
Should get rid of this warning on console:



> Cross-Origin Request Warning: The Same Origin Policy will disallow reading the remote resource at `https://backend-next.catcolab.org/rpc?input=%257B%2522jsonrpc%2522%253A%25222.0%2522%252C%2522method%2522%253A%2522validate_session%2522%252C%2522id%2522%253A0%252C%2522params%2522%253A%255B%255D%257D` soon. (Reason: When the `Access-Control-Allow-Headers` is `*`, the `Authorization` header is not covered. To include the `Authorization` header, it must be explicitly listed in CORS header `Access-Control-Allow-Headers`).

