### PR TITLE
Update Darwin SDK references to new nixpkgs API

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -100,8 +100,6 @@
           darwinDeps =
             if pkgs.stdenv.isDarwin then
               [
-                pkgs.darwin.apple_sdk.frameworks.Security
-                pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
                 pkgs.libiconv
               ]
             else


### PR DESCRIPTION
possibly fix the error:

```
➜ CatColab (main) nix develop
[49.8 MiB DL] unpacking 'github:rust-lang/rust-analyzer/f8e784353bde7cbf9a9046285c1caf41ac484ebe?narHash=sha256-G4NwzhODScKnXq
error:
       … while calling the 'derivationStrict' builtin
         at «nix-internal»/derivation-internal.nix:38:12:
           37|
           38|   strict = drvFunc drvAttrs;
             |            ^
           39|

       … while evaluating derivation 'catcolab-devshell'
         whose name attribute is located at «github:nixos/nixpkgs/30a3c51»/pkgs/stdenv/generic/make-derivation.nix:541:13

       … while evaluating attribute '__impureHostDeps' of derivation 'catcolab-devshell'
         at «github:nixos/nixpkgs/30a3c51»/pkgs/stdenv/generic/make-derivation.nix:693:15:
          692|               );
          693|               __impureHostDeps =
             |               ^
          694|                 computedImpureHostDeps

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: darwin.apple_sdk_11_0 has been removed as it was a legacy compatibility stub; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin-legacy-frameworks> for migration instructions
```