### PR TITLE
Make CORS layer in backend very permissive

### DIFF
--- a/packages/backend/src/main.rs
+++ b/packages/backend/src/main.rs
@@ -7,7 +7,6 @@ use axum::{Router, routing::get};
 use axum::{extract::State, response::IntoResponse};
 use clap::{Parser, Subcommand};
 use firebase_auth::FirebaseAuth;
-use http::header::{AUTHORIZATION, CONTENT_TYPE};
 use sqlx::postgres::PgPoolOptions;
 use sqlx_migrator::cli::MigrationCommand;
 use sqlx_migrator::migrator::{Migrate, Migrator};
@@ -212,7 +211,7 @@ async fn run_web_server(
         app = app.route("/", get(|| async { "Hello! The CatColab server is running" }));
     }
 
-    app = app.layer(CorsLayer::permissive().allow_headers([AUTHORIZATION, CONTENT_TYPE]));
+    app = app.layer(CorsLayer::very_permissive());
 
     info!("Web server listening at port {port}");
 


### PR DESCRIPTION
It seems that with the auth allow headers added with #1097 next failed on creating new models because the added auth header overwrote the `Allow-Headers: *` that permissive sets.

I deployed this change to next to test because it's hard to reproduce on localhost. I left it up so people can continue to create new models on next if they need to.

EDIT: It seems the better fix is 6e9d4e60e887c608e790c75fa21608b5d32fda64 which uses `very_permissive()` (that in-turn uses `mirror_request()`) to say any headers the request sends are allowed, like we intended to with `permissive`. 