### PR TITLE
Put nix in nix, pinning it to same version as server

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -116,29 +116,30 @@
           buildInputs =
             with pkgs;
             [
-              darkhttpd
-              lld
-              rustToolchain
-              openssl
-              rust-analyzer
-              rustfmt
               clippy
+              darkhttpd
+              esbuild
+              lld
+              netcat
+              nodejs_24
+              nix
+              openssl
               pkg-config
               pnpm
-              nodejs_24
+              postgresql
+              python3
+              python312Packages.ipykernel
+              python312Packages.jupyter-core
+              python312Packages.jupyter-server
+              python312Packages.requests
+              python312Packages.websocket-client
+              rust-analyzer
+              rustToolchain
+              rustfmt
               sqlx-cli
-              wasm-pack
               vscode-langservers-extracted
               wasm-bindgen-cli
-              esbuild
-              python312Packages.jupyter-server
-              python312Packages.jupyter-core
-              python312Packages.websocket-client
-              python312Packages.requests
-              python312Packages.ipykernel
-              python3
-              netcat
-              postgresql
+              wasm-pack
             ]
             ++ darwinDeps
             ++ [


### PR DESCRIPTION
@jmoggr Yo, I heard you like nix so I put nix in your nix so we can deploy nix with the nix inside nix.

This pins the `nix` version to the same as what's on the server since I ran into issues running deploy with the newer 2.33 version. I also sorted the `buildInputs` alphabetically.