### PR TITLE
Enable table view analysis on staging server

### DIFF
--- a/packages/frontend/src/stdlib/theories/simple-schema.ts
+++ b/packages/frontend/src/stdlib/theories/simple-schema.ts
@@ -16,11 +16,11 @@ export default function createSchemaTheory(theoryMeta: TheoryMeta): Theory {
         }),
     ];
 
-    if (import.meta.env.DEV) {
+    if (import.meta.env.MODE !== "production") {
         diagramAnalyses.push(
             analyses.tabularView({
                 id: "tabularview",
-                name: "Tabular Visualization",
+                name: "Table view",
                 description: "Visualize the instance as a table",
                 help: "tabularview",
             }),


### PR DESCRIPTION
I had not read the [Vite docs](https://vite.dev/guide/env-and-mode) as carefully as I should have: the env vars `PROD` and `DEV` refer to the `NODE_ENV` variable, not the Vite mode, and [Node's own docs](https://nodejs.org/en/learn/getting-started/nodejs-the-difference-between-development-and-production) warn against ever setting `NODE_ENV` to anything other than `production`. An unfortunate situation all around.