### PR TITLE
Fix Safari font measurement for ELK visualizations

### DIFF
--- a/packages/frontend/src/visualization/font_utils.ts
+++ b/packages/frontend/src/visualization/font_utils.ts
@@ -5,9 +5,9 @@ import invariant from "tiny-invariant";
  * Returns a font specification string suitable for Canvas 2D context.
  */
 export function getMainFont(): string {
-    return `1rem ${getComputedStyle(document.documentElement)
-        .getPropertyValue("--main-font")
-        .trim()}`;
+    const style = getComputedStyle(document.documentElement);
+    const rootFontSize = parseFloat(style.fontSize);
+    return `${rootFontSize}px ${style.getPropertyValue("--main-font")}`;
 }
 
 /** Get the monospace font string for text measurement.
@@ -15,9 +15,9 @@ export function getMainFont(): string {
  * Returns a font specification string suitable for Canvas 2D context.
  */
 export function getMonoFont(): string {
-    return `1rem ${getComputedStyle(document.documentElement)
-        .getPropertyValue("--mono-font")
-        .trim()}`;
+    const style = getComputedStyle(document.documentElement);
+    const rootFontSize = parseFloat(style.fontSize);
+    return `${rootFontSize}px ${style.getPropertyValue("--mono-font")}`;
 }
 
 /** Measures the bounding box of text to be rendered in SVG.


### PR DESCRIPTION
Relative units like `rem` are resolved relative to the canvas element itself (or the document root for rem). When the canvas is not in the DOM there's no inherited styling context. The behavior becomes browser-dependent:
- Chrome/Firefox: Tend to resolve `1rem` against the document root's font size even for detached canvases, so it "works" 
- Safari: Appears to handle this more strictly it seems to fail to resolve `rem `properly producing incorrect measurements.