### PR TITLE
Pin biome binary from GitHub releases instead of nixpkgs-unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -186,22 +186,6 @@
         "type": "github"
       }
     },
-    "nixpkgsUnstable": {
-      "locked": {
-        "lastModified": 1767379071,
-        "narHash": "sha256-EgE0pxsrW9jp9YFMkHL9JMXxcqi/OoumPJYwf+Okucw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "fb7944c166a3b630f177938e478f0378e64ce108",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1743014863,
@@ -257,8 +241,7 @@
         "deploy-rs": "deploy-rs",
         "fenix": "fenix",
         "nixos-generators": "nixos-generators",
-        "nixpkgs": "nixpkgs_4",
-        "nixpkgsUnstable": "nixpkgsUnstable"
+        "nixpkgs": "nixpkgs_4"
       }
     },
     "rust-analyzer-src": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,10 +14,6 @@
       url = "github:ipetkov/crane";
     };
 
-    nixpkgsUnstable = {
-      url = "github:NixOS/nixpkgs/nixos-unstable";
-    };
-
     nixos-generators.url = "github:nix-community/nixos-generators";
   };
 
@@ -105,9 +101,6 @@
             else
               [ ];
 
-          pkgsUnstable = import inputs.nixpkgsUnstable {
-            system = "x86_64-linux";
-          };
           nightlyRustfmt = inputs.fenix.packages.${system}.latest.rustfmt;
         in
         pkgs.mkShell {
@@ -143,7 +136,7 @@
             ++ [
               inputs.agenix.packages.${system}.agenix
               inputs.deploy-rs.packages.${system}.default
-              pkgsUnstable.biome
+              (import ./infrastructure/biome.nix { inherit pkgs system; })
             ];
 
           # macOS-specific environment variables for OpenSSL and pkg-config

--- a/infrastructure/biome.nix
+++ b/infrastructure/biome.nix
@@ -1,0 +1,41 @@
+# Fetch biome binary directly from GitHub releases so we can pin the
+# exact version without hunting for a matching nixpkgs commit.
+#
+# To update: change `version`, then run `nix develop` — if the hashes are
+# wrong, nix will tell you the correct ones.
+{
+  pkgs,
+  system,
+}:
+let
+  version = "2.3.8";
+  platformMap = {
+    "x86_64-linux" = {
+      name = "biome-linux-x64-musl";
+      hash = "sha256-pj8YPrCl7eo2u2wC+RtApinsIltPUUV144T04A32Npw=";
+    };
+    "x86_64-darwin" = {
+      name = "biome-darwin-x64";
+      hash = "sha256-xBt0o6DYZC0JprS3GC+i3jGEIo7f+PHSiRq1V8LraxE=";
+    };
+    "aarch64-darwin" = {
+      name = "biome-darwin-arm64";
+      hash = "sha256-p9AF4yYzIv6uPsXRqkHBTf4EelN7QuBqs9G+IxS5HII=";
+    };
+  };
+  platform = platformMap.${system};
+in
+pkgs.stdenv.mkDerivation {
+  pname = "biome";
+  inherit version;
+  src = pkgs.fetchurl {
+    url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%40${version}/${platform.name}";
+    hash = platform.hash;
+  };
+  dontUnpack = true;
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $src $out/bin/biome
+    chmod +x $out/bin/biome
+  '';
+}


### PR DESCRIPTION
The version of `biome` installed through `npm` does not work on Nix systems. Previously we were using biome for `nixpkgs-unstable`, however finding commit in `nixpkgs-unstable` with the `biome` version that matched `npm` was a PITA.

Instead we can get a matching biome version directly from their releases.

Interestingly the executable in their release is statically linked, allowing it to work fine on nix. But that raises the question: where is the binary used by npm coming from? ¯\_(ツ)_/¯ just webdev things.