### PR TITLE
Tighten up docs on hash mismatch

### DIFF
--- a/dev-docs/fixing-hash-mismatches.md
+++ b/dev-docs/fixing-hash-mismatches.md
@@ -6,19 +6,26 @@ title: "Fixing hash mismatches in Nix"
 
 #### pnpm Dependencies in the Frontend
 
-This only applies to the `frontend` package.
+This only applies to the `frontend` package. The pnpm hash is located in `packages/frontend/default.nix`
+within the `pkgs.fetchPnpmDeps` block.
 
-The following error occurs when a dependency has changed but the Nix hash has not:
+When a pnpm dependency has changed but the Nix hash has not, running `nix build .#frontend` will fail
+with a hash mismatch that looks like this:
 ```
-> ERR_PNPM_NO_OFFLINE_TARBALL  A package is missing from the store but cannot download it in offline mode. The missing package may be downloaded from https://registry.npmjs.org/@automerge/prosemirror/-/prosemirror-0.2.0-alpha.0.tgz.
+error: hash mismatch in fixed-output derivation '/nix/store/4wpp80j18vvm232ii1ajl2kqnbfgvzq2-frontend-pnpm-deps.drv':
+         specified: sha256-vuBwhtNTTRbpgPZS+AQDybASYM9rwWYG8l0bscVQUso=
+            got:    sha256-sxczRF8IsYqQzmAAv+IiFeWJygqHCVnSk8fEuy5d1JM=
+```
+
+This can be fixed by replacing the `specified` hash in `packages/frontend/default.nix` with the `got` hash.
+
+You may also see a pnpm-specific error like this:
+```
+> ERR_PNPM_NO_OFFLINE_TARBALL  A package is missing from the store but cannot download it in offline mode.
 > ERROR: pnpm failed to install dependencies
 ```
 
-In this case you can follow the instructions:
-
-1. Set pnpmDeps.hash in packages/frontend/defaultnix to "" (empty string)
-2. Build the derivation by running `nix build .#frontend` and wait for it to fail with a hash mismatch
-3. Copy the 'got: sha256-' value back into the pnpmDeps.hash field
+This will be accompanied by the hash mismatch above and can be fixed the same way.
 
 
 #### Other Dependencies

--- a/dev-docs/fixing-hash-mismatches.md
+++ b/dev-docs/fixing-hash-mismatches.md
@@ -4,19 +4,7 @@ title: "Fixing hash mismatches in Nix"
 
 ### Fixing Hash Mismatches in Nix
 
-Nix uses **fixed-output derivations** to fetch external dependencies (from npm, crates.io, GitHub, etc.).
-These derivations require a cryptographic hash to verify that the fetched content matches what's expected,
-ensuring reproducibility and security.
-
-When a fixed-output dependency changes, so will its hash, causing a hash mismatch error in Nix.
-This generally happens in two scenarios:
-1. Intentional updates: You upgrade a package version
-2. Upstream changes: The upstream package was modified without a version change
-
-If you encounter a hash mismatch without updating anything it should probably be investigated: it means
-the external source changed unexpectedly.
-
-#### pnpm Dependencies
+#### pnpm Dependencies in the Frontend
 
 This only applies to the `frontend` package.
 
@@ -26,19 +14,11 @@ The following error occurs when a dependency has changed but the Nix hash has no
 > ERROR: pnpm failed to install dependencies
 ```
 
-In this case you can follow the instructions given below the error message:
-```
-> If you see ERR_PNPM_NO_OFFLINE_TARBALL above this, follow these to fix the issue:
-> 1. Set pnpmDeps.hash to "" (empty string)
-> 2. Build the derivation and wait for it to fail with a hash mismatch
-> 3. Copy the 'got: sha256-' value back into the pnpmDeps.hash field
-```
+In this case you can follow the instructions:
 
-The hash is located in `packages/frontend/default.nix` within the `pkgs.fetchPnpmDeps` block.
-You can search for the text "hash" to find it quickly.
-
-The frontend package can be built by running the command `nix build .#frontend` in the repository root.
-This will build the minimum needed to print the hash mismatch described in the instructions.
+1. Set pnpmDeps.hash in packages/frontend/defaultnix to "" (empty string)
+2. Build the derivation by running `nix build .#frontend` and wait for it to fail with a hash mismatch
+3. Copy the 'got: sha256-' value back into the pnpmDeps.hash field
 
 
 #### Other Dependencies
@@ -58,3 +38,18 @@ Currently all hashes except for `pnpm` are defined in `flake.nix` in the repo ro
 You may encounter hash mismatches for these dependencies:
 - wasm-bindgen-cli
 - rust-toolchain
+
+
+#### Explanation
+
+Nix uses **fixed-output derivations** to fetch external dependencies (from npm, crates.io, GitHub, etc.).
+These derivations require a cryptographic hash to verify that the fetched content matches what's expected,
+ensuring reproducibility and security.
+
+When a fixed-output dependency changes, so will its hash, causing a hash mismatch error in Nix.
+This generally happens in two scenarios:
+1. Intentional updates: You upgrade a package version
+2. Upstream changes: The upstream package was modified without a version change
+
+If you encounter a hash mismatch without updating anything it should probably be investigated: it means
+the external source changed unexpectedly.


### PR DESCRIPTION
These are a bit too wordy for a situation where we normally "just want to get the check to pass". Also they talk about "instructions given below the error message" which don't seem to exist. 