### PR TITLE
Fix build for staging falling back to production due to bash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
           pnpm install
           pnpm --filter ./packages/frontend run build:deps
           # Uses env from packages/frontend/.env.staging
-          pnpm --filter ./packages/frontend run build -- --mode staging
+          pnpm --filter ./packages/frontend run build:staging
 
       - name: Build for Production
         if: github.event_name == 'release'

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -10,6 +10,7 @@
         "build:tcm": "tcm -p 'src/**/*.module.css' . && npm run format",
         "build:deps": "npm run build:wasm && npm run build:bindings && npm run build:tcm",
         "build": "tsc -b && vite build --sourcemap true",
+        "build:staging": "tsc -b && vite build --sourcemap true --mode staging",
         "preview": "vite preview",
         "format": "biome format --write",
         "check": "npm run build:deps && npm run lint && tsc",


### PR DESCRIPTION
#1136 implicitly changed how the the shell expansion of `-- --mode staging`. It became a positional argument instead of an option. This is kind of hard to trace because the code does not interact directly.