### PR TITLE
Stop running biome format after tcm

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -7,7 +7,7 @@
     "scripts": {
         "build:wasm": "npm --prefix ../catlog-wasm run build:browser",
         "build:bindings": "cargo run -p backend -- generate-bindings",
-        "build:tcm": "tcm -p 'src/**/*.module.css' . && npm run format",
+        "build:tcm": "tcm -p 'src/**/*.module.css' .",
         "build:deps": "npm run build:wasm && npm run build:bindings && npm run build:tcm",
         "build": "tsc -b && vite build --sourcemap true",
         "build:staging": "tsc -b && vite build --sourcemap true --mode staging",


### PR DESCRIPTION
The files are ignored from git and ignored in biome anyway. The .#frontend nix job needs to run tcm but doesn't have biome.