### PR TITLE
Notify client when server version changes mid-session

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -205,6 +205,7 @@
           backend = pkgsLinux.callPackage ./packages/backend/default.nix {
             inherit craneLib cargoArtifacts;
             pkgs = pkgsLinux;
+            gitHash = self.rev or "dev";
           };
 
           migrator = pkgsLinux.callPackage ./packages/migrator/default.nix {

--- a/packages/backend/build.rs
+++ b/packages/backend/build.rs
@@ -1,0 +1,8 @@
+//! Build script that embeds the git hash into the binary at compile time.
+//! The build script's cached output is invalidated when the `GIT_HASH` env var changes.
+
+fn main() {
+    let hash = std::env::var("GIT_HASH").unwrap_or_else(|_| "dev".to_string());
+    println!("cargo:rustc-env=GIT_HASH={hash}");
+    println!("cargo:rerun-if-env-changed=GIT_HASH");
+}

--- a/packages/backend/default.nix
+++ b/packages/backend/default.nix
@@ -2,6 +2,7 @@
   craneLib,
   cargoArtifacts,
   pkgs,
+  gitHash,
 }:
 let
   crate = craneLib.crateNameFromCargoToml {
@@ -12,6 +13,8 @@ let
 in
 craneLib.buildPackage {
   inherit cargoArtifacts pname version;
+
+  GIT_HASH = gitHash;
 
   cargoExtraArgs = "-p backend --config profile.release.opt-level=3";
 

--- a/packages/backend/src/main.rs
+++ b/packages/backend/src/main.rs
@@ -2,7 +2,7 @@
 
 use axum::extract::Request;
 use axum::extract::ws::WebSocketUpgrade;
-use axum::middleware::from_fn_with_state;
+use axum::middleware::{from_fn, from_fn_with_state};
 use axum::{Router, routing::get};
 use axum::{extract::State, response::IntoResponse};
 use clap::{Parser, Subcommand};
@@ -167,6 +167,18 @@ async fn status_handler() -> &'static str {
     "Running"
 }
 
+async fn version_header_middleware(
+    req: Request<axum::body::Body>,
+    next: axum::middleware::Next,
+) -> impl IntoResponse {
+    let mut response = next.run(req).await;
+    response.headers_mut().insert(
+        http::header::HeaderName::from_static("git-hash"),
+        http::HeaderValue::from_static(env!("GIT_HASH")),
+    );
+    response
+}
+
 async fn websocket_handler(
     ws: WebSocketUpgrade,
     State(repo): State<samod::Repo>,
@@ -190,6 +202,7 @@ async fn run_web_server(
     let (qubit_service, qubit_handle) = rpc_router.as_rpc(state.clone()).into_service();
 
     let rpc_with_mw = ServiceBuilder::new()
+        .layer(from_fn(version_header_middleware))
         .layer(from_fn_with_state(firebase_auth.clone(), auth_middleware))
         .service(qubit_service);
 
@@ -218,7 +231,10 @@ async fn run_web_server(
         app = app.route("/", get(|| async { "Hello! The CatColab server is running" }));
     }
 
-    app = app.layer(CorsLayer::very_permissive());
+    app = app.layer(
+        CorsLayer::very_permissive()
+            .expose_headers([http::header::HeaderName::from_static("git-hash")]),
+    );
 
     info!("Web server listening at port {port}");
 

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -28,7 +28,13 @@ const Root = (props: RouteSectionProps) => {
     invariant(repoUrl, "Must set environment variable VITE_AUTOMERGE_REPO_URL");
 
     const firebaseApp = initializeApp(firebaseOptions);
-    const api = new Api({ serverUrl, repoUrl, firebaseApp });
+    const [isVersionMismatch, setVersionMismatch] = createSignal(false);
+    const api = new Api({
+        serverUrl,
+        repoUrl,
+        firebaseApp,
+        onVersionChange: () => setVersionMismatch(true),
+    });
 
     const [isSessionInvalid] = createResource(
         // oxlint-disable-next-line solid/reactivity -- createResource fetcher
@@ -65,6 +71,9 @@ const Root = (props: RouteSectionProps) => {
                     <Show when={isSessionInvalid()}>
                         <SessionExpiredModal />
                     </Show>
+                    <Show when={isVersionMismatch()}>
+                        <VersionMismatchModal />
+                    </Show>
                 </MetaProvider>
             </FirebaseProvider>
         </MultiProvider>
@@ -93,6 +102,25 @@ export function SessionExpiredModal() {
                     <p>Your session is no longer valid. Please reload the page to continue.</p>
                     <Button variant="positive" onClick={handleReload} disabled={reloading()}>
                         {reloading() ? "Reloading..." : "Reload Page"}
+                    </Button>
+                </Content>
+            </Portal>
+        </Dialog>
+    );
+}
+
+function VersionMismatchModal() {
+    return (
+        <Dialog initialOpen={true}>
+            <Portal>
+                <Content class="popup">
+                    <h3>New Version Available</h3>
+                    <p>
+                        The server has been updated. Please reload the page to get the latest
+                        version.
+                    </p>
+                    <Button variant="positive" onClick={() => location.reload()}>
+                        Reload Page
                     </Button>
                 </Content>
             </Portal>

--- a/packages/frontend/src/api/rpc.ts
+++ b/packages/frontend/src/api/rpc.ts
@@ -9,8 +9,14 @@ import type { QubitServer, RpcResult } from "catcolab-api";
 export type RpcClient = QubitServer;
 
 /** Create the RPC client for communicating with the backend. */
-export function createRpcClient(serverUrl: string, firebaseApp?: FirebaseApp) {
+export function createRpcClient(
+    serverUrl: string,
+    firebaseApp?: FirebaseApp,
+    onVersionChange?: () => void,
+) {
     let currentUser: User | null = null;
+    let serverVersion: string | null = null;
+
     const authInitialized = new Promise<null>((resolve) => {
         if (firebaseApp) {
             getAuth(firebaseApp).onAuthStateChanged((user) => {
@@ -33,7 +39,18 @@ export function createRpcClient(serverUrl: string, firebaseApp?: FirebaseApp) {
                 headers,
             };
         }
-        return await fetch(input, init);
+        const response = await fetch(input, init);
+
+        const gitHash = response.headers.get("git-hash");
+        if (gitHash && gitHash !== "dev") {
+            if (serverVersion === null) {
+                serverVersion = gitHash;
+            } else if (gitHash !== serverVersion) {
+                onVersionChange?.();
+            }
+        }
+
+        return response;
     };
     const transport = http(`${serverUrl}/rpc`, {
         fetch: fetchWithAuth,

--- a/packages/frontend/src/api/types.ts
+++ b/packages/frontend/src/api/types.ts
@@ -35,10 +35,15 @@ export class Api {
      */
     private readonly docCache: Map<Uuid, DocCacheEntry>;
 
-    constructor(props: { serverUrl: string; repoUrl: string; firebaseApp: FirebaseApp }) {
+    constructor(props: {
+        serverUrl: string;
+        repoUrl: string;
+        firebaseApp: FirebaseApp;
+        onVersionChange?: () => void;
+    }) {
         this.serverHost = new URL(props.serverUrl).host;
 
-        this.rpc = createRpcClient(props.serverUrl, props.firebaseApp);
+        this.rpc = createRpcClient(props.serverUrl, props.firebaseApp, props.onVersionChange);
 
         this.repo = new Repo({
             storage: new IndexedDBStorageAdapter("catcolab"),


### PR DESCRIPTION
Notify long running clients when the backend changes.

The frontend is checking if the git hash returned in an RPC header is different from the last hash it saw. This sidesteps the issue where the frontend and backend are often deployed independently, with one changing but not the other.

This does not handle the case where:
- there is a new version of the frontend available
- the browser loads a stale frontend from cache (this is unlikely, since netlify handles cache busting for us).

However I don't think it's possible to handle those cases while we are deploying the frontend and backend independently. While this isn't perfect, I think it's fairly minimal and would have at least saved myself a couple for :facepalm: moments.