### PR TITLE
Fix deployment status 'Not Found' error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -162,6 +162,8 @@ jobs:
       - name: Update deployment status to success
         if: needs.deploy.result == 'success'
         uses: chrnorm/deployment-status@v2
+        # The deployment may have already been deleted by another run so we need to be ok with errors
+        continue-on-error: true
         with:
           token: ${{ github.token }}
           environment-url: ${{ needs.deploy.outputs.deploy_url }}
@@ -173,6 +175,8 @@ jobs:
       - name: Update deployment status to failure
         if: needs.deploy.result != 'success'
         uses: chrnorm/deployment-status@v2
+        # The deployment may have already been deleted by another run so we need to be ok with errors
+        continue-on-error: true
         with:
           token: ${{ github.token }}
           log-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
Since deleting deployments #1094 there is a race condition where a subsequent run can delete deployments that the previous run wants to set a status on ([example](https://github.com/ToposInstitute/CatColab/actions/runs/23595003621/job/68709456244)). The workaround/fix is to just be ok with failing to set a status on a deployment. 