### PR TITLE
Make default editors for objects and morphisms explicit

### DIFF
--- a/packages/frontend/src/model/model_editor.tsx
+++ b/packages/frontend/src/model/model_editor.tsx
@@ -13,8 +13,6 @@ import { TheoryLibraryContext, type ModelTypeMeta, type Theory } from "../theory
 import { LiveModelContext } from "./context";
 import type { LiveModelDoc } from "./document";
 import { InstantiationCellEditor } from "./instantiation_cell_editor";
-import { MorphismCellEditor } from "./morphism_cell_editor";
-import { ObjectCellEditor } from "./object_cell_editor";
 import {
     duplicateModelJudgment,
     newInstantiatedModel,
@@ -68,7 +66,8 @@ export function ModelCellEditor(props: FormalCellEditorProps<ModelJudgment>) {
                 {(theory) => {
                     const obDecl = () => props.content as ObDecl;
                     const editor = () =>
-                        editorOverrides()?.obEditors?.get(obDecl().obType) ?? ObjectCellEditor;
+                        editorOverrides()?.obEditors?.get(obDecl().obType) ??
+                        theory().modelObTypeMeta(obDecl().obType)?.editor;
                     return (
                         <Dynamic
                             component={editor()}
@@ -87,7 +86,8 @@ export function ModelCellEditor(props: FormalCellEditorProps<ModelJudgment>) {
                 {(theory) => {
                     const morDecl = () => props.content as MorDecl;
                     const editor = () =>
-                        editorOverrides()?.morEditors?.get(morDecl().morType) ?? MorphismCellEditor;
+                        editorOverrides()?.morEditors?.get(morDecl().morType) ??
+                        theory().modelMorTypeMeta(morDecl().morType)?.editor;
                     return (
                         <Dynamic
                             component={editor()}

--- a/packages/frontend/src/model/morphism_cell_editor.tsx
+++ b/packages/frontend/src/model/morphism_cell_editor.tsx
@@ -11,7 +11,7 @@ import arrowStyles from "../stdlib/arrow_styles.module.css";
 import "./morphism_cell_editor.css";
 
 /** Editor for a morphism declaration cell in a model. */
-export function MorphismCellEditor(props: MorphismEditorProps) {
+export default function MorphismCellEditor(props: MorphismEditorProps) {
     const liveModel = useContext(LiveModelContext);
     invariant(liveModel, "Live model should be provided as context");
 

--- a/packages/frontend/src/model/object_cell_editor.tsx
+++ b/packages/frontend/src/model/object_cell_editor.tsx
@@ -6,7 +6,7 @@ import type { ObjectEditorProps } from "./editors";
 import "./object_cell_editor.css";
 
 /** Editor for an object declaration cell in a model. */
-export function ObjectCellEditor(props: ObjectEditorProps) {
+export default function ObjectCellEditor(props: ObjectEditorProps) {
     const cssClasses = () => [
         "formal-judgment",
         "object-decl",

--- a/packages/frontend/src/stdlib/theories/causal-loop-delays.ts
+++ b/packages/frontend/src/stdlib/theories/causal-loop-delays.ts
@@ -1,8 +1,11 @@
+import { lazy } from "solid-js";
+
 import { ThDelayableSignedCategory } from "catlog-wasm";
-import { MorphismCellEditor } from "../../model/morphism_cell_editor";
-import { ObjectCellEditor } from "../../model/object_cell_editor";
 import { Theory, type TheoryMeta } from "../../theory";
 import * as analyses from "../analyses";
+
+const ObjectCellEditor = lazy(() => import("../../model/object_cell_editor"));
+const MorphismCellEditor = lazy(() => import("../../model/morphism_cell_editor"));
 
 export default function createCausalLoopDelaysTheory(theoryMeta: TheoryMeta): Theory {
     const thDelayedSignedCategory = new ThDelayableSignedCategory();

--- a/packages/frontend/src/stdlib/theories/causal-loop-delays.ts
+++ b/packages/frontend/src/stdlib/theories/causal-loop-delays.ts
@@ -1,4 +1,6 @@
 import { ThDelayableSignedCategory } from "catlog-wasm";
+import { MorphismCellEditor } from "../../model/morphism_cell_editor";
+import { ObjectCellEditor } from "../../model/object_cell_editor";
 import { Theory, type TheoryMeta } from "../../theory";
 import * as analyses from "../analyses";
 
@@ -19,6 +21,7 @@ export default function createCausalLoopDelaysTheory(theoryMeta: TheoryMeta): Th
             {
                 tag: "ObType",
                 obType: { tag: "Basic", content: "Object" },
+                editor: ObjectCellEditor,
                 name: "Variable",
                 shortcut: ["V"],
                 description: "Variable quantity",
@@ -29,6 +32,7 @@ export default function createCausalLoopDelaysTheory(theoryMeta: TheoryMeta): Th
                     tag: "Hom",
                     content: { tag: "Basic", content: "Object" },
                 },
+                editor: MorphismCellEditor,
                 name: "Positive link",
                 shortcut: ["P"],
                 description: "Fast-acting positive influence",
@@ -38,6 +42,7 @@ export default function createCausalLoopDelaysTheory(theoryMeta: TheoryMeta): Th
             {
                 tag: "MorType",
                 morType: { tag: "Basic", content: "Negative" },
+                editor: MorphismCellEditor,
                 name: "Negative link",
                 shortcut: ["N"],
                 description: "Fast-acting negative influence",
@@ -47,6 +52,7 @@ export default function createCausalLoopDelaysTheory(theoryMeta: TheoryMeta): Th
             {
                 tag: "MorType",
                 morType: { tag: "Basic", content: "PositiveSlow" },
+                editor: MorphismCellEditor,
                 name: "Delayed positive link",
                 description: "Slow-acting positive influence",
                 arrowStyle: "plusCaesura",
@@ -55,6 +61,7 @@ export default function createCausalLoopDelaysTheory(theoryMeta: TheoryMeta): Th
             {
                 tag: "MorType",
                 morType: { tag: "Basic", content: "NegativeSlow" },
+                editor: MorphismCellEditor,
                 name: "Delayed negative link",
                 description: "Slow-acting negative influence",
                 arrowStyle: "minusCaesura",

--- a/packages/frontend/src/stdlib/theories/causal-loop.ts
+++ b/packages/frontend/src/stdlib/theories/causal-loop.ts
@@ -1,8 +1,11 @@
+import { lazy } from "solid-js";
+
 import { ThSignedCategory } from "catlog-wasm";
-import { MorphismCellEditor } from "../../model/morphism_cell_editor";
-import { ObjectCellEditor } from "../../model/object_cell_editor";
 import { Theory, type TheoryMeta } from "../../theory";
 import * as analyses from "../analyses";
+
+const ObjectCellEditor = lazy(() => import("../../model/object_cell_editor"));
+const MorphismCellEditor = lazy(() => import("../../model/morphism_cell_editor"));
 
 export default function createCausalLoopTheory(theoryMeta: TheoryMeta): Theory {
     const thSignedCategory = new ThSignedCategory();

--- a/packages/frontend/src/stdlib/theories/causal-loop.ts
+++ b/packages/frontend/src/stdlib/theories/causal-loop.ts
@@ -1,4 +1,6 @@
 import { ThSignedCategory } from "catlog-wasm";
+import { MorphismCellEditor } from "../../model/morphism_cell_editor";
+import { ObjectCellEditor } from "../../model/object_cell_editor";
 import { Theory, type TheoryMeta } from "../../theory";
 import * as analyses from "../analyses";
 
@@ -14,6 +16,7 @@ export default function createCausalLoopTheory(theoryMeta: TheoryMeta): Theory {
             {
                 tag: "ObType",
                 obType: { tag: "Basic", content: "Object" },
+                editor: ObjectCellEditor,
                 name: "Variable",
                 shortcut: ["V"],
                 description: "Variable quantity",
@@ -24,6 +27,7 @@ export default function createCausalLoopTheory(theoryMeta: TheoryMeta): Theory {
                     tag: "Hom",
                     content: { tag: "Basic", content: "Object" },
                 },
+                editor: MorphismCellEditor,
                 name: "Positive link",
                 shortcut: ["P"],
                 description: "Variables change in the same direction",
@@ -33,6 +37,7 @@ export default function createCausalLoopTheory(theoryMeta: TheoryMeta): Theory {
             {
                 tag: "MorType",
                 morType: { tag: "Basic", content: "Negative" },
+                editor: MorphismCellEditor,
                 name: "Negative link",
                 shortcut: ["N"],
                 description: "Variables change in the opposite direction",

--- a/packages/frontend/src/stdlib/theories/indeterminate-causal-loop.ts
+++ b/packages/frontend/src/stdlib/theories/indeterminate-causal-loop.ts
@@ -1,4 +1,6 @@
 import { ThNullableSignedCategory } from "catlog-wasm";
+import { MorphismCellEditor } from "../../model/morphism_cell_editor";
+import { ObjectCellEditor } from "../../model/object_cell_editor";
 import { Theory, type TheoryMeta } from "../../theory";
 import * as analyses from "../analyses";
 
@@ -13,6 +15,7 @@ export default function createIndeterminateCausalLoopTheory(theoryMeta: TheoryMe
             {
                 tag: "ObType",
                 obType: { tag: "Basic", content: "Object" },
+                editor: ObjectCellEditor,
                 name: "Variable",
                 shortcut: ["V"],
                 description: "Variable quantity",
@@ -23,6 +26,7 @@ export default function createIndeterminateCausalLoopTheory(theoryMeta: TheoryMe
                     tag: "Hom",
                     content: { tag: "Basic", content: "Object" },
                 },
+                editor: MorphismCellEditor,
                 name: "Positive link",
                 description: "Variables change in the same direction",
                 shortcut: ["P"],
@@ -32,6 +36,7 @@ export default function createIndeterminateCausalLoopTheory(theoryMeta: TheoryMe
             {
                 tag: "MorType",
                 morType: { tag: "Basic", content: "Negative" },
+                editor: MorphismCellEditor,
                 name: "Negative link",
                 shortcut: ["N"],
                 description: "Variables change in the opposite direction",
@@ -41,6 +46,7 @@ export default function createIndeterminateCausalLoopTheory(theoryMeta: TheoryMe
             {
                 tag: "MorType",
                 morType: { tag: "Basic", content: "Zero" },
+                editor: MorphismCellEditor,
                 name: "Indeterminate link",
                 description: "The direction that variables change is indeterminate",
                 shortcut: ["Z"],

--- a/packages/frontend/src/stdlib/theories/indeterminate-causal-loop.ts
+++ b/packages/frontend/src/stdlib/theories/indeterminate-causal-loop.ts
@@ -1,8 +1,11 @@
+import { lazy } from "solid-js";
+
 import { ThNullableSignedCategory } from "catlog-wasm";
-import { MorphismCellEditor } from "../../model/morphism_cell_editor";
-import { ObjectCellEditor } from "../../model/object_cell_editor";
 import { Theory, type TheoryMeta } from "../../theory";
 import * as analyses from "../analyses";
+
+const ObjectCellEditor = lazy(() => import("../../model/object_cell_editor"));
+const MorphismCellEditor = lazy(() => import("../../model/morphism_cell_editor"));
 
 export default function createIndeterminateCausalLoopTheory(theoryMeta: TheoryMeta): Theory {
     const thNullableSignedCategory = new ThNullableSignedCategory();

--- a/packages/frontend/src/stdlib/theories/petri-net.ts
+++ b/packages/frontend/src/stdlib/theories/petri-net.ts
@@ -1,11 +1,12 @@
 import { lazy } from "solid-js";
 
 import { ThSymMonoidalCategory } from "catlog-wasm";
-import { MorphismCellEditor } from "../../model/morphism_cell_editor";
-import { ObjectCellEditor } from "../../model/object_cell_editor";
 import { Theory, type TheoryMeta } from "../../theory";
 import { MorTypeMap } from "../../theory/types";
 import * as analyses from "../analyses";
+
+const ObjectCellEditor = lazy(() => import("../../model/object_cell_editor"));
+const MorphismCellEditor = lazy(() => import("../../model/morphism_cell_editor"));
 
 export default function createPetriNetTheory(theoryMeta: TheoryMeta): Theory {
     const thSymMonoidalCategory = new ThSymMonoidalCategory();

--- a/packages/frontend/src/stdlib/theories/petri-net.ts
+++ b/packages/frontend/src/stdlib/theories/petri-net.ts
@@ -1,6 +1,8 @@
 import { lazy } from "solid-js";
 
 import { ThSymMonoidalCategory } from "catlog-wasm";
+import { MorphismCellEditor } from "../../model/morphism_cell_editor";
+import { ObjectCellEditor } from "../../model/object_cell_editor";
 import { Theory, type TheoryMeta } from "../../theory";
 import { MorTypeMap } from "../../theory/types";
 import * as analyses from "../analyses";
@@ -38,6 +40,7 @@ export default function createPetriNetTheory(theoryMeta: TheoryMeta): Theory {
             {
                 tag: "ObType",
                 obType: { tag: "Basic", content: "Object" },
+                editor: ObjectCellEditor,
                 name: "Place",
                 description: "State of the system",
                 shortcut: ["O"],
@@ -48,6 +51,7 @@ export default function createPetriNetTheory(theoryMeta: TheoryMeta): Theory {
                     tag: "Hom",
                     content: { tag: "Basic", content: "Object" },
                 },
+                editor: MorphismCellEditor,
                 name: "Transition",
                 description: "Event causing change of state",
                 shortcut: ["M"],

--- a/packages/frontend/src/stdlib/theories/polynomial-ode.ts
+++ b/packages/frontend/src/stdlib/theories/polynomial-ode.ts
@@ -1,6 +1,11 @@
+import { lazy } from "solid-js";
+
 import { ThPolynomialODE } from "catlog-wasm";
 import { Theory, type TheoryMeta } from "../../theory";
 import * as analyses from "../analyses";
+
+const ObjectCellEditor = lazy(() => import("../../model/object_cell_editor"));
+const MorphismCellEditor = lazy(() => import("../../model/morphism_cell_editor"));
 
 export default function createPolynomialODETheory(theoryMeta: TheoryMeta): Theory {
     const thPolynomialODE = new ThPolynomialODE();
@@ -13,6 +18,7 @@ export default function createPolynomialODETheory(theoryMeta: TheoryMeta): Theor
             {
                 tag: "ObType",
                 obType: { tag: "Basic", content: "State" },
+                editor: ObjectCellEditor,
                 name: "Variable",
                 description: "State variable in ODE system",
                 shortcut: ["V"],
@@ -20,6 +26,7 @@ export default function createPolynomialODETheory(theoryMeta: TheoryMeta): Theor
             {
                 tag: "MorType",
                 morType: { tag: "Basic", content: "Contribution" },
+                editor: MorphismCellEditor,
                 name: "Contribution",
                 description: "Monomial contribution to ODE system",
                 shortcut: ["C"],

--- a/packages/frontend/src/stdlib/theories/power-system.ts
+++ b/packages/frontend/src/stdlib/theories/power-system.ts
@@ -1,8 +1,11 @@
+import { lazy } from "solid-js";
+
 import { ThPowerSystem } from "catlog-wasm";
-import { MorphismCellEditor } from "../../model/morphism_cell_editor";
-import { ObjectCellEditor } from "../../model/object_cell_editor";
 import { Theory, type TheoryMeta } from "../../theory";
 import * as analyses from "../analyses";
+
+const ObjectCellEditor = lazy(() => import("../../model/object_cell_editor"));
+const MorphismCellEditor = lazy(() => import("../../model/morphism_cell_editor"));
 
 export default function createPowerSystemsTheory(theoryMeta: TheoryMeta): Theory {
     const thPowerSystem = new ThPowerSystem();

--- a/packages/frontend/src/stdlib/theories/power-system.ts
+++ b/packages/frontend/src/stdlib/theories/power-system.ts
@@ -1,4 +1,6 @@
 import { ThPowerSystem } from "catlog-wasm";
+import { MorphismCellEditor } from "../../model/morphism_cell_editor";
+import { ObjectCellEditor } from "../../model/object_cell_editor";
 import { Theory, type TheoryMeta } from "../../theory";
 import * as analyses from "../analyses";
 
@@ -13,6 +15,7 @@ export default function createPowerSystemsTheory(theoryMeta: TheoryMeta): Theory
             {
                 tag: "ObType",
                 obType: { tag: "Basic", content: "Bus" },
+                editor: ObjectCellEditor,
                 name: "Bus",
                 description: "Node in the power system",
                 shortcut: ["B"],
@@ -23,6 +26,7 @@ export default function createPowerSystemsTheory(theoryMeta: TheoryMeta): Theory
                     tag: "Hom",
                     content: { tag: "Basic", content: "Bus" },
                 },
+                editor: MorphismCellEditor,
                 name: "Line",
                 description: "Passive line between buses",
                 arrowStyle: "unmarked",
@@ -32,6 +36,7 @@ export default function createPowerSystemsTheory(theoryMeta: TheoryMeta): Theory
             {
                 tag: "MorType",
                 morType: { tag: "Basic", content: "Passive" },
+                editor: MorphismCellEditor,
                 name: "Transformer",
                 description: "Passive line allowing a change of voltage",
                 arrowStyle: "unmarked",
@@ -40,6 +45,7 @@ export default function createPowerSystemsTheory(theoryMeta: TheoryMeta): Theory
             {
                 tag: "MorType",
                 morType: { tag: "Basic", content: "Branch" },
+                editor: MorphismCellEditor,
                 name: "Link",
                 description: "Controllable flow between buses",
                 arrowStyle: "unmarked",

--- a/packages/frontend/src/stdlib/theories/primitive-signed-stock-flow.ts
+++ b/packages/frontend/src/stdlib/theories/primitive-signed-stock-flow.ts
@@ -1,4 +1,6 @@
 import { ThCategorySignedLinks } from "catlog-wasm";
+import { MorphismCellEditor } from "../../model/morphism_cell_editor";
+import { ObjectCellEditor } from "../../model/object_cell_editor";
 import { Theory, type TheoryMeta } from "../../theory";
 import * as analyses from "../analyses";
 
@@ -16,6 +18,7 @@ export default function createPrimitiveSignedStockFlowTheory(theoryMeta: TheoryM
             {
                 tag: "ObType",
                 obType: { tag: "Basic", content: "Object" },
+                editor: ObjectCellEditor,
                 name: "Stock",
                 description: "Thing with an amount",
                 shortcut: ["S"],
@@ -28,6 +31,7 @@ export default function createPrimitiveSignedStockFlowTheory(theoryMeta: TheoryM
                     tag: "Hom",
                     content: { tag: "Basic", content: "Object" },
                 },
+                editor: MorphismCellEditor,
                 name: "Flow",
                 description: "Flow from one stock to another",
                 shortcut: ["F"],
@@ -36,6 +40,7 @@ export default function createPrimitiveSignedStockFlowTheory(theoryMeta: TheoryM
             {
                 tag: "MorType",
                 morType: { tag: "Basic", content: "Link" },
+                editor: MorphismCellEditor,
                 name: "Positive link",
                 description: "Positive influence of a stock on a flow",
                 arrowStyle: "plus",
@@ -45,6 +50,7 @@ export default function createPrimitiveSignedStockFlowTheory(theoryMeta: TheoryM
             {
                 tag: "MorType",
                 morType: { tag: "Basic", content: "NegativeLink" },
+                editor: MorphismCellEditor,
                 name: "Negative link",
                 description: "Negative influence of a stock on a flow",
                 arrowStyle: "minus",

--- a/packages/frontend/src/stdlib/theories/primitive-signed-stock-flow.ts
+++ b/packages/frontend/src/stdlib/theories/primitive-signed-stock-flow.ts
@@ -1,8 +1,11 @@
+import { lazy } from "solid-js";
+
 import { ThCategorySignedLinks } from "catlog-wasm";
-import { MorphismCellEditor } from "../../model/morphism_cell_editor";
-import { ObjectCellEditor } from "../../model/object_cell_editor";
 import { Theory, type TheoryMeta } from "../../theory";
 import * as analyses from "../analyses";
+
+const ObjectCellEditor = lazy(() => import("../../model/object_cell_editor"));
+const MorphismCellEditor = lazy(() => import("../../model/morphism_cell_editor"));
 
 import styles from "../styles.module.css";
 import svgStyles from "../svg_styles.module.css";

--- a/packages/frontend/src/stdlib/theories/primitive-stock-flow.ts
+++ b/packages/frontend/src/stdlib/theories/primitive-stock-flow.ts
@@ -1,4 +1,6 @@
 import { ThCategoryLinks } from "catlog-wasm";
+import { MorphismCellEditor } from "../../model/morphism_cell_editor";
+import { ObjectCellEditor } from "../../model/object_cell_editor";
 import { Theory, type TheoryMeta } from "../../theory";
 import * as analyses from "../analyses";
 
@@ -17,6 +19,7 @@ export default function createPrimitiveStockFlowTheory(theoryMeta: TheoryMeta): 
             {
                 tag: "ObType",
                 obType: { tag: "Basic", content: "Object" },
+                editor: ObjectCellEditor,
                 name: "Stock",
                 description: "Thing with an amount",
                 shortcut: ["S"],
@@ -29,6 +32,7 @@ export default function createPrimitiveStockFlowTheory(theoryMeta: TheoryMeta): 
                     tag: "Hom",
                     content: { tag: "Basic", content: "Object" },
                 },
+                editor: MorphismCellEditor,
                 name: "Flow",
                 description: "Flow from one stock to another",
                 shortcut: ["F"],
@@ -37,6 +41,7 @@ export default function createPrimitiveStockFlowTheory(theoryMeta: TheoryMeta): 
             {
                 tag: "MorType",
                 morType: { tag: "Basic", content: "Link" },
+                editor: MorphismCellEditor,
                 name: "Link",
                 description: "Influence of a stock on a flow",
                 preferUnnamed: true,

--- a/packages/frontend/src/stdlib/theories/primitive-stock-flow.ts
+++ b/packages/frontend/src/stdlib/theories/primitive-stock-flow.ts
@@ -1,8 +1,11 @@
+import { lazy } from "solid-js";
+
 import { ThCategoryLinks } from "catlog-wasm";
-import { MorphismCellEditor } from "../../model/morphism_cell_editor";
-import { ObjectCellEditor } from "../../model/object_cell_editor";
 import { Theory, type TheoryMeta } from "../../theory";
 import * as analyses from "../analyses";
+
+const ObjectCellEditor = lazy(() => import("../../model/object_cell_editor"));
+const MorphismCellEditor = lazy(() => import("../../model/morphism_cell_editor"));
 
 import styles from "../styles.module.css";
 import svgStyles from "../svg_styles.module.css";

--- a/packages/frontend/src/stdlib/theories/reg-net.ts
+++ b/packages/frontend/src/stdlib/theories/reg-net.ts
@@ -1,4 +1,6 @@
 import { ThSignedCategory } from "catlog-wasm";
+import { MorphismCellEditor } from "../../model/morphism_cell_editor";
+import { ObjectCellEditor } from "../../model/object_cell_editor";
 import { Theory, type TheoryMeta } from "../../theory";
 import * as analyses from "../analyses";
 
@@ -14,6 +16,7 @@ export default function createRegulatoryNetworkTheory(theoryMeta: TheoryMeta): T
             {
                 tag: "ObType",
                 obType: { tag: "Basic", content: "Object" },
+                editor: ObjectCellEditor,
                 name: "Species",
                 shortcut: ["S"],
                 description: "Biochemical species in the network",
@@ -24,6 +27,7 @@ export default function createRegulatoryNetworkTheory(theoryMeta: TheoryMeta): T
                     tag: "Hom",
                     content: { tag: "Basic", content: "Object" },
                 },
+                editor: MorphismCellEditor,
                 name: "Promotion",
                 shortcut: ["P"],
                 description: "Positive interaction: activates or promotes",
@@ -32,6 +36,7 @@ export default function createRegulatoryNetworkTheory(theoryMeta: TheoryMeta): T
             {
                 tag: "MorType",
                 morType: { tag: "Basic", content: "Negative" },
+                editor: MorphismCellEditor,
                 name: "Inhibition",
                 shortcut: ["N"],
                 description: "Negative interaction: represses or inhibits",

--- a/packages/frontend/src/stdlib/theories/reg-net.ts
+++ b/packages/frontend/src/stdlib/theories/reg-net.ts
@@ -1,8 +1,11 @@
+import { lazy } from "solid-js";
+
 import { ThSignedCategory } from "catlog-wasm";
-import { MorphismCellEditor } from "../../model/morphism_cell_editor";
-import { ObjectCellEditor } from "../../model/object_cell_editor";
 import { Theory, type TheoryMeta } from "../../theory";
 import * as analyses from "../analyses";
+
+const ObjectCellEditor = lazy(() => import("../../model/object_cell_editor"));
+const MorphismCellEditor = lazy(() => import("../../model/morphism_cell_editor"));
 
 export default function createRegulatoryNetworkTheory(theoryMeta: TheoryMeta): Theory {
     const thSignedCategory = new ThSignedCategory();

--- a/packages/frontend/src/stdlib/theories/simple-olog.ts
+++ b/packages/frontend/src/stdlib/theories/simple-olog.ts
@@ -1,8 +1,11 @@
+import { lazy } from "solid-js";
+
 import { ThCategory } from "catlog-wasm";
-import { MorphismCellEditor } from "../../model/morphism_cell_editor";
-import { ObjectCellEditor } from "../../model/object_cell_editor";
 import { Theory, type TheoryMeta } from "../../theory";
 import * as analyses from "../analyses";
+
+const ObjectCellEditor = lazy(() => import("../../model/object_cell_editor"));
+const MorphismCellEditor = lazy(() => import("../../model/morphism_cell_editor"));
 
 import styles from "../styles.module.css";
 import svgStyles from "../svg_styles.module.css";

--- a/packages/frontend/src/stdlib/theories/simple-olog.ts
+++ b/packages/frontend/src/stdlib/theories/simple-olog.ts
@@ -1,4 +1,6 @@
 import { ThCategory } from "catlog-wasm";
+import { MorphismCellEditor } from "../../model/morphism_cell_editor";
+import { ObjectCellEditor } from "../../model/object_cell_editor";
 import { Theory, type TheoryMeta } from "../../theory";
 import * as analyses from "../analyses";
 
@@ -21,6 +23,7 @@ export default function createOlogTheory(theoryMeta: TheoryMeta): Theory {
             {
                 tag: "ObType",
                 obType: { tag: "Basic", content: "Object" },
+                editor: ObjectCellEditor,
                 name: "Type",
                 description: "Type or class of things",
                 shortcut: ["O"],
@@ -33,6 +36,7 @@ export default function createOlogTheory(theoryMeta: TheoryMeta): Theory {
                     tag: "Hom",
                     content: { tag: "Basic", content: "Object" },
                 },
+                editor: MorphismCellEditor,
                 name: "Aspect",
                 description: "Aspect or property of a type",
                 shortcut: ["M"],

--- a/packages/frontend/src/stdlib/theories/simple-schema.ts
+++ b/packages/frontend/src/stdlib/theories/simple-schema.ts
@@ -1,4 +1,6 @@
 import { ThSchema } from "catlog-wasm";
+import { MorphismCellEditor } from "../../model/morphism_cell_editor";
+import { ObjectCellEditor } from "../../model/object_cell_editor";
 import { type DiagramAnalysisMeta, Theory, type TheoryMeta } from "../../theory";
 import * as analyses from "../analyses";
 
@@ -35,6 +37,7 @@ export default function createSchemaTheory(theoryMeta: TheoryMeta): Theory {
             {
                 tag: "ObType",
                 obType: { tag: "Basic", content: "Entity" },
+                editor: ObjectCellEditor,
                 name: "Entity",
                 description: "Type of entity or thing",
                 shortcut: ["O"],
@@ -48,6 +51,7 @@ export default function createSchemaTheory(theoryMeta: TheoryMeta): Theory {
                     tag: "Hom",
                     content: { tag: "Basic", content: "Entity" },
                 },
+                editor: MorphismCellEditor,
                 name: "Mapping",
                 description: "Many-to-one relation between entities",
                 shortcut: ["M"],
@@ -56,6 +60,7 @@ export default function createSchemaTheory(theoryMeta: TheoryMeta): Theory {
             {
                 tag: "MorType",
                 morType: { tag: "Basic", content: "Attr" },
+                editor: MorphismCellEditor,
                 name: "Attribute",
                 description: "Data attribute of an entity",
                 shortcut: ["A"],
@@ -64,6 +69,7 @@ export default function createSchemaTheory(theoryMeta: TheoryMeta): Theory {
             {
                 tag: "ObType",
                 obType: { tag: "Basic", content: "AttrType" },
+                editor: ObjectCellEditor,
                 name: "Attribute type",
                 description: "Data type for an attribute",
                 textClasses: [textStyles.code],
@@ -74,6 +80,7 @@ export default function createSchemaTheory(theoryMeta: TheoryMeta): Theory {
                     tag: "Hom",
                     content: { tag: "Basic", content: "AttrType" },
                 },
+                editor: MorphismCellEditor,
                 name: "Operation",
                 description: "Operation on data types for attributes",
                 textClasses: [textStyles.code],

--- a/packages/frontend/src/stdlib/theories/simple-schema.ts
+++ b/packages/frontend/src/stdlib/theories/simple-schema.ts
@@ -1,8 +1,11 @@
+import { lazy } from "solid-js";
+
 import { ThSchema } from "catlog-wasm";
-import { MorphismCellEditor } from "../../model/morphism_cell_editor";
-import { ObjectCellEditor } from "../../model/object_cell_editor";
 import { type DiagramAnalysisMeta, Theory, type TheoryMeta } from "../../theory";
 import * as analyses from "../analyses";
+
+const ObjectCellEditor = lazy(() => import("../../model/object_cell_editor"));
+const MorphismCellEditor = lazy(() => import("../../model/morphism_cell_editor"));
 
 import styles from "../styles.module.css";
 import svgStyles from "../svg_styles.module.css";

--- a/packages/frontend/src/stdlib/theories/unary-dec.ts
+++ b/packages/frontend/src/stdlib/theories/unary-dec.ts
@@ -1,4 +1,6 @@
 import { ThCategoryWithScalars } from "catlog-wasm";
+import { MorphismCellEditor } from "../../model/morphism_cell_editor";
+import { ObjectCellEditor } from "../../model/object_cell_editor";
 import { Theory, type TheoryMeta } from "../../theory";
 import * as analyses from "../analyses";
 
@@ -12,6 +14,7 @@ export default function createUnaryDECTheory(theoryMeta: TheoryMeta): Theory {
             {
                 tag: "ObType",
                 obType: { tag: "Basic", content: "Object" },
+                editor: ObjectCellEditor,
                 name: "Form type",
                 shortcut: ["F"],
                 description: "A type of differential form on the space",
@@ -19,6 +22,7 @@ export default function createUnaryDECTheory(theoryMeta: TheoryMeta): Theory {
             {
                 tag: "MorType",
                 morType: { tag: "Basic", content: "Nonscalar" },
+                editor: MorphismCellEditor,
                 name: "Operator",
                 shortcut: ["D"],
                 description: "A differential operator",
@@ -29,6 +33,7 @@ export default function createUnaryDECTheory(theoryMeta: TheoryMeta): Theory {
                     tag: "Hom",
                     content: { tag: "Basic", content: "Object" },
                 },
+                editor: MorphismCellEditor,
                 name: "Scalar",
                 arrowStyle: "scalar",
                 shortcut: ["S"],

--- a/packages/frontend/src/stdlib/theories/unary-dec.ts
+++ b/packages/frontend/src/stdlib/theories/unary-dec.ts
@@ -1,8 +1,11 @@
+import { lazy } from "solid-js";
+
 import { ThCategoryWithScalars } from "catlog-wasm";
-import { MorphismCellEditor } from "../../model/morphism_cell_editor";
-import { ObjectCellEditor } from "../../model/object_cell_editor";
 import { Theory, type TheoryMeta } from "../../theory";
 import * as analyses from "../analyses";
+
+const ObjectCellEditor = lazy(() => import("../../model/object_cell_editor"));
+const MorphismCellEditor = lazy(() => import("../../model/morphism_cell_editor"));
 
 export default function createUnaryDECTheory(theoryMeta: TheoryMeta): Theory {
     const thCategoryWithScalars = new ThCategoryWithScalars();

--- a/packages/frontend/src/theory/theory.ts
+++ b/packages/frontend/src/theory/theory.ts
@@ -1,7 +1,13 @@
+import type { Component } from "solid-js";
+
 import type { KbdKey } from "catcolab-ui-components";
 import type { DblModel, DblTheory, MorType, ObOp, ObType } from "catlog-wasm";
 import type { DiagramAnalysisComponent, ModelAnalysisComponent } from "../analysis";
-import type { EditorVariantOverrides } from "../model/editors";
+import type {
+    EditorVariantOverrides,
+    MorphismEditorProps,
+    ObjectEditorProps,
+} from "../model/editors";
 import { uniqueIndexArray } from "../util/indexing";
 import type { ArrowStyle } from "../visualization";
 import { MorTypeMap, ObTypeMap } from "./types";
@@ -263,12 +269,18 @@ export type ModelTypeMeta =
 export type ModelObTypeMeta = BaseTypeMeta & {
     /** Object type in the underlying double theory. */
     obType: ObType;
+
+    /** Editor component for objects of this type. */
+    editor: Component<ObjectEditorProps>;
 };
 
 /** Metadata for a morphism type as used in models. */
 export type ModelMorTypeMeta = BaseTypeMeta & {
     /** Morphism type in the underlying double theory. */
     morType: MorType;
+
+    /** Editor component for morphisms of this type. */
+    editor: Component<MorphismEditorProps>;
 
     /** Style of arrow to use for morphisms of this type. */
     arrowStyle?: ArrowStyle;


### PR DESCRIPTION
Building on #1180 this makes the default editors for a model/theory explicit so they can be changed for e.g. https://github.com/ToposInstitute/CatColab/pull/1211