### PR TITLE
Block browser native undo/redo in rich text editor to prevent state corruption

### DIFF
--- a/packages/frontend/src/components/rich_text_editor/rich_text_editor.tsx
+++ b/packages/frontend/src/components/rich_text_editor/rich_text_editor.tsx
@@ -340,6 +340,12 @@ function richTextEditorKeymap(schema: CustomSchema, props: RichTextEditorOptions
     bindings["Mod-i"] = toggleMark(schema.marks.em);
     bindings["Mod-l"] = insertLinkCmd;
     bindings["Mod-m"] = insertMathDisplayCmd;
+
+    // Block browser native undo/redo to prevent contenteditable undo from
+    // desynchronizing ProseMirror state with the DOM.
+    bindings["Mod-z"] = () => true;
+    bindings["Mod-y"] = () => true;
+    bindings["Mod-Shift-z"] = () => true;
     bindings["Backspace"] = chainCommands(
         deleteSelection,
         mathBackspaceCmd,


### PR DESCRIPTION
Native browser shortcuts kinda worked some of the time, but also kinda broke things some of the time. I didn't see any obvious way of making the native undo work nicely with our undo, disabling it I think is the least bad UX until we get better shortcuts working.