### PR TITLE
Add tracing to RPC requests with errors

### DIFF
--- a/packages/backend/src/rpc.rs
+++ b/packages/backend/src/rpc.rs
@@ -191,30 +191,24 @@ enum RpcResult<T> {
 
 impl<T> From<AppError> for RpcResult<T> {
     fn from(error: AppError) -> Self {
-        let code = match &error {
-            AppError::Invalid(msg) => {
-                warn!(msg, "rpc: invalid request");
-                StatusCode::BAD_REQUEST
-            }
+        let code = match error {
+            AppError::Invalid(_) => StatusCode::BAD_REQUEST,
             AppError::Unauthorized => StatusCode::UNAUTHORIZED,
             AppError::Forbidden(_) => StatusCode::FORBIDDEN,
-            AppError::NotFound(msg) => {
-                warn!(msg, "rpc: not found");
-                StatusCode::NOT_FOUND
-            }
-            AppError::Db(sqlx::Error::RowNotFound) => {
-                warn!("rpc: not found (row not found)");
-                StatusCode::NOT_FOUND
-            }
-            _ => {
-                error!(%error, "rpc: internal server error");
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
+            AppError::NotFound(_) | AppError::Db(sqlx::Error::RowNotFound) => StatusCode::NOT_FOUND,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
-        RpcResult::Err {
-            code: code.as_u16(),
-            message: error.to_string(),
+        let message = error.to_string();
+        match code {
+            StatusCode::BAD_REQUEST | StatusCode::NOT_FOUND => {
+                warn!(message, "RPC: client error");
+            }
+            StatusCode::INTERNAL_SERVER_ERROR => {
+                error!(message, "RPC: internal error");
+            }
+            _ => {}
         }
+        RpcResult::Err { code: code.as_u16(), message }
     }
 }
 

--- a/packages/backend/src/rpc.rs
+++ b/packages/backend/src/rpc.rs
@@ -3,7 +3,7 @@ use http::StatusCode;
 use qubit::{Extensions, FromRequestExtensions, Router, RpcError, handler};
 use serde::Serialize;
 use serde_json::Value;
-use tracing::debug;
+use tracing::{debug, error, warn};
 use uuid::Uuid;
 
 use super::app::{AppCtx, AppError, AppState, RefMsg};
@@ -191,12 +191,25 @@ enum RpcResult<T> {
 
 impl<T> From<AppError> for RpcResult<T> {
     fn from(error: AppError) -> Self {
-        let code = match error {
-            AppError::Invalid(_) => StatusCode::BAD_REQUEST,
+        let code = match &error {
+            AppError::Invalid(msg) => {
+                warn!(msg, "rpc: invalid request");
+                StatusCode::BAD_REQUEST
+            }
             AppError::Unauthorized => StatusCode::UNAUTHORIZED,
             AppError::Forbidden(_) => StatusCode::FORBIDDEN,
-            AppError::NotFound(_) | AppError::Db(sqlx::Error::RowNotFound) => StatusCode::NOT_FOUND,
-            _ => StatusCode::INTERNAL_SERVER_ERROR,
+            AppError::NotFound(msg) => {
+                warn!(msg, "rpc: not found");
+                StatusCode::NOT_FOUND
+            }
+            AppError::Db(sqlx::Error::RowNotFound) => {
+                warn!("rpc: not found (row not found)");
+                StatusCode::NOT_FOUND
+            }
+            _ => {
+                error!(%error, "rpc: internal server error");
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
         };
         RpcResult::Err {
             code: code.as_u16(),


### PR DESCRIPTION
This helps more easily see when errors happen that are sort of swallowed by the RPC machinery.