### PR TITLE
Tweak document list date columns to not truncate

### DIFF
--- a/packages/frontend/src/user/documents.css
+++ b/packages/frontend/src/user/documents.css
@@ -37,13 +37,13 @@
 /* Documents page: 7 columns — Icon / Name / Owners / Permission / Created / Last edited / Actions */
 .documents-page .ref-grid-header,
 .documents-page .ref-grid-row {
-    grid-template-columns: 40px 2fr 120px 120px 140px 140px 50px;
+    grid-template-columns: 40px 2fr 120px 120px 165px 165px 50px;
 }
 
 /* Trash page: 7 columns — Actions / Icon / Name / Owners / Permission / Created / Last edited */
 .trash-bin-page .ref-grid-header,
 .trash-bin-page .ref-grid-row {
-    grid-template-columns: 50px 40px 2fr 120px 120px 140px 140px;
+    grid-template-columns: 50px 40px 2fr 120px 120px 165px 165px;
 }
 
 /* Adjust for scrollbar in Chromium browsers only */


### PR DESCRIPTION
Avoiding:
<img width="363" height="390" alt="image" src="https://github.com/user-attachments/assets/88bf91ea-09a6-45b6-8f0f-3ef24f235767" />

