### PR TITLE
Control when coefficients parenthesize in polynomial printing

### DIFF
--- a/packages/catlog/src/simulate/ode/polynomial.rs
+++ b/packages/catlog/src/simulate/ode/polynomial.rs
@@ -230,8 +230,8 @@ mod tests {
         ];
         let sys: PolynomialSystem<_, _, _> = terms.into_iter().collect();
         let expected = expect![[r#"
-            dS = (-β) I S
-            dI = (-γ) I + β I S
+            dS = -β I S
+            dI = -γ I + β I S
             dR = γ I
         "#]];
         expected.assert_eq(&sys.to_string());

--- a/packages/catlog/src/stdlib/analyses/ode/linear_ode.rs
+++ b/packages/catlog/src/stdlib/analyses/ode/linear_ode.rs
@@ -136,7 +136,7 @@ mod test {
         let neg_feedback = stdlib::models::negative_feedback(th);
         let (sys, _) = builder().linear_ode_system(&neg_feedback);
         let expected = expect![[r#"
-            dx = (-negative) y
+            dx = -negative y
             dy = positive x
         "#]];
         expected.assert_eq(&sys.to_string());

--- a/packages/catlog/src/stdlib/analyses/ode/lotka_volterra.rs
+++ b/packages/catlog/src/stdlib/analyses/ode/lotka_volterra.rs
@@ -162,8 +162,8 @@ mod test {
         let (sys, _) = builder().lotka_volterra_system(&neg_feedback);
         let sys = sys.extend_scalars(|coef| coef.map_variables(|name| format!("Param({name})")));
         let expected = expect!([r#"
-            dx = (Param(x)) x - (Param(negative)) x y
-            dy = (Param(positive)) x y + (Param(y)) y
+            dx = Param(x) x - Param(negative) x y
+            dy = Param(positive) x y + Param(y) y
         "#]);
         expected.assert_eq(&sys.to_string());
     }

--- a/packages/catlog/src/stdlib/analyses/ode/mass_action.rs
+++ b/packages/catlog/src/stdlib/analyses/ode/mass_action.rs
@@ -485,7 +485,7 @@ mod tests {
         let sys = StockFlowMassActionAnalysis::default()
             .build_system(&model, analyses::ode::MassConservationType::Balanced);
         let expected = expect!([r#"
-            dx = (-f) x y
+            dx = -f x y
             dy = f x y
         "#]);
         expected.assert_eq(&sys.to_string());
@@ -502,8 +502,8 @@ mod tests {
             ),
         );
         let expected = expect!([r#"
-            dx = (-Outgoing(f)) x y
-            dy = (Incoming(f)) x y
+            dx = -Outgoing(f) x y
+            dy = Incoming(f) x y
         "#]);
         expected.assert_eq(&sys.to_string());
     }
@@ -518,7 +518,7 @@ mod tests {
         let sys = StockFlowMassActionAnalysis::default()
             .build_system(&model, analyses::ode::MassConservationType::Balanced);
         let expected = expect!([r#"
-            dx = (-f) x y^{-1}
+            dx = -f x y^{-1}
             dy = f x y^{-1}
         "#]);
         expected.assert_eq(&sys.to_string());
@@ -535,8 +535,8 @@ mod tests {
             ),
         );
         let expected = expect!([r#"
-            dx = (-Outgoing(f)) x y^{-1}
-            dy = (Incoming(f)) x y^{-1}
+            dx = -Outgoing(f) x y^{-1}
+            dy = Incoming(f) x y^{-1}
         "#]);
         expected.assert_eq(&sys.to_string());
     }
@@ -551,7 +551,7 @@ mod tests {
         let sys = PetriNetMassActionAnalysis::default()
             .build_system(&model, analyses::ode::MassConservationType::Balanced);
         let expected = expect!([r#"
-            dx = (-f) c x
+            dx = -f c x
             dy = f c x
             dc = 0
         "#]);
@@ -569,8 +569,8 @@ mod tests {
             ),
         );
         let expected = expect!([r#"
-            dx = (-Outgoing(f)) c x
-            dy = (Incoming(f)) c x
+            dx = -Outgoing(f) c x
+            dy = Incoming(f) c x
             dc = (Incoming(f) - Outgoing(f)) c x
         "#]);
         expected.assert_eq(&sys.to_string());
@@ -587,8 +587,8 @@ mod tests {
             ),
         );
         let expected = expect!([r#"
-            dx = (-(x->[f])) c x
-            dy = (([f]->y)) c x
+            dx = -(x->[f]) c x
+            dy = ([f]->y) c x
             dc = (([f]->c) - (c->[f])) c x
         "#]);
         expected.assert_eq(&sys.to_string());

--- a/packages/catlog/src/stdlib/analyses/ode/polynomial_ode.rs
+++ b/packages/catlog/src/stdlib/analyses/ode/polynomial_ode.rs
@@ -144,9 +144,9 @@ mod tests {
         let model = lotka_volterra_dynamics(th);
         let sys = PolynomialODEAnalysis::default().build_system(&model);
         let expected = expect!([r#"
-            dA = (A_growth) A + (BA_interaction) A B
-            dB = (AB_interaction) A B + (B_growth) B + (CB_interaction) B C
-            dC = (BC_interaction) B C + (C_growth) C
+            dA = A_growth A + BA_interaction A B
+            dB = AB_interaction A B + B_growth B + CB_interaction B C
+            dC = BC_interaction B C + C_growth C
         "#]);
         expected.assert_eq(&sys.to_string());
     }

--- a/packages/catlog/src/zero/alg.rs
+++ b/packages/catlog/src/zero/alg.rs
@@ -156,13 +156,15 @@ where
     /// Convert to a LaTeX string, formatting each monomial via [`Monomial::to_latex`].
     pub fn to_latex(&self) -> String {
         let fmt_term = |coef: &Coef, monomial: &Monomial<Var, Exp>| -> String {
-            let mono_str = monomial.to_latex();
+            let monomial = monomial.to_latex();
             if coef.is_one() {
-                mono_str
+                monomial
             } else if *coef == Coef::one().neg() {
-                format!("-{mono_str}")
+                format!("-{monomial}")
+            } else if coef.needs_parentheses() {
+                format!("({coef}) \\cdot {monomial}")
             } else {
-                format!("{coef} \\cdot {mono_str}")
+                format!("{coef} \\cdot {monomial}")
             }
         };
 
@@ -216,6 +218,10 @@ where
         } else {
             false
         }
+    }
+
+    fn needs_parentheses(&self) -> bool {
+        self.0.len() != 1
     }
 }
 

--- a/packages/catlog/src/zero/rig.rs
+++ b/packages/catlog/src/zero/rig.rs
@@ -17,7 +17,7 @@ use num_traits::{One, Pow, Signed, Zero};
 use std::collections::{BTreeMap, btree_map};
 use std::fmt::Display;
 use std::iter::{Product, Sum};
-use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub};
+use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use derivative::Derivative;
 use duplicate::duplicate_item;
@@ -95,11 +95,17 @@ pub trait DisplayCoef {
     /// expression `-k` has a negative sign, but may or may not denote a
     /// negative number, depending on whether `k` itself takes a positive value.
     fn has_negative_sign(&self) -> bool;
+
+    /// Does the coefficient need to be parenthesized when displayed?
+    fn needs_parentheses(&self) -> bool;
 }
 
 #[duplicate_item(T; [u32]; [u64]; [usize])]
 impl DisplayCoef for T {
     fn has_negative_sign(&self) -> bool {
+        false
+    }
+    fn needs_parentheses(&self) -> bool {
         false
     }
 }
@@ -108,6 +114,9 @@ impl DisplayCoef for T {
 impl DisplayCoef for T {
     fn has_negative_sign(&self) -> bool {
         self.is_negative()
+    }
+    fn needs_parentheses(&self) -> bool {
+        false
     }
 }
 
@@ -138,6 +147,16 @@ where
         Coef: One,
     {
         Combination([(var, Coef::one())].into_iter().collect())
+    }
+
+    /// Number of variables appearing in the combination.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Is the combination empty, i.e., equal to zero?
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 
     /// Iterates over the variables used in the combination.
@@ -236,34 +255,15 @@ where
     Coef: Display + DisplayCoef + Clone + PartialEq + One + Neg<Output = Coef>,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let is_simple = |s: &str| {
-            // Numeric: digits and dots
-            if s.chars().all(|c| c.is_ascii_digit() || c == '.') {
-                return true;
-            }
-            // Alphabetic identifier
-            if s.chars().all(|c| c.is_alphabetic()) {
-                return true;
-            }
-            // Braced identifier like {uuid} or {name}
-            if s.starts_with('{') && s.ends_with('}') && s.matches('{').count() == 1 {
-                return true;
-            }
-            false
-        };
-
         let fmt_scalar_mul = |f: &mut std::fmt::Formatter<'_>, coef: &Coef, var: &Var| {
             if coef.is_one() {
                 write!(f, "{var}")
             } else if *coef == Coef::one().neg() {
                 write!(f, "-{var}")
+            } else if coef.needs_parentheses() {
+                write!(f, "({coef}) {var}")
             } else {
-                let coef_str = coef.to_string();
-                if is_simple(&coef_str) {
-                    write!(f, "{coef_str} {var}")
-                } else {
-                    write!(f, "({coef_str}) {var}")
-                }
+                write!(f, "{coef} {var}")
             }
         };
 
@@ -394,6 +394,16 @@ where
     }
 }
 
+impl<Var, Coef> SubAssign for Combination<Var, Coef>
+where
+    Var: Ord,
+    Coef: Default + Add<Output = Coef> + Neg<Output = Coef> + Zero,
+{
+    fn sub_assign(&mut self, rhs: Self) {
+        *self += -rhs;
+    }
+}
+
 impl<Var, Coef> Sub for Combination<Var, Coef>
 where
     Var: Ord,
@@ -401,8 +411,9 @@ where
 {
     type Output = Self;
 
-    fn sub(self, rhs: Self) -> Self::Output {
-        self + (-rhs)
+    fn sub(mut self, rhs: Self) -> Self::Output {
+        self -= rhs;
+        self
     }
 }
 
@@ -452,6 +463,16 @@ where
         Exp: One,
     {
         Monomial([(var, Exp::one())].into_iter().collect())
+    }
+
+    /// Number of variables appearing in the monomial.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Is the monomial empty, i.e., equal to one?
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 
     /// Iterates over the variables used in the monomial.


### PR DESCRIPTION
Previously, we used the unreliable hack of inspecting the string *after* the coefficient had been formatted.