### PR TITLE
Replace `deepCopyJSON` with structured clones

### DIFF
--- a/packages/document-methods/src/deepcopy.ts
+++ b/packages/document-methods/src/deepcopy.ts
@@ -1,4 +1,0 @@
-// FIXME: This shouldn't be here.
-export function deepCopyJSON(value: unknown) {
-    return JSON.parse(JSON.stringify(value));
-}

--- a/packages/document-methods/src/diagram.ts
+++ b/packages/document-methods/src/diagram.ts
@@ -10,7 +10,6 @@ import type {
     StableRef,
 } from "catcolab-document-types";
 import { currentVersion } from "catcolab-document-types";
-import { deepCopyJSON } from "./deepcopy";
 import { newNotebook } from "./notebook";
 
 /** A document defining a diagram in a model. */
@@ -56,6 +55,6 @@ export const newDiagramMorphismDecl = (
 
 /** Duplicate a diagram judgment, creating a fresh UUID. */
 export const duplicateDiagramJudgment = (jgmt: DiagramJudgment): DiagramJudgment => ({
-    ...deepCopyJSON(jgmt),
+    ...structuredClone(jgmt),
     id: v7(),
 });

--- a/packages/document-methods/src/globals.d.ts
+++ b/packages/document-methods/src/globals.d.ts
@@ -1,0 +1,8 @@
+// Ambient declaration for the host-provided global `structuredClone`.
+//
+// `structuredClone` is part of the HTML Living Standard and available in all
+// modern JavaScript runtimes (browsers, Node ≥17, Deno, Bun, Web Workers), but
+// its TypeScript declaration only ships with the `"DOM"` and `"WebWorker"`
+// libs. Declaring it locally keeps this package runtime-agnostic at the type
+// level.
+declare function structuredClone<T>(value: T, options?: { transfer?: unknown[] }): T;

--- a/packages/document-methods/src/model.ts
+++ b/packages/document-methods/src/model.ts
@@ -2,7 +2,6 @@ import { v7 } from "uuid";
 
 import type { Document, Link, ModelJudgment, MorType, ObType } from "catcolab-document-types";
 import { currentVersion } from "catcolab-document-types";
-import { deepCopyJSON } from "./deepcopy";
 import { newNotebook } from "./notebook";
 
 /** A document defining a model. */
@@ -52,6 +51,6 @@ export const newInstantiatedModel = (
 
 /** Duplicate a model judgment, creating a fresh UUID when applicable. */
 export const duplicateModelJudgment = (jgmt: ModelJudgment): ModelJudgment => ({
-    ...deepCopyJSON(jgmt),
+    ...structuredClone(jgmt),
     id: v7(),
 });

--- a/packages/document-methods/src/notebook.ts
+++ b/packages/document-methods/src/notebook.ts
@@ -2,7 +2,6 @@ import invariant from "tiny-invariant";
 import { v7 } from "uuid";
 
 import type { Cell, Notebook } from "catcolab-document-types";
-import { deepCopyJSON } from "./deepcopy";
 
 /** A cell containing custom data, usually a formal object. */
 export type FormalCell<T> = Cell<T> & { tag: "formal" };
@@ -141,10 +140,17 @@ export function numCells<T>(notebook: Notebook<T>): number {
     return notebook.cellOrder.length;
 }
 
-function duplicateCell<T>(cell: Cell<T>, duplicateFn?: (cellContent: T) => T): Cell<T> {
+/** Duplicate a cell, optionally using a caller-supplied content cloner.
+
+The default cloner is `structuredClone`, which requires `cell.content` to
+be a plain JavaScript value (no proxies). Callers working with Automerge
+or Solid store proxies should materialize the cell to plain JS before
+calling this function.
+ */
+export function duplicateCell<T>(cell: Cell<T>, duplicateFn?: (cellContent: T) => T): Cell<T> {
     switch (cell.tag) {
         case "formal": {
-            const content = (duplicateFn ?? deepCopyJSON)(cell.content);
+            const content = duplicateFn ? duplicateFn(cell.content) : structuredClone(cell.content);
             return newFormalCell(content);
         }
         case "rich-text":
@@ -154,16 +160,6 @@ function duplicateCell<T>(cell: Cell<T>, duplicateFn?: (cellContent: T) => T): C
         default:
             throw new Error(`Call has unknown tag: ${cell}`);
     }
-}
-
-export function duplicateCellAtIndex<T>(
-    notebook: Notebook<T>,
-    index: number,
-    duplicateFn?: (cellContent: T) => T,
-) {
-    const cell = getCellByIndex(notebook, index);
-    const newCell = duplicateCell(cell, duplicateFn);
-    insertCellAtIndex(notebook, newCell, index + 1);
 }
 
 export function mutateCellContentById<T>(

--- a/packages/frontend/src/model/morphism_cell_editor.tsx
+++ b/packages/frontend/src/model/morphism_cell_editor.tsx
@@ -1,8 +1,8 @@
 import { createMemo, createSignal, useContext } from "solid-js";
-import { unwrap } from "solid-js/store";
 import invariant from "tiny-invariant";
 
 import { NameInput } from "catcolab-ui-components";
+import { removeProxyAndCopy } from "../util/remove_proxy_and_copy";
 import { LiveModelContext } from "./context";
 import type { MorphismEditorProps } from "./editors";
 import { obClasses } from "./object_cell_editor";
@@ -68,7 +68,7 @@ export default function MorphismCellEditor(props: MorphismEditorProps) {
                     ob={props.morphism.dom}
                     setOb={(ob) => {
                         props.modifyMorphism((mor) => {
-                            mor.dom = structuredClone(unwrap(ob));
+                            mor.dom = removeProxyAndCopy(ob);
                         });
                     }}
                     obType={domType()}
@@ -120,7 +120,7 @@ export default function MorphismCellEditor(props: MorphismEditorProps) {
                     ob={props.morphism.cod}
                     setOb={(ob) => {
                         props.modifyMorphism((mor) => {
-                            mor.cod = structuredClone(unwrap(ob));
+                            mor.cod = removeProxyAndCopy(ob);
                         });
                     }}
                     obType={codType()}

--- a/packages/frontend/src/model/object_list_editor.tsx
+++ b/packages/frontend/src/model/object_list_editor.tsx
@@ -14,7 +14,7 @@ import invariant from "tiny-invariant";
 import type { TextInputOptions } from "catcolab-ui-components";
 import type { Ob, QualifiedName } from "catlog-wasm";
 import { ObIdInput } from "../components";
-import { deepCopyJSON } from "../util/deepcopy";
+import { removeProxyAndCopy } from "../util/remove_proxy_and_copy";
 import { LiveModelContext } from "./context";
 import { buildObList, extractObList } from "./ob_operations";
 import type { ObInputProps } from "./object_input";
@@ -63,7 +63,7 @@ export function ObListEditor(originalProps: ObListEditorProps) {
     };
 
     const updateObList = (f: (objects: Array<Ob | null>) => void) => {
-        const objects = deepCopyJSON(obList());
+        const objects = removeProxyAndCopy(obList());
         f(objects);
         setObList(objects);
     };

--- a/packages/frontend/src/model/string_diagram_morphism_cell_editor.tsx
+++ b/packages/frontend/src/model/string_diagram_morphism_cell_editor.tsx
@@ -1,10 +1,10 @@
 import { Index, createEffect, createMemo, createSignal, untrack, useContext } from "solid-js";
-import { unwrap } from "solid-js/store";
 import invariant from "tiny-invariant";
 
 import { NameInput } from "catcolab-ui-components";
 import type { Ob, ObOp, ObType, QualifiedName } from "catlog-wasm";
 import { ObIdInput } from "../components";
+import { removeProxyAndCopy } from "../util/remove_proxy_and_copy";
 import { LiveModelContext } from "./context";
 import type { MorphismEditorProps } from "./editors";
 import { buildObList, extractObList, unwrapApp, wrapApp } from "./ob_operations";
@@ -186,25 +186,25 @@ export default function StringDiagramMorphismCellEditor(props: MorphismEditorPro
     const setDomObs = (objects: Array<Ob | null>) => {
         const ob = makeObList(objects, domType(), domApplyOp());
         props.modifyMorphism((mor) => {
-            mor.dom = structuredClone(unwrap(ob));
+            mor.dom = removeProxyAndCopy(ob);
         });
     };
 
     const setCodObs = (objects: Array<Ob | null>) => {
         const ob = makeObList(objects, codType(), codApplyOp());
         props.modifyMorphism((mor) => {
-            mor.cod = structuredClone(unwrap(ob));
+            mor.cod = removeProxyAndCopy(ob);
         });
     };
 
     const updateDomObs = (f: (objects: Array<Ob | null>) => void) => {
-        const objects = structuredClone(unwrap(domObs()));
+        const objects = removeProxyAndCopy(domObs());
         f(objects);
         setDomObs(objects);
     };
 
     const updateCodObs = (f: (objects: Array<Ob | null>) => void) => {
-        const objects = structuredClone(unwrap(codObs()));
+        const objects = removeProxyAndCopy(codObs());
         f(objects);
         setCodObs(objects);
     };

--- a/packages/frontend/src/notebook/notebook_editor.tsx
+++ b/packages/frontend/src/notebook/notebook_editor.tsx
@@ -24,6 +24,7 @@ import {
     keyEventHasModifier,
     type ModifierKey,
 } from "catcolab-ui-components";
+import { materializeFromAutomerge } from "../util/materialize_from_automerge";
 import {
     type CellActions,
     type CellDragData,
@@ -314,9 +315,18 @@ export function NotebookEditor<T>(props: {
                             // oxlint-disable-next-line solid/reactivity -- event handler
                             cellActions.duplicate = () => {
                                 const index = i();
+                                // Materialize the source cell out of Automerge
+                                // before entering the change callback, so that
+                                // `duplicateCell` (which uses `structuredClone`
+                                // by default) operates on plain JS values.
+                                const plainCell = materializeFromAutomerge(
+                                    props.handle.doc(),
+                                    cell,
+                                );
+                                const newCell = Nb.duplicateCell(plainCell, props.duplicateCell);
                                 // oxlint-disable-next-line solid/reactivity -- event handler
                                 props.changeNotebook((nb) => {
-                                    Nb.duplicateCellAtIndex(nb, index, props.duplicateCell);
+                                    Nb.insertCellAtIndex(nb, newCell, index + 1);
                                 });
                                 setActiveCell(index + 1);
                             };

--- a/packages/frontend/src/user/permissions.tsx
+++ b/packages/frontend/src/user/permissions.tsx
@@ -32,7 +32,7 @@ import {
 } from "catcolab-ui-components";
 import type { Document } from "catlog-wasm";
 import { type DocRef, type LiveDoc, useApi } from "../api";
-import { deepCopyJSON } from "../util/deepcopy";
+import { removeProxyAndCopy } from "../util/remove_proxy_and_copy";
 import { Login } from "./login";
 import { AddUserInput, NameUser } from "./username";
 
@@ -78,7 +78,7 @@ export function PermissionsForm(props: { refId: string; onComplete?: () => void 
     createEffect(() => {
         const permissions = currentPermissions();
         if (permissions) {
-            setState(deepCopyJSON(permissions));
+            setState(removeProxyAndCopy(permissions));
         }
     });
 

--- a/packages/frontend/src/util/deepcopy.ts
+++ b/packages/frontend/src/util/deepcopy.ts
@@ -1,9 +1,0 @@
-/** Make a deep copy of a JSON object.
-
-The new-ish function `structuredClone` in the HTML DOM API seems not to work
-with the proxy objects used by Solid, so we resort to the classic
-stringify-then-parse method. Is there a less hacky method?
- */
-export function deepCopyJSON(value: unknown) {
-    return JSON.parse(JSON.stringify(value));
-}

--- a/packages/frontend/src/util/materialize_from_automerge.ts
+++ b/packages/frontend/src/util/materialize_from_automerge.ts
@@ -1,0 +1,16 @@
+import { type Doc, getBackend, getObjectId } from "@automerge/automerge";
+import invariant from "tiny-invariant";
+
+/** Materialize an Automerge sub-tree into a plain JavaScript value.
+
+Given an Automerge document root `doc` and any nested proxy `subtree`
+reachable from that root, returns a deep, plain-JS copy of the addressed
+sub-tree. The result contains no Automerge proxies and is safe to mutate,
+pass to `structuredClone`, or store outside an Automerge change callback.
+
+*/
+export function materializeFromAutomerge<T>(doc: Doc<unknown>, subtree: T): T {
+    const objId = getObjectId(subtree as object);
+    invariant(objId, "Value is not an Automerge map or list");
+    return getBackend(doc).materialize(objId) as T;
+}

--- a/packages/frontend/src/util/remove_proxy_and_copy.ts
+++ b/packages/frontend/src/util/remove_proxy_and_copy.ts
@@ -1,0 +1,10 @@
+import { unwrap } from "solid-js/store";
+
+/** Make a deep copy of a value, including Solid store proxies.
+
+`structuredClone` does not work directly on Solid store proxies, so we first
+unwrap the proxy and then clone. Safe to call on values that are not proxies.
+ */
+export function removeProxyAndCopy<T>(value: T): T {
+    return structuredClone(unwrap(value));
+}


### PR DESCRIPTION
Replaces our use of `JSON.parse(JSON.stringify(...))` workaround for cloning proxy objects.

Turned out more complicated than I expected because Automerge also uses proxies but doesn't provide a nice `unwrap` like Solid does. 