### PR TITLE
Show completions of text inputs by default on focus

### DIFF
--- a/packages/frontend/src/components/id_input.tsx
+++ b/packages/frontend/src/components/id_input.tsx
@@ -148,7 +148,6 @@ export function IdInput(
                 status={status()}
                 autofill={props.generateId ? setNewId : undefined}
                 {...inputProps}
-                showCompletionsOnFocus={inputProps.showCompletionsOnFocus ?? true}
             />
         </div>
     );

--- a/packages/frontend/src/components/id_input.tsx
+++ b/packages/frontend/src/components/id_input.tsx
@@ -148,6 +148,7 @@ export function IdInput(
                 status={status()}
                 autofill={props.generateId ? setNewId : undefined}
                 {...inputProps}
+                showCompletionsOnFocus={inputProps.showCompletionsOnFocus ?? true}
             />
         </div>
     );

--- a/packages/ui-components/src/text_input.tsx
+++ b/packages/ui-components/src/text_input.tsx
@@ -28,7 +28,7 @@ export type TextInputOptions = TextInputActions & {
     /** List of possible auto-completions. */
     completions?: Completion[];
 
-    /** Whether to show possible auto-completions when focus is gained. */
+    /** Whether to show possible auto-completions when focus is gained. Defaults to yes. */
     showCompletionsOnFocus?: boolean;
 
     /** Extra CSS class to apply to the completions popup. */
@@ -225,16 +225,22 @@ export function TextInput(allProps: TextInputProps) {
                     use:focus={(isFocused) => {
                         if (isFocused) {
                             options.hasFocused?.();
+                            if (
+                                options.completions != null &&
+                                (options.showCompletionsOnFocus ?? true)
+                            ) {
+                                setCompletionsOpen(true);
+                            }
                         } else {
                             options.hasBlurred?.();
-                        }
-                        if (!isFocused || options.showCompletionsOnFocus) {
-                            setCompletionsOpen(isFocused);
+                            setCompletionsOpen(false);
                         }
                     }}
                     onInput={(evt) => {
                         props.setText(evt.target.value);
-                        setCompletionsOpen(true);
+                        if (options.completions != null) {
+                            setCompletionsOpen(true);
+                        }
                     }}
                     onKeyDown={onKeyDown}
                     {...inputProps}


### PR DESCRIPTION
I'm not sure why we aren't defaulting to showing all the possible completions when clicking on an input.