### PR TITLE
Improved UI for instantiation specializations

### DIFF
--- a/packages/frontend/src/components/id_input.tsx
+++ b/packages/frontend/src/components/id_input.tsx
@@ -6,6 +6,7 @@ import {
     InlineInput,
     type InlineInputErrorStatus,
     type InlineInputOptions,
+    PlaceholderInlineInput,
 } from "catcolab-ui-components";
 import type {
     LabelSegment,
@@ -226,3 +227,15 @@ export function MorIdInput(
 
     return <IdInput id={id()} setId={setId} {...inputProps} />;
 }
+
+/** A non-editable placeholder shaped like an `IdInput`.
+
+Use this where an `IdInput` would normally appear but the input cannot yet be
+edited (e.g. because a related id is unset). The placeholder occupies the same
+space and aligns on the same baseline as a real `IdInput`.
+ */
+export const IdInputPlaceholder = (props: { placeholder?: string }) => (
+    <div class="id-input">
+        <PlaceholderInlineInput placeholder={props.placeholder ?? "..."} />
+    </div>
+);

--- a/packages/frontend/src/model/instantiation_cell_editor.css
+++ b/packages/frontend/src/model/instantiation_cell_editor.css
@@ -10,17 +10,55 @@
 }
 
 .model-specializations {
+    --add-specialization-height: 1.5em;
+
+    /* Use a grid so the arrow column is always at the same x position across
+       all rows, regardless of what is rendered on the left or right side. */
+    display: grid;
+    grid-template-columns: max-content max-content 1fr;
+    align-items: baseline;
+    column-gap: 1ex;
+    row-gap: 0;
+
+    position: relative;
     list-style: none;
 
     margin-left: 0.5rem;
     padding-left: 1rem;
-    border-left: 2px solid var(--color-gray-450);
+    transition: padding-bottom 0.15s;
+
+    &.has-instantiated {
+        padding-bottom: var(--add-specialization-height);
+    }
+
+    &:before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        width: 2px;
+        background: var(--color-gray-450);
+        transition: bottom 0.15s;
+    }
+
+    &.has-instantiated:before {
+        bottom: var(--add-specialization-height);
+    }
+
+    /* Each row spans all three grid columns by becoming a subgrid. */
+    & > li {
+        display: grid;
+        grid-template-columns: subgrid;
+        grid-column: 1 / -1;
+        align-items: baseline;
+    }
 }
 
 .model-specialization {
-    display: flex;
-    flex-direction: row;
-    gap: 1ex;
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-column: 1 / -1;
     align-items: baseline;
 
     & .specialize-as:before {
@@ -29,5 +67,42 @@
 
     & .placeholder {
         color: var(--color-gray-750);
+    }
+
+    /* When the inline-input-filler is being used directly as a placeholder
+       (no real input on top of it), make it visible. */
+    & .inline-input-filler.placeholder {
+        visibility: visible;
+    }
+}
+
+.model-specialization-add {
+    cursor: pointer;
+    height: 0;
+    overflow: hidden;
+    pointer-events: none;
+    opacity: 0;
+    transition:
+        opacity 0.15s,
+        height 0.15s;
+}
+
+.formal-judgment:hover .model-specializations.has-instantiated,
+.formal-judgment:focus-within .model-specializations.has-instantiated {
+    padding-bottom: 0;
+
+    &:before {
+        bottom: 0;
+    }
+}
+
+.formal-judgment:hover .model-specializations.has-instantiated .model-specialization-add,
+.formal-judgment:focus-within .model-specializations.has-instantiated .model-specialization-add {
+    opacity: 0.5;
+    height: var(--add-specialization-height);
+    pointer-events: auto;
+
+    &:hover {
+        opacity: 0.85;
     }
 }

--- a/packages/frontend/src/model/instantiation_cell_editor.css
+++ b/packages/frontend/src/model/instantiation_cell_editor.css
@@ -65,16 +65,6 @@
         content: "⟵";
     }
 
-    & .placeholder {
-        color: var(--color-gray-750);
-    }
-
-    /* When the inline-input-filler is being used directly as a placeholder
-       (no real input on top of it), make it visible. */
-    & .inline-input-filler.placeholder {
-        visibility: visible;
-    }
-
     /* Mark the left-hand side as a sub-object with a leading dot. The left
        cell is the first grid item in every row (left, arrow, right). */
     & > :nth-child(1):before {

--- a/packages/frontend/src/model/instantiation_cell_editor.css
+++ b/packages/frontend/src/model/instantiation_cell_editor.css
@@ -74,6 +74,13 @@
     & .inline-input-filler.placeholder {
         visibility: visible;
     }
+
+    /* Mark the left-hand side as a sub-object with a leading dot. The left
+       cell is the first grid item in every row (left, arrow, right). */
+    & > :nth-child(1):before {
+        content: ".";
+        margin-right: -0.4ex;
+    }
 }
 
 .model-specialization-add {

--- a/packages/frontend/src/model/instantiation_cell_editor.tsx
+++ b/packages/frontend/src/model/instantiation_cell_editor.tsx
@@ -184,7 +184,20 @@ export function InstantiationCellEditor(props: {
                 <span class="is-a" />
                 <DocumentPicker
                     refId={refId() ?? null}
-                    setRefId={setRefId}
+                    setRefId={(newRefId) => {
+                        setRefId(newRefId);
+                        // After picking a model, move focus out of the picker
+                        // and into the specializations area so the user can
+                        // keep going on the keyboard. If there are no rows
+                        // yet, add an empty one to focus.
+                        if (newRefId) {
+                            if (props.instantiation.specializations.length === 0) {
+                                insertSpecializationAtTop();
+                            } else {
+                                activateIndex(0);
+                            }
+                        }
+                    }}
                     filterCompletions={filterCompletions}
                     placeholder="..."
                     deleteBackward={() => setActiveComponent("name")}

--- a/packages/frontend/src/model/instantiation_cell_editor.tsx
+++ b/packages/frontend/src/model/instantiation_cell_editor.tsx
@@ -1,5 +1,14 @@
 import type { DocInfo } from "catcolab-api/src/user_state";
-import { batch, createSignal, Index, Show, splitProps, useContext } from "solid-js";
+import {
+    batch,
+    createEffect,
+    createSignal,
+    Index,
+    Show,
+    splitProps,
+    untrack,
+    useContext,
+} from "solid-js";
 import invariant from "tiny-invariant";
 
 import { NameInput, type TextInputOptions } from "catcolab-ui-components";
@@ -73,6 +82,73 @@ export function InstantiationCellEditor(props: {
         activateIndex(0);
     };
 
+    const appendSpecialization = () => {
+        let newIndex = 0;
+        props.modifyInstantiation((inst) => {
+            inst.specializations.push({ id: null, ob: null });
+            newIndex = inst.specializations.length - 1;
+        });
+        activateIndex(newIndex);
+    };
+
+    // Track the displayed text in each specialization row's id input so we can
+    // distinguish a fully-empty row from one with invalid (incomplete) text.
+    // The ob input is only rendered when id is set, so we don't need to track
+    // its text for emptiness detection.
+    const idInputTexts = new Map<number, string>();
+
+    /** Drop specialization rows whose id and ob are both null AND whose visible
+     * text in the id input is empty. Rows with invalid (non-empty) text are
+     * kept so the user can correct them.
+     */
+    const pruneEmptySpecializations = () => {
+        const specs = props.instantiation.specializations;
+        // Collect indices of empty rows in increasing order.
+        const removedIndices: number[] = [];
+        for (let i = 0; i < specs.length; i++) {
+            const spec = specs[i]!;
+            const idText = idInputTexts.get(i) ?? "";
+            if (spec.id == null && spec.ob == null && idText === "") {
+                removedIndices.push(i);
+            }
+        }
+        if (removedIndices.length === 0) {
+            return;
+        }
+        // Splice in reverse order so earlier indices stay valid; this avoids
+        // creating a new array and reassigning, which would copy proxy objects.
+        props.modifyInstantiation((inst) => {
+            for (let k = removedIndices.length - 1; k >= 0; k--) {
+                inst.specializations.splice(removedIndices[k]!, 1);
+            }
+        });
+        // Remap the text-tracking map to the new indices.
+        const removedSet = new Set(removedIndices);
+        const newIdTexts = new Map<number, string>();
+        let newIdx = 0;
+        for (let oldIdx = 0; oldIdx < specs.length; oldIdx++) {
+            if (removedSet.has(oldIdx)) {
+                continue;
+            }
+            const idText = idInputTexts.get(oldIdx);
+            if (idText !== undefined) {
+                newIdTexts.set(newIdx, idText);
+            }
+            newIdx++;
+        }
+        idInputTexts.clear();
+        for (const [k, v] of newIdTexts) {
+            idInputTexts.set(k, v);
+        }
+    };
+
+    // Clean up empty rows when the cell becomes inactive.
+    createEffect(() => {
+        if (!props.isActive) {
+            untrack(() => pruneEmptySpecializations());
+        }
+    });
+
     const exitDownFromTop = () => {
         if (props.instantiation.specializations.length === 0) {
             props.actions.activateBelow();
@@ -108,10 +184,7 @@ export function InstantiationCellEditor(props: {
                 <span class="is-a" />
                 <DocumentPicker
                     refId={refId() ?? null}
-                    setRefId={(refId) => {
-                        setRefId(refId);
-                        insertSpecializationAtTop();
-                    }}
+                    setRefId={setRefId}
                     filterCompletions={filterCompletions}
                     placeholder="..."
                     deleteBackward={() => setActiveComponent("name")}
@@ -126,7 +199,10 @@ export function InstantiationCellEditor(props: {
                     }}
                 />
             </div>
-            <ul class="model-specializations">
+            <ul
+                class="model-specializations"
+                classList={{ "has-instantiated": instantiated() != null }}
+            >
                 <Index each={props.instantiation.specializations}>
                     {(spec, i) => (
                         <li>
@@ -139,6 +215,7 @@ export function InstantiationCellEditor(props: {
                                         f(spec);
                                     });
                                 }}
+                                onIdTextChange={(text) => idInputTexts.set(i, text)}
                                 instantiatedModel={instantiated()?.validatedModel.model ?? null}
                                 isActive={
                                     props.isActive &&
@@ -176,6 +253,34 @@ export function InstantiationCellEditor(props: {
                         </li>
                     )}
                 </Index>
+                <Show when={instantiated()}>
+                    <li
+                        class="model-specialization-add"
+                        onMouseDown={(evt) => {
+                            appendSpecialization();
+                            props.actions.hasFocused();
+                            evt.preventDefault();
+                        }}
+                    >
+                        <div class="model-specialization">
+                            {/* Match the DOM of a real specialization row
+                                (IdInput-shaped input/filler on both sides) so
+                                the ghost's text positions align with real rows
+                                whose ob input is rendered. */}
+                            <div class="id-input">
+                                <div class="inline-input-container">
+                                    <span class="inline-input-filler placeholder">{"..."}</span>
+                                </div>
+                            </div>
+                            <span class="specialize-as" />
+                            <div class="id-input">
+                                <div class="inline-input-container">
+                                    <span class="inline-input-filler placeholder">{"..."}</span>
+                                </div>
+                            </div>
+                        </div>
+                    </li>
+                </Show>
             </ul>
         </div>
     );
@@ -188,6 +293,8 @@ function SpecializationEditor(
         specialization: SpecializeModel;
         modifySpecialization: (f: (spec: SpecializeModel) => void) => void;
         instantiatedModel: DblModel | null;
+        /** Called when the displayed text of the id input changes. */
+        onIdTextChange?: (text: string) => void;
     } & Pick<
         TextInputOptions,
         "isActive" | "hasFocused" | "createBelow" | "deleteBackward" | "exitDown" | "exitUp"
@@ -217,6 +324,7 @@ function SpecializationEditor(
                         spec.id = id;
                     });
                 }}
+                onTextChange={props.onIdTextChange}
                 completions={props.instantiatedModel?.obGenerators()}
                 idToLabel={(id) => props.instantiatedModel?.obGeneratorLabel(id)}
                 labelToId={(label) => props.instantiatedModel?.obGeneratorWithLabel(label)}
@@ -231,7 +339,16 @@ function SpecializationEditor(
                 {...inputProps}
             />
             <span class="specialize-as" />
-            <Show when={obType()} fallback={<span class="placeholder">{"..."}</span>}>
+            <Show
+                when={obType()}
+                fallback={
+                    <div class="id-input">
+                        <div class="inline-input-container">
+                            <span class="inline-input-filler placeholder">{"..."}</span>
+                        </div>
+                    </div>
+                }
+            >
                 {(obType) => (
                     <ObInput
                         placeholder="..."

--- a/packages/frontend/src/model/instantiation_cell_editor.tsx
+++ b/packages/frontend/src/model/instantiation_cell_editor.tsx
@@ -14,7 +14,7 @@ import invariant from "tiny-invariant";
 import { NameInput, type TextInputOptions } from "catcolab-ui-components";
 import type { DblModel, InstantiatedModel, Ob, SpecializeModel } from "catlog-wasm";
 import { useApi } from "../api";
-import { DocumentPicker, IdInput } from "../components";
+import { DocumentPicker, IdInput, IdInputPlaceholder } from "../components";
 import type { CellActions } from "../notebook";
 import { DocRefIdContext } from "../page/context";
 import { useUserState } from "../user/user_state_context";
@@ -263,21 +263,9 @@ export function InstantiationCellEditor(props: {
                         }}
                     >
                         <div class="model-specialization">
-                            {/* Match the DOM of a real specialization row
-                                (IdInput-shaped input/filler on both sides) so
-                                the ghost's text positions align with real rows
-                                whose ob input is rendered. */}
-                            <div class="id-input">
-                                <div class="inline-input-container">
-                                    <span class="inline-input-filler placeholder">{"..."}</span>
-                                </div>
-                            </div>
+                            <IdInputPlaceholder />
                             <span class="specialize-as" />
-                            <div class="id-input">
-                                <div class="inline-input-container">
-                                    <span class="inline-input-filler placeholder">{"..."}</span>
-                                </div>
-                            </div>
+                            <IdInputPlaceholder />
                         </div>
                     </li>
                 </Show>
@@ -339,16 +327,7 @@ function SpecializationEditor(
                 {...inputProps}
             />
             <span class="specialize-as" />
-            <Show
-                when={obType()}
-                fallback={
-                    <div class="id-input">
-                        <div class="inline-input-container">
-                            <span class="inline-input-filler placeholder">{"..."}</span>
-                        </div>
-                    </div>
-                }
-            >
+            <Show when={obType()} fallback={<IdInputPlaceholder />}>
                 {(obType) => (
                     <ObInput
                         placeholder="..."

--- a/packages/ui-components/src/inline_input.css
+++ b/packages/ui-components/src/inline_input.css
@@ -41,3 +41,10 @@
         border-bottom: 2px solid var(--color-inline-input-danger);
     }
 }
+
+/* Used by `PlaceholderInlineInput`: make the filler visible (since there is
+   no real input on top of it) and render it in the placeholder color. */
+.inline-input-filler.placeholder-inline-input {
+    visibility: visible;
+    color: var(--color-text-placeholder);
+}

--- a/packages/ui-components/src/inline_input.stories.tsx
+++ b/packages/ui-components/src/inline_input.stories.tsx
@@ -7,7 +7,7 @@ import type { Meta, StoryObj } from "storybook-solidjs-vite";
 
 import { Button } from "./button";
 import type { Completion } from "./completions";
-import { InlineInput } from "./inline_input";
+import { InlineInput, PlaceholderInlineInput } from "./inline_input";
 
 const meta = {
     title: "Forms & Inputs/InlineInput",
@@ -196,6 +196,28 @@ export const WithAutofill: Story = {
                     }}
                 />
                 {autofillTriggered() && <p style={{ color: "green" }}>Autofill triggered</p>}
+            </div>
+        );
+    },
+};
+
+export const Placeholder: Story = {
+    render: () => {
+        const [text, setText] = createSignal("");
+
+        return (
+            <div style={{ padding: "16px" }}>
+                <p>
+                    A <code>PlaceholderInlineInput</code> is shaped like a real{" "}
+                    <code>InlineInput</code> so the two align on the same baseline:
+                </p>
+                <div style={{ display: "flex", "align-items": "baseline", gap: "1ex" }}>
+                    <InlineInput text={text()} setText={setText} placeholder="Real input" />
+                    <span>{"\u27F5"}</span>
+                    <PlaceholderInlineInput />
+                </div>
+                <p style={{ "margin-top": "16px" }}>With a custom placeholder:</p>
+                <PlaceholderInlineInput placeholder="not yet available" />
             </div>
         );
     },

--- a/packages/ui-components/src/inline_input.tsx
+++ b/packages/ui-components/src/inline_input.tsx
@@ -38,3 +38,25 @@ export const InlineInput = (props: InlineInputProps) => (
         />
     </div>
 );
+
+/** Props for `PlaceholderInlineInput` component. */
+export type PlaceholderInlineInputProps = {
+    /** Placeholder text to display. Defaults to `"..."`. */
+    placeholder?: string;
+};
+
+/** A non-editable placeholder shaped like an `InlineInput`.
+
+Renders the same DOM shell as `InlineInput` (so its size, baseline, and spacing
+match a real inline input) but with no underlying text field. Use this where an
+`InlineInput` would normally appear but the input cannot yet be edited (e.g.
+because its parent state is incomplete) and you want a dimmed placeholder
+occupying the same space.
+ */
+export const PlaceholderInlineInput = (props: PlaceholderInlineInputProps) => (
+    <div class="inline-input-container">
+        <span class="inline-input-filler placeholder-inline-input">
+            {props.placeholder ?? "..."}
+        </span>
+    </div>
+);


### PR DESCRIPTION
Improves instantiation specialization selection UI. Similar behavior to the string diagram transition editor. closes https://github.com/ToposInstitute/CatColab/issues/891 

Also prefixed the left-hand side with a "." because I think it's clearer. 


https://github.com/user-attachments/assets/24413f3a-8e34-4d02-8454-af8c4ff3fab2

