### PR TITLE
`@ext` macro for AlgJulia interop

### DIFF
--- a/packages/algjulia-interop/Project.toml
+++ b/packages/algjulia-interop/Project.toml
@@ -12,6 +12,7 @@ MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
 Oxygen = "df9a0d86-3283-4920-82dc-4555fc0d1d8b"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [extensions]
 CatlabExt = ["Catlab", "ACSets"]
@@ -24,4 +25,5 @@ MLStyle = "0.4.17"
 Oxygen = "1.7.5"
 Reexport = "1.2.2"
 StructTypes = "1.11.0"
+TOML = "1.0.3"
 julia = "1.11"

--- a/packages/algjulia-interop/scripts/endpoint.jl
+++ b/packages/algjulia-interop/scripts/endpoint.jl
@@ -31,12 +31,12 @@ function CorsHandler(handle)
     end
 end
 
-defaults = [:Catlab,:ACSets] # all extensions to date
+defaults = [:CatlabExt] # all extensions to date
 
-# Dynamically load packages in command lin eargs
-for pkg in (isempty(ARGS) ? defaults : Symbol.(ARGS) )
-  @info "using $pkg"
-  @eval using $pkg
+# Dynamically load packages in command line args
+for ext in (isempty(ARGS) ? defaults : Symbol.(ARGS) )
+  @info "loading $ext"
+  eval(Expr(:macrocall, Symbol("@ext"), LineNumberNode(0), Expr(:call, ext, "Project.toml")))
 end
 
 for m in methods(CatColabInterop.endpoint)

--- a/packages/algjulia-interop/src/CatColabInterop.jl
+++ b/packages/algjulia-interop/src/CatColabInterop.jl
@@ -3,6 +3,8 @@ module CatColabInterop
 export endpoint 
 
 using Reexport
+using MLStyle
+using TOML
 
 """ 
 Extend this method with endpoint(::Val{my_analysis_name}) in extension packages.
@@ -11,5 +13,34 @@ function endpoint end
 
 include("Types.jl")
 @reexport using .Types
+
+"""
+Loads an extension
+
+Usage:
+
+```
+    const DecapodesExt = @ext DecapodesExt(relative_path_of_Project.toml)
+```
+"""
+macro ext(body)
+    (extension, toml) = @match body begin
+        Expr(:call, ex, toml) => (ex, toml)
+        ::Symbol => (body, "Project.toml")
+        _ => error("!: $body")
+    end
+    parsed_toml = TOML.parsefile(toml)
+    pkgs = Symbol.(parsed_toml["extensions"][String(extension)])
+    l = length(pkgs)
+    result = Expr(:block)
+    for (i, pkg) in enumerate(pkgs)
+        push!(result.args, Expr(:macrocall, Symbol("@info"), LineNumberNode(i), "using $pkg ($i/$l)"))
+        push!(result.args, Expr(:using, Expr(Symbol("."), pkg)))
+    end
+    push!(result.args, Expr(:call, Expr(Symbol("."), :Base, QuoteNode(:get_extension)),
+        :CatColabInterop, QuoteNode(extension)))
+    esc(result)
+end
+export @ext
 
 end # module

--- a/packages/algjulia-interop/test/TestCatlab.jl
+++ b/packages/algjulia-interop/test/TestCatlab.jl
@@ -1,10 +1,11 @@
 module TestCatlab 
 
-using CatColabInterop, Catlab
+using CatColabInterop
 using Catlab.CategoricalAlgebra.Pointwise.FunctorialDataMigrations.Yoneda: 
   colimit_representables
 using HTTP, Test, Oxygen, JSON3
-const CatlabExt = Base.get_extension(CatColabInterop, :CatlabExt)
+
+const CatlabExt = @ext CatlabExt("../Project.toml")
 
 # Example JSON
 #-------------


### PR DESCRIPTION
This macro loads extensions by parsing their required packages out of the TOML file. Since CatlabExt requires two packages, the impact on the code in this PR is pretty minimal. However for CatColabInterop.jl extensions which require many more packages, this simplifies both the code in the `endpoint.jl` script as well as loading extensions in tests.
 
For example,
```
using CatColabInterop
using DiagrammaticEquations, Decapodes, ACSets, CombinatorialSpaces, ComponentArrays, StaticArrays, LinearAlgebra, Distributions, OrdinaryDiffEq, CoordRefSystems

using HTTP, Test, Oxygen, JSON3

const DecapodesExt = Base.get_extension(CatColabInterop, :DecapodesExt)
```
becomes
```
using CatColabInterop
using HTTP, Test, Oxygen, JSON3
const DecapodesExt = @ext DecapodesExt("../Project.toml")
```