### PR TITLE
Use keyed `Match` in document_page

### DIFF
--- a/packages/frontend/src/page/document_page.tsx
+++ b/packages/frontend/src/page/document_page.tsx
@@ -428,36 +428,36 @@ export function DocumentPane(props: {
                     </Show>
                     <div class="notebook-container">
                         <Switch>
-                            <Match when={props.doc.type === "model" && props.doc}>
-                                {(liveModel) => <ModelDocumentHead liveModel={liveModel()} />}
+                            <Match keyed when={props.doc.type === "model" && props.doc}>
+                                {(liveModel) => <ModelDocumentHead liveModel={liveModel} />}
                             </Match>
-                            <Match when={props.doc.type === "diagram" && props.doc}>
+                            <Match keyed when={props.doc.type === "diagram" && props.doc}>
                                 {(liveDiagram) => (
-                                    <DocumentHead liveDoc={liveDiagram().liveDoc}>
-                                        <DiagramInfo liveDiagram={liveDiagram()} />
+                                    <DocumentHead liveDoc={liveDiagram.liveDoc}>
+                                        <DiagramInfo liveDiagram={liveDiagram} />
                                     </DocumentHead>
                                 )}
                             </Match>
-                            <Match when={props.doc.type === "analysis" && props.doc}>
+                            <Match keyed when={props.doc.type === "analysis" && props.doc}>
                                 {(liveAnalysis) => (
-                                    <DocumentHead liveDoc={liveAnalysis().liveDoc}>
-                                        <AnalysisInfo liveAnalysis={liveAnalysis()} />
+                                    <DocumentHead liveDoc={liveAnalysis.liveDoc}>
+                                        <AnalysisInfo liveAnalysis={liveAnalysis} />
                                     </DocumentHead>
                                 )}
                             </Match>
                         </Switch>
                         <Switch>
-                            <Match when={props.doc.type === "model" && props.doc}>
-                                {(liveModel) => <ModelNotebookEditor liveModel={liveModel()} />}
+                            <Match keyed when={props.doc.type === "model" && props.doc}>
+                                {(liveModel) => <ModelNotebookEditor liveModel={liveModel} />}
                             </Match>
-                            <Match when={props.doc.type === "diagram" && props.doc}>
+                            <Match keyed when={props.doc.type === "diagram" && props.doc}>
                                 {(liveDiagram) => (
-                                    <DiagramNotebookEditor liveDiagram={liveDiagram()} />
+                                    <DiagramNotebookEditor liveDiagram={liveDiagram} />
                                 )}
                             </Match>
-                            <Match when={props.doc.type === "analysis" && props.doc}>
+                            <Match keyed when={props.doc.type === "analysis" && props.doc}>
                                 {(liveAnalysis) => (
-                                    <AnalysisNotebookEditor liveAnalysis={liveAnalysis()} />
+                                    <AnalysisNotebookEditor liveAnalysis={liveAnalysis} />
                                 )}
                             </Match>
                         </Switch>


### PR DESCRIPTION
Avoids the error copied below when switching documents in panes through the side-bar. As far as I understand it (though I don't feel like I've fully wrapped my head around it): by using `Match` with `keyed` and thus no `Accessor` in the callback, we fix a race between the async resource (the doc) and unregistering of the `Match` callback.

```
Uncaught (in promise) Error: Attempting to access a stale value from <Match> that could possibly be undefined. This may occur because you are reading the accessor returned from the component at a time where it has already been unmounted. We recommend cleaning up any stale timers or async, or reading from the initial condition.
    castError dev.js:1015
    handleError dev.js:1028
    runUpdates dev.js:855
    completeLoad dev.js:330
    loadEnd dev.js:325
    load dev.js:395
    promise callback*load dev.js:395
    createResource dev.js:420
    runComputation dev.js:742
    updateComputation dev.js:724
    runTop dev.js:833
    runQueue dev.js:904
    completeUpdates dev.js:860
    runUpdates dev.js:850
    startTransition dev.js:568
    promise callback*startTransition dev.js:552
    transition routing.js:365
    navigateFromRoute routing.js:472
    untrack dev.js:470
    navigateFromRoute routing.js:434
    navigatorFactory routing.js:483
    handleClick document_page_sidebar.tsx:222
    handleNode dev.js:501
    eventHandler dev.js:522
    delegateEvents dev.js:225
    <anonymous> expandable_list.tsx:74
Caused by: "Attempting to access a stale value from <Match> that could possibly be undefined. This may occur because you are reading the accessor returned from the component at a time where it has already been unmounted. We recommend cleaning up any stale timers or async, or reading from the initial condition."
dev.js:1015:10
    handleError http://localhost:5173/node_modules/.vite/deps/chunk-KWF3LCG2.js?v=6de6de04:1027
    runUpdates http://localhost:5173/node_modules/.vite/deps/chunk-KWF3LCG2.js?v=6de6de04:850
    completeLoad http://localhost:5173/node_modules/.vite/deps/chunk-KWF3LCG2.js?v=6de6de04:315
    loadEnd http://localhost:5173/node_modules/.vite/deps/chunk-KWF3LCG2.js?v=6de6de04:310
    load http://localhost:5173/node_modules/.vite/deps/chunk-KWF3LCG2.js?v=6de6de04:380
    (Async: promise callback)
    load http://localhost:5173/node_modules/.vite/deps/chunk-KWF3LCG2.js?v=6de6de04:380
    createResource http://localhost:5173/node_modules/.vite/deps/chunk-KWF3LCG2.js?v=6de6de04:405
    runComputation http://localhost:5173/node_modules/.vite/deps/chunk-KWF3LCG2.js?v=6de6de04:734
    updateComputation http://localhost:5173/node_modules/.vite/deps/chunk-KWF3LCG2.js?v=6de6de04:717
    runTop http://localhost:5173/node_modules/.vite/deps/chunk-KWF3LCG2.js?v=6de6de04:827
    runQueue http://localhost:5173/node_modules/.vite/deps/chunk-KWF3LCG2.js?v=6de6de04:901
    completeUpdates http://localhost:5173/node_modules/.vite/deps/chunk-KWF3LCG2.js?v=6de6de04:856
    runUpdates http://localhost:5173/node_modules/.vite/deps/chunk-KWF3LCG2.js?v=6de6de04:845
    startTransition http://localhost:5173/node_modules/.vite/deps/chunk-KWF3LCG2.js?v=6de6de04:557
    (Async: promise callback)
    startTransition http://localhost:5173/node_modules/.vite/deps/chunk-KWF3LCG2.js?v=6de6de04:541
    transition http://localhost:5173/node_modules/.pnpm/@solidjs+router@0.15.3_solid-js@1.9.10/node_modules/@solidjs/router/dist/routing.js?v=6de6de04:365
    navigateFromRoute http://localhost:5173/node_modules/.pnpm/@solidjs+router@0.15.3_solid-js@1.9.10/node_modules/@solidjs/router/dist/routing.js?v=6de6de04:472
    untrack http://localhost:5173/node_modules/.vite/deps/chunk-KWF3LCG2.js?v=6de6de04:457
    navigateFromRoute http://localhost:5173/node_modules/.pnpm/@solidjs+router@0.15.3_solid-js@1.9.10/node_modules/@solidjs/router/dist/routing.js?v=6de6de04:434
    navigatorFactory http://localhost:5173/node_modules/.pnpm/@solidjs+router@0.15.3_solid-js@1.9.10/node_modules/@solidjs/router/dist/routing.js?v=6de6de04:483
    handleClick http://localhost:5173/src/page/document_page_sidebar.tsx?t=1778250578278:38
    InterpretGeneratorResume self-hosted:1312
    AsyncFunctionNext self-hosted:780
    (Async: async)
    handleNode http://localhost:5173/node_modules/.vite/deps/chunk-IXYHYZCU.js?v=6de6de04:912
    eventHandler http://localhost:5173/node_modules/.vite/deps/chunk-IXYHYZCU.js?v=6de6de04:933
    (Async: EventListener.handleEvent)
    delegateEvents http://localhost:5173/node_modules/.vite/deps/chunk-IXYHYZCU.js?v=6de6de04:634
    <anonymous> http://localhost:5173/@fs/home/kaspar/projects/topos/CatColab/packages/ui-components/src/expandable_list.tsx:96
```