### PR TITLE
Patch for owner change on `wasm-pack`

### DIFF
--- a/dev-docs/pnpm-lock.yaml
+++ b/dev-docs/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  wasm-pack@0.14.0:
+    hash: 3c7b8af86d6b541704193ec3130f1444612e1187cf4f53aff0ed0570b58d5e56
+    path: ../patches/wasm-pack@0.14.0.patch
+
 importers:
 
   .:

--- a/packages/backend/pkg/pnpm-lock.yaml
+++ b/packages/backend/pkg/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  wasm-pack@0.14.0:
+    hash: 3c7b8af86d6b541704193ec3130f1444612e1187cf4f53aff0ed0570b58d5e56
+    path: ../../../patches/wasm-pack@0.14.0.patch
+
 importers:
 
   .:

--- a/packages/document-methods/pnpm-lock.yaml
+++ b/packages/document-methods/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  wasm-pack@0.14.0:
+    hash: 3c7b8af86d6b541704193ec3130f1444612e1187cf4f53aff0ed0570b58d5e56
+    path: ../../patches/wasm-pack@0.14.0.patch
+
 importers:
 
   .:
@@ -26,7 +31,7 @@ importers:
         version: 5.9.3
       wasm-pack:
         specifier: ^0.14.0
-        version: 0.14.0
+        version: 0.14.0(patch_hash=3c7b8af86d6b541704193ec3130f1444612e1187cf4f53aff0ed0570b58d5e56)
 
 packages:
 
@@ -235,7 +240,7 @@ snapshots:
 
   uuid@13.0.0: {}
 
-  wasm-pack@0.14.0:
+  wasm-pack@0.14.0(patch_hash=3c7b8af86d6b541704193ec3130f1444612e1187cf4f53aff0ed0570b58d5e56):
     dependencies:
       binary-install: 1.1.2
     transitivePeerDependencies:

--- a/packages/frontend/default.nix
+++ b/packages/frontend/default.nix
@@ -37,7 +37,7 @@ let
 
     pnpmDeps = pkgs.fetchPnpmDeps {
       # see ../../dev-docs/fixing-hash-mismatches.md
-      hash = "";
+      hash = "LpQ4TxbVpdXPe6MGdtg/TQX7n4b0QAkgkj0ju9U+gZc=";
 
       pname = name;
       fetcherVersion = 2;

--- a/packages/frontend/default.nix
+++ b/packages/frontend/default.nix
@@ -37,8 +37,7 @@ let
 
     pnpmDeps = pkgs.fetchPnpmDeps {
       # see ../../dev-docs/fixing-hash-mismatches.md
-      hash = "LpQ4TxbVpdXPe6MGdtg/TQX7n4b0QAkgkj0ju9U+gZc=";
-
+      hash = "sha256-LpQ4TxbVpdXPe6MGdtg/TQX7n4b0QAkgkj0ju9U+gZc=";
       pname = name;
       fetcherVersion = 2;
       # Only includes package.json and pnpm-lock.yaml files to ensure consistent hashing in different

--- a/packages/frontend/default.nix
+++ b/packages/frontend/default.nix
@@ -19,6 +19,7 @@ let
         ../../.npmrc
         ../../pnpm-workspace.yaml
         ../../pnpm-lock.yaml
+        ../../patches
         ../../packages/frontend
         ../../packages/ui-components
         ../../packages/document-methods
@@ -36,7 +37,7 @@ let
 
     pnpmDeps = pkgs.fetchPnpmDeps {
       # see ../../dev-docs/fixing-hash-mismatches.md
-      hash = "sha256-n/0a/wK2mLkGvKWSBs/8zdfgF+dxMmPz3Ir1k30Qw9s=";
+      hash = "";
 
       pname = name;
       fetcherVersion = 2;
@@ -48,6 +49,7 @@ let
           ../../.npmrc
           ../../pnpm-workspace.yaml
           ../../pnpm-lock.yaml
+          ../../patches
           ../../packages/frontend/package.json
           ../../packages/frontend/pnpm-lock.yaml
           ../../packages/ui-components/package.json

--- a/packages/frontend/pnpm-lock.yaml
+++ b/packages/frontend/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  wasm-pack@0.14.0:
+    hash: 3c7b8af86d6b541704193ec3130f1444612e1187cf4f53aff0ed0570b58d5e56
+    path: ../../patches/wasm-pack@0.14.0.patch
+
 importers:
 
   .:
@@ -212,7 +217,7 @@ importers:
         version: 4.0.8(@types/debug@4.1.12)(@types/node@24.10.0)(yaml@2.5.1)
       wasm-pack:
         specifier: ^0.14.0
-        version: 0.14.0
+        version: 0.14.0(patch_hash=3c7b8af86d6b541704193ec3130f1444612e1187cf4f53aff0ed0570b58d5e56)
       web-worker:
         specifier: ^1.5.0
         version: 1.5.0
@@ -1748,8 +1753,8 @@ packages:
   flatted@3.4.1:
     resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
 
-  follow-redirects@1.15.9:
-    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -2329,9 +2334,6 @@ packages:
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
-
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
@@ -4443,7 +4445,7 @@ snapshots:
 
   axios@0.26.1:
     dependencies:
-      follow-redirects: 1.15.9
+      follow-redirects: 1.16.0
     transitivePeerDependencies:
       - debug
 
@@ -4935,7 +4937,7 @@ snapshots:
 
   flatted@3.4.1: {}
 
-  follow-redirects@1.15.9: {}
+  follow-redirects@1.16.0: {}
 
   foreground-child@3.3.0:
     dependencies:
@@ -4977,7 +4979,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -5986,10 +5988,6 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.4
 
-  minimatch@3.1.2:
-    dependencies:
-      brace-expansion: 1.1.11
-
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.11
@@ -6838,7 +6836,7 @@ snapshots:
 
   w3c-keyname@2.2.8: {}
 
-  wasm-pack@0.14.0:
+  wasm-pack@0.14.0(patch_hash=3c7b8af86d6b541704193ec3130f1444612e1187cf4f53aff0ed0570b58d5e56):
     dependencies:
       binary-install: 1.1.2
     transitivePeerDependencies:

--- a/packages/gaios/pnpm-lock.yaml
+++ b/packages/gaios/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  wasm-pack@0.14.0:
+    hash: 3c7b8af86d6b541704193ec3130f1444612e1187cf4f53aff0ed0570b58d5e56
+    path: ../../patches/wasm-pack@0.14.0.patch
+
 importers:
 
   .:

--- a/packages/ui-components/pnpm-lock.yaml
+++ b/packages/ui-components/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  wasm-pack@0.14.0:
+    hash: 3c7b8af86d6b541704193ec3130f1444612e1187cf4f53aff0ed0570b58d5e56
+    path: ../../patches/wasm-pack@0.14.0.patch
+
 importers:
 
   .:

--- a/patches/wasm-pack@0.14.0.patch
+++ b/patches/wasm-pack@0.14.0.patch
@@ -1,0 +1,13 @@
+diff --git a/binary.js b/binary.js
+index 7f0472a1f80325d4b75860f0ec9f784779a90c01..f9d1fae49b5bb6dd6baa1a8e268c8aa930fe299a 100644
+--- a/binary.js
++++ b/binary.js
+@@ -31,7 +31,7 @@ const getPlatform = () => {
+ const getBinary = () => {
+   const platform = getPlatform();
+   const version = require("./package.json").version;
+-  const author = "drager";
++  const author = "wasm-bindgen";
+   const name = "wasm-pack";
+   const url = `https://github.com/${author}/${name}/releases/download/v${version}/${name}-v${version}-${platform}.tar.gz`;
+   return new Binary(platform === windows ? "wasm-pack.exe" : "wasm-pack", url, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  wasm-pack@0.14.0:
+    hash: 3c7b8af86d6b541704193ec3130f1444612e1187cf4f53aff0ed0570b58d5e56
+    path: patches/wasm-pack@0.14.0.patch
+
 importers:
 
   .:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,5 @@ packages:
   - "packages/document-methods"
   - "packages/ui-components"
   - "packages/gaios"
+patchedDependencies:
+    wasm-pack@0.14.0: patches/wasm-pack@0.14.0.patch


### PR DESCRIPTION
The owner of our wasm-pack wrapper just changed and it was breaking; this patch looks like one way of working through this, don't know if there's a better idea. 