### PR TITLE
Make optional deps be ordinary deps in AlgJulia interop

### DIFF
--- a/packages/algjulia-interop/Project.toml
+++ b/packages/algjulia-interop/Project.toml
@@ -13,9 +13,6 @@ Oxygen = "df9a0d86-3283-4920-82dc-4555fc0d1d8b"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 
-[extensions]
-CatlabExt = ["Catlab", "ACSets"]
-
 [compat]
 ACSets = "0.2.26"
 Catlab = "0.17.2"

--- a/packages/algjulia-interop/scripts/endpoint.jl
+++ b/packages/algjulia-interop/scripts/endpoint.jl
@@ -10,6 +10,9 @@ using CatColabInterop
 using Oxygen
 using HTTP
 
+using Catlab 
+using ACSets
+
 const port = parse(Int, get(ENV, "JULIA_PORT", "8080"))
 
 const CORS_HEADERS = [
@@ -29,14 +32,6 @@ function CorsHandler(handle)
             r
         end
     end
-end
-
-defaults = [:Catlab,:ACSets] # all extensions to date
-
-# Dynamically load packages in command lin eargs
-for pkg in (isempty(ARGS) ? defaults : Symbol.(ARGS) )
-  @info "using $pkg"
-  @eval using $pkg
 end
 
 for m in methods(CatColabInterop.endpoint)

--- a/packages/algjulia-interop/src/CatColabInterop.jl
+++ b/packages/algjulia-interop/src/CatColabInterop.jl
@@ -4,12 +4,14 @@ export endpoint
 
 using Reexport
 
-""" 
-Extend this method with endpoint(::Val{my_analysis_name}) in extension packages.
-"""
+""" Extend this method with endpoint(::Val{my_analysis_name}). """
 function endpoint end 
 
 include("Types.jl")
 @reexport using .Types
+
+include("CatlabInterop.jl")
+# Add more interops here...
+
 
 end # module

--- a/packages/algjulia-interop/src/CatlabInterop.jl
+++ b/packages/algjulia-interop/src/CatlabInterop.jl
@@ -1,4 +1,4 @@
-module CatlabExt
+module CatlabInterop
 
 using ACSets
 using Catlab: Presentation, FreeSchema, Left

--- a/packages/algjulia-interop/test/Manifest.toml
+++ b/packages/algjulia-interop/test/Manifest.toml
@@ -2,13 +2,13 @@
 
 julia_version = "1.12.5"
 manifest_format = "2.0"
-project_hash = "ae3caef2a0866469616d51a6bb9ac744f063ad55"
+project_hash = "8e27b017675e11d4ba34f579de046e8ab3cb258a"
 
 [[deps.ACSets]]
 deps = ["AlgebraicInterfaces", "Base64", "CompTime", "DataStructures", "JSON3", "MLStyle", "OrderedCollections", "PEG", "Permutations", "Pkg", "PrettyTables", "Random", "Reexport", "SHA", "StaticArrays", "StructEquality", "StructTypes", "Tables"]
-git-tree-sha1 = "80ca69d6844aa5a1e67338b5362e393007c4c168"
+git-tree-sha1 = "dabea268e85bfa2d87019772d1e5b5115542450f"
 uuid = "227ef7b5-1206-438b-ac65-934d6da304b8"
-version = "0.2.26"
+version = "0.2.28"
 
     [deps.ACSets.extensions]
     DataFramesACSetsExt = "DataFrames"
@@ -44,18 +44,15 @@ version = "0.1.9"
 
 [[deps.CatColabInterop]]
 deps = ["ACSets", "Catlab", "HTTP", "MLStyle", "Oxygen", "Reexport", "StructTypes"]
-path = "."
+path = ".."
 uuid = "9ecda8fb-39ab-46a2-a496-7285fa6368c1"
 version = "0.1.1"
 
-    [deps.CatColabInterop.extensions]
-    CatlabExt = ["Catlab", "ACSets"]
-
 [[deps.Catlab]]
 deps = ["ACSets", "AlgebraicInterfaces", "Colors", "CompTime", "Compose", "DataStructures", "GATlab", "GeneralizedGenerated", "JSON3", "LightXML", "LinearAlgebra", "Logging", "MLStyle", "PEG", "PrettyTables", "Random", "Reexport", "SparseArrays", "StaticArrays", "Statistics", "StructEquality", "StructTypes", "Tables"]
-git-tree-sha1 = "bf515a1858d0dfd00887a3ba1daf587d14ec7b51"
+git-tree-sha1 = "fadf5ec3e429cc88be1178b6baf687b99bb3177c"
 uuid = "134e5e36-593f-5add-ad60-77f754baafbe"
-version = "0.17.4"
+version = "0.17.5"
 
     [deps.Catlab.extensions]
     CatlabConvexExt = "Convex"
@@ -217,9 +214,9 @@ version = "1.0.0"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
-git-tree-sha1 = "0533e564aae234aff59ab625543145446d8b6ec2"
+git-tree-sha1 = "7204148362dafe5fe6a273f855b8ccbe4df8173e"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.7.1"
+version = "1.8.0"
 
 [[deps.JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
@@ -339,9 +336,9 @@ version = "1.1.10"
 
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "926c6af3a037c68d02596a44c22ec3595f5f760b"
+git-tree-sha1 = "ff69a2b1330bcb730b9ac1ab7dd680176f5896b8"
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.6+0"
+version = "2.28.1010+0"
 
 [[deps.Measures]]
 git-tree-sha1 = "b513cedd20d9c914783d8ad83d08120702bf2c77"
@@ -418,9 +415,9 @@ version = "1.0.4"
 
 [[deps.Parsers]]
 deps = ["Dates", "PrecompileTools", "UUIDs"]
-git-tree-sha1 = "7d2f8f21da5db6a806faf7b9b292296da42b2810"
+git-tree-sha1 = "5d5e0a78e971354b1c7bff0655d11fdc1b0e12c8"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.8.3"
+version = "2.8.4"
 
 [[deps.Permutations]]
 deps = ["Combinatorics", "LinearAlgebra", "Random"]
@@ -432,18 +429,16 @@ version = "0.4.23"
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 version = "1.12.1"
+weakdeps = ["REPL"]
 
     [deps.Pkg.extensions]
     REPLExt = "REPL"
 
-    [deps.Pkg.weakdeps]
-    REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
-
 [[deps.PrecompileTools]]
 deps = ["Preferences"]
-git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
+git-tree-sha1 = "07a921781cab75691315adc645096ed5e370cb77"
 uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-version = "1.2.1"
+version = "1.3.3"
 
 [[deps.Preferences]]
 deps = ["TOML"]
@@ -457,14 +452,25 @@ uuid = "8162dcfd-2161-5ef2-ae6c-7681170c5f98"
 version = "0.2.0"
 
 [[deps.PrettyTables]]
-deps = ["Crayons", "LaTeXStrings", "Markdown", "PrecompileTools", "Printf", "Reexport", "StringManipulation", "Tables"]
-git-tree-sha1 = "1101cd475833706e4d0e7b122218257178f48f34"
+deps = ["Crayons", "LaTeXStrings", "Markdown", "PrecompileTools", "Printf", "REPL", "Reexport", "StringManipulation", "Tables"]
+git-tree-sha1 = "624de6279ab7d94fc9f672f0068107eb6619732c"
 uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
-version = "2.4.0"
+version = "3.3.2"
+
+    [deps.PrettyTables.extensions]
+    PrettyTablesTypstryExt = "Typstry"
+
+    [deps.PrettyTables.weakdeps]
+    Typstry = "f0ed7684-a786-439e-b1e3-3b82803b501e"
 
 [[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 version = "1.11.0"
 
 [[deps.Random]]

--- a/packages/algjulia-interop/test/TestCatlab.jl
+++ b/packages/algjulia-interop/test/TestCatlab.jl
@@ -4,8 +4,7 @@ using CatColabInterop, Catlab
 using Catlab.CategoricalAlgebra.Pointwise.FunctorialDataMigrations.Yoneda: 
   colimit_representables
 using HTTP, Test, Oxygen, JSON3
-const CatlabExt = Base.get_extension(CatColabInterop, :CatlabExt)
-
+import CatColabInterop.CatlabInterop
 # Example JSON
 #-------------
 body = read((@__DIR__)*"/data/diagrams/acset.json", String)
@@ -16,11 +15,11 @@ p = JSON3.read(body, ModelDiagram)
 
 # Convert to ACSet 
 #-----------------
-schema, names = CatlabExt.model_to_schema(p.model)
+schema, ids = CatColabInterop.CatlabInterop.model_to_schema(p.model)
 acset_type = AnonACSet(
   schema; type_assignment=Dict(a=>Nothing for a in schema.attrtypes))
 y = yoneda(constructor(acset_type))
-data = CatlabExt.diagram_to_data(p.diagram, names)
+data = CatlabInterop.diagram_to_data(p.diagram, ids)
 names, res = colimit_representables(data, y)
 
 S = acset_schema(res)
@@ -36,8 +35,14 @@ expected[1, :g] = AttrVar(1)
 
 # Test final JSON output
 #-----------------------
-expected_json = Dict(:Z => ["z"],:f => ["y"],:X => ["x"],:Y => ["y"],:g => ["z"])
-@test expected_json == CatlabExt.acset_to_json(res, schema, CatlabExt.make_names(res, names))
+expected_json = Dict(
+  "019a60e3-1785-72b9-90d2-84dc8bdddc85" => ["z"],
+  "019a6042-2872-7654-a9b4-67becc9ef693" => ["y"],
+  "019a6042-1241-77bd-8055-bfea5c206bc7" => ["x"],
+  "019a6042-1f1c-745e-bfea-753eeaccedf2" => ["y"], 
+  "019a60e3-2ccf-74ef-a1e1-1c940564e1ca" => ["z"] 
+)
+@test expected_json == CatlabInterop.acset_to_json(res, schema, ids, CatlabInterop.make_names(res, names))
 
 # Optionally test the endpoint if running endpoint.jl:
 # resp = HTTP.post("http://127.0.0.1:8080/acsetcolim"; body)
@@ -49,6 +54,6 @@ expected_json = Dict(:Z => ["z"],:f => ["y"],:X => ["x"],:Y => ["y"],:g => ["z"]
 @acset_type T(SchThree)
 exT = @acset T begin A=2; B=3; C=3; f=[2,3]; g=[2,3,2] end
 names = (z=(:C, 1), y= (:B, 1), x = (:A, 1), x2 = (:A, 2))
-@test CatlabExt.make_names(exT, names) == Dict(:A=>["x","x2"], :B=>["y","f(x)","f(x2)"], :C=>["z","g(y)","g(f(x))"])
+@test CatlabInterop.make_names(exT, names) == Dict(:A=>["x","x2"], :B=>["y","f(x)","f(x2)"], :C=>["z","g(y)","g(f(x))"])
 
 end # module


### PR DESCRIPTION
To simplify the Julia interop, we now avoid the package extension feature and dynamic loading of dependencies. 

The downside of this simplicity is that someone who just wants to run `endpoint.jl` with a subset of the dependencies cannot (and therefore may have to precompile for a long time). However, the primary intended usage of this package is for it to be running on a central instance which is only precompiled once.