### PR TITLE
Make deployment set a status on the `main` commit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ env:
 
 permissions:
   deployments: write
+  statuses: write
 
 jobs:
   create_deployment:
@@ -289,3 +290,18 @@ jobs:
           description: 'Backend deployment failed'
           state: 'failure'
           deployment-id: ${{ needs.create_backend_deployment.outputs.deployment_id }}
+
+      - name: Post commit status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const state = '${{ needs.deploy_backend.result }}' === 'success' ? 'success' : 'failure';
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ github.event.workflow_run.head_sha }}',
+              state: state,
+              target_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}',
+              description: state === 'success' ? 'Backend deployed to AWS' : 'Backend deployment failed',
+              context: 'deploy / backend'
+            });


### PR DESCRIPTION
I thought the deployment action handled this but seems we have to explicitly report deployment success/failure to the commit so that we get notified of failure more prominently. 