### PR TITLE
Reset active input in editors when focus is lost

### DIFF
--- a/packages/frontend/src/diagram/morphism_cell_editor.tsx
+++ b/packages/frontend/src/diagram/morphism_cell_editor.tsx
@@ -1,4 +1,4 @@
-import { createSignal, useContext } from "solid-js";
+import { createEffect, createSignal, useContext } from "solid-js";
 import invariant from "tiny-invariant";
 import { v7 } from "uuid";
 
@@ -24,6 +24,13 @@ export function DiagramMorphismCellEditor(props: {
     invariant(liveDiagram, "Live diagram should be provided as context");
 
     const [activeInput, setActiveInput] = createSignal<DiagramMorphismCellInput>("mor");
+
+    // Reset to default on deactivation so re-entry lands on the morphism input.
+    createEffect(() => {
+        if (!props.isActive) {
+            setActiveInput("mor");
+        }
+    });
 
     const domType = () => props.theory.theory.src(props.decl.morType);
     const codType = () => props.theory.theory.tgt(props.decl.morType);

--- a/packages/frontend/src/model/contribution_cell_editor.tsx
+++ b/packages/frontend/src/model/contribution_cell_editor.tsx
@@ -1,4 +1,4 @@
-import { createMemo, createSignal, useContext, Switch, Match } from "solid-js";
+import { createEffect, createMemo, createSignal, useContext, Switch, Match } from "solid-js";
 import invariant from "tiny-invariant";
 
 import { NameInput } from "catcolab-ui-components";
@@ -33,6 +33,13 @@ export default function ContributionCellEditor(
     invariant(liveModel, "Live model should be provided as context");
 
     const [activeInput, setActiveInput] = createSignal<MorphismCellInput>("name");
+
+    // Reset to default on deactivation so re-entry lands on the name input.
+    createEffect(() => {
+        if (!props.isActive) {
+            setActiveInput("name");
+        }
+    });
 
     const morTypeMeta = () => props.theory.modelMorTypeMeta(props.morphism.morType);
 

--- a/packages/frontend/src/model/instantiation_cell_editor.tsx
+++ b/packages/frontend/src/model/instantiation_cell_editor.tsx
@@ -77,6 +77,16 @@ export function InstantiationCellEditor(props: {
             setActiveIndex(index);
         });
 
+    // Reset to default on deactivation so re-entry lands on the name input.
+    createEffect(() => {
+        if (!props.isActive) {
+            batch(() => {
+                setActiveComponent("name");
+                setActiveIndex(0);
+            });
+        }
+    });
+
     const insertSpecializationAtTop = () => {
         props.modifyInstantiation((inst) => {
             inst.specializations.unshift({ id: null, ob: null });
@@ -306,6 +316,13 @@ function SpecializationEditor(
     const [inputProps, props] = splitProps(allProps, ["createBelow", "exitDown", "exitUp"]);
 
     const [activeInput, setActiveInput] = createSignal<SpecializationEditorInput>("id");
+
+    // Reset to default on deactivation so re-entry lands on the id input.
+    createEffect(() => {
+        if (!props.isActive) {
+            setActiveInput("id");
+        }
+    });
 
     const obType = () => {
         const id = props.specialization.id;

--- a/packages/frontend/src/model/morphism_cell_editor.tsx
+++ b/packages/frontend/src/model/morphism_cell_editor.tsx
@@ -1,4 +1,4 @@
-import { createMemo, createSignal, useContext } from "solid-js";
+import { createEffect, createMemo, createSignal, useContext } from "solid-js";
 import invariant from "tiny-invariant";
 
 import { NameInput } from "catcolab-ui-components";
@@ -17,6 +17,13 @@ export default function MorphismCellEditor(props: MorphismEditorProps) {
     invariant(liveModel, "Live model should be provided as context");
 
     const [activeInput, setActiveInput] = createSignal<MorphismCellInput>("name");
+
+    // Reset to default on deactivation so re-entry lands on the name input.
+    createEffect(() => {
+        if (!props.isActive) {
+            setActiveInput("name");
+        }
+    });
 
     const morTypeMeta = () => props.theory.modelMorTypeMeta(props.morphism.morType);
 

--- a/packages/frontend/src/model/string_diagram_morphism_cell_editor.tsx
+++ b/packages/frontend/src/model/string_diagram_morphism_cell_editor.tsx
@@ -134,6 +134,13 @@ export default function StringDiagramMorphismCellEditor(props: MorphismEditorPro
 
     const [active, setActive] = createSignal<ActiveInput | null>({ zone: "name" });
 
+    // Reset to default on deactivation so re-entry lands on the name input.
+    createEffect(() => {
+        if (!props.isActive) {
+            setActive({ zone: "name" });
+        }
+    });
+
     // Track which wire indices have non-empty text (including incomplete input).
     const domInputTexts = new Map<number, string>();
     const codInputTexts = new Map<number, string>();


### PR DESCRIPTION
Make keyboard navigation more predictable. The focused input no longer depends on the last input that was previously focused in the cell. 