### PR TITLE
Mitigate invalid date being passed to relative_time

### DIFF
--- a/packages/ui-components/src/relative_time.tsx
+++ b/packages/ui-components/src/relative_time.tsx
@@ -1,3 +1,5 @@
+import { Show } from "solid-js";
+
 // oxlint-disable-next-line no-unassigned-import -- side-effect import registers the custom element
 import "@github/relative-time-element";
 
@@ -19,9 +21,34 @@ declare module "solid-js" {
     }
 }
 
+const warnedTimestamps = new Set<unknown>();
+
+function toIsoStringSafe(ts: unknown): string | undefined {
+    if (typeof ts !== "number" || !Number.isFinite(ts)) {
+        if (!warnedTimestamps.has(ts)) {
+            warnedTimestamps.add(ts);
+            console.warn("RelativeTime: invalid timestamp", ts);
+        }
+        return undefined;
+    }
+    const d = new Date(ts);
+    if (Number.isNaN(d.getTime())) {
+        if (!warnedTimestamps.has(ts)) {
+            warnedTimestamps.add(ts);
+            console.warn("RelativeTime: timestamp produced invalid Date", ts);
+        }
+        return undefined;
+    }
+    return d.toISOString();
+}
+
 /** Display a timestamp as relative text, with the exact time as a tooltip. Auto-updates. */
 export function RelativeTime(props: { timestamp: number }) {
-    const datetime = () => new Date(props.timestamp).toISOString();
+    const datetime = () => toIsoStringSafe(props.timestamp);
 
-    return <relative-time datetime={datetime()} />;
+    return (
+        <Show when={datetime()} fallback={<span aria-hidden="true">—</span>}>
+            {(dt) => <relative-time datetime={dt()} />}
+        </Show>
+    );
 }


### PR DESCRIPTION
closes #1259

My hypothesis is this is a partial sync state of automerge but I haven't verified that. This avoids the error and logs a warning instead which we can keep an eye on.