### PR TITLE
Colors: stop using green, alias blue to "indicator"

### DIFF
--- a/packages/frontend/src/page/home_page.css
+++ b/packages/frontend/src/page/home_page.css
@@ -65,13 +65,7 @@
 .home-nav-button {
     margin-top: 20px;
     padding: 10px 20px;
-    background: var(--color-topos-primary);
-    border: none;
-    border-radius: 5px;
-    font-family: var(--main-font);
     font-size: 18px;
-    color: var(--color-background);
-    cursor: pointer;
 }
 
 .quick-actions {
@@ -205,31 +199,5 @@
 }
 
 .home-nav-button.get-started {
-    border: 1px solid var(--color-background);
-    border-radius: 5px;
-    cursor: pointer;
     font-weight: bold;
-    color: var(--color-background);
-}
-
-.home-nav-button.outline {
-    background: var(--color-background);
-    color: var(--color-gray-850);
-    border: 1px solid var(--color-gray-700);
-    border-radius: 5px;
-    cursor: pointer;
-}
-
-.home-nav-button.outline:hover:not(:disabled) {
-    background-color: var(--color-hover-button-light);
-}
-
-.home-nav-button:hover:not(:disabled) {
-    background-color: var(--color-topos-primary-hover);
-}
-
-/* stylelint-disable-next-line no-descending-specificity -- :disabled and :hover:not(:disabled) are mutually exclusive */
-.home-nav-button:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
 }

--- a/packages/frontend/src/page/home_page.tsx
+++ b/packages/frontend/src/page/home_page.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "@solidjs/router";
 import { getAuth } from "firebase/auth";
+import ArrowLeftIcon from "lucide-solid/icons/arrow-left";
 import Binoculars from "lucide-solid/icons/binoculars";
 import Bird from "lucide-solid/icons/bird";
 import ExternalLink from "lucide-solid/icons/external-link";
@@ -58,11 +59,8 @@ export default function HomePage() {
                             <div class="home-body fade-in">
                                 <Login onComplete={handleLoginComplete} />
                                 <div class="home-navigation-buttons left">
-                                    <Button
-                                        variant="positive"
-                                        class="home-nav-button"
-                                        onClick={() => setLoginOpen(false)}
-                                    >
+                                    <Button variant="utility" onClick={() => setLoginOpen(false)}>
+                                        <ArrowLeftIcon />
                                         Go back
                                     </Button>
                                 </div>

--- a/packages/frontend/src/page/home_page.tsx
+++ b/packages/frontend/src/page/home_page.tsx
@@ -11,6 +11,7 @@ import LogInIcon from "lucide-solid/icons/log-in";
 import { useAuth, useFirebaseApp } from "solid-firebase";
 import { createSignal, Match, Show, Switch } from "solid-js";
 
+import { Button } from "catcolab-ui-components";
 import { useApi } from "../api";
 import { createModel } from "../model/document";
 import { stdTheories } from "../stdlib";
@@ -57,12 +58,13 @@ export default function HomePage() {
                             <div class="home-body fade-in">
                                 <Login onComplete={handleLoginComplete} />
                                 <div class="home-navigation-buttons left">
-                                    <button
+                                    <Button
+                                        variant="positive"
                                         class="home-nav-button"
                                         onClick={() => setLoginOpen(false)}
                                     >
                                         Go back
-                                    </button>
+                                    </Button>
                                 </div>
                             </div>
                         </Match>
@@ -74,28 +76,34 @@ export default function HomePage() {
                                 </div>
                                 <div class="quick-actions">
                                     <Show when={!isAuthLoading() && !isLoggedIn()}>
-                                        <button
+                                        <Button
+                                            variant="positive"
                                             class="home-nav-button get-started"
                                             onClick={() => setLoginOpen(true)}
                                         >
                                             <LogInIcon />
                                             <span>Log in or sign up</span>
-                                        </button>
+                                        </Button>
                                     </Show>
                                     <Show when={!isAuthLoading() && isLoggedIn()}>
-                                        <a href="/documents" class="home-nav-button outline">
+                                        <Button
+                                            variant="utility"
+                                            class="home-nav-button"
+                                            onClick={() => navigate("/documents")}
+                                        >
                                             <Files />
                                             <span>My documents</span>
-                                        </a>
+                                        </Button>
                                     </Show>
-                                    <button
+                                    <Button
+                                        variant="positive"
                                         class="home-nav-button get-started"
                                         onClick={handleCreateModel}
                                         disabled={creating()}
                                     >
                                         <FilePlus />
                                         <span>{creating() ? "Creating..." : "New model"}</span>
-                                    </button>
+                                    </Button>
                                 </div>
                                 <div class="resources-container">
                                     <div class="resources-list">

--- a/packages/frontend/src/page/sidebar_layout.css
+++ b/packages/frontend/src/page/sidebar_layout.css
@@ -175,7 +175,7 @@
     }
 
     &.focused {
-        border-left-color: var(--color-alert-question);
+        border-left-color: var(--color-indicator);
     }
 }
 

--- a/packages/ui-components/src/alert.css
+++ b/packages/ui-components/src/alert.css
@@ -34,5 +34,5 @@
 }
 
 .alert-question {
-    --alert-color: var(--color-accent-info);
+    --alert-color: var(--color-alert-question);
 }

--- a/packages/ui-components/src/alert.css
+++ b/packages/ui-components/src/alert.css
@@ -34,5 +34,5 @@
 }
 
 .alert-question {
-    --alert-color: var(--color-alert-question);
+    --alert-color: var(--color-accent-info);
 }

--- a/packages/ui-components/src/button.tsx
+++ b/packages/ui-components/src/button.tsx
@@ -12,7 +12,7 @@ export function Button(
         children: JSX.Element;
     } & ComponentProps<"button">,
 ) {
-    const [props, buttonProps] = splitProps(allProps, ["variant", "children"]);
+    const [props, buttonProps] = splitProps(allProps, ["variant", "children", "class"]);
 
     const variantClass = () => {
         switch (props.variant) {
@@ -29,9 +29,9 @@ export function Button(
 
     return (
         <button
-            class={`button ${variantClass()}`}
-            type={buttonProps.type || "button"}
             {...buttonProps}
+            class={`button ${variantClass()}${props.class ? ` ${props.class}` : ""}`}
+            type={buttonProps.type || "button"}
         >
             {props.children}
         </button>

--- a/packages/ui-components/src/colors.css
+++ b/packages/ui-components/src/colors.css
@@ -78,12 +78,12 @@
      * Positive Colors
      * From lightest to darkest
      * ======================================== */
-    --color-icon-button-positive-hover: #efe;
-    --color-icon-button-positive-active: #dfd;
-    --color-button-positive-hover: #3cb371;
-    --color-button-positive-base: #2e8b57;
-    --color-icon-button-positive-text: #0a0;
-    --color-button-positive-border: darkgreen;
+    --color-icon-button-positive-hover: #e8f7f6;
+    --color-icon-button-positive-active: #d4efed;
+    --color-button-positive-hover: var(--color-topos-primary-hover);
+    --color-button-positive-base: var(--color-topos-primary);
+    --color-icon-button-positive-text: var(--color-topos-primary);
+    --color-button-positive-border: var(--color-topos-primary);
 
     /* ========================================
      * Danger Colors
@@ -111,7 +111,7 @@
     /* ========================================
      * Information Colors 
      * ======================================== */
-    --color-accent-info: cornflowerblue;
+    --color-indicator: cornflowerblue;
     --color-alert-note: teal;
 
     /* ========================================

--- a/packages/ui-components/src/colors.css
+++ b/packages/ui-components/src/colors.css
@@ -111,7 +111,7 @@
     /* ========================================
      * Information Colors 
      * ======================================== */
-    --color-alert-question: cornflowerblue;
+    --color-accent-info: cornflowerblue;
     --color-alert-note: teal;
 
     /* ========================================

--- a/packages/ui-components/src/colors.css
+++ b/packages/ui-components/src/colors.css
@@ -112,7 +112,8 @@
      * Information Colors 
      * ======================================== */
     --color-indicator: cornflowerblue;
-    --color-alert-note: teal;
+    --color-alert-question: var(--color-indicator);
+    --color-alert-note: var(--color-topos-primary);
 
     /* ========================================
      * Rich Text Editor Colors

--- a/packages/ui-components/src/colors.stories.tsx
+++ b/packages/ui-components/src/colors.stories.tsx
@@ -456,7 +456,7 @@ export const AllColors: Story = {
 
                 <ColorSection
                     title="Information"
-                    colors={["--color-alert-question", "--color-alert-note"]}
+                    colors={["--color-accent-info", "--color-alert-note"]}
                 />
 
                 <ColorSection
@@ -3150,11 +3150,11 @@ export const InformationColorUsage: Story = {
                             "font-weight": "600",
                         }}
                     >
-                        Alert Question Variant (alert.css)
+                        Information Accent (alert.css, history_navigator.module.css)
                     </h2>
                     <p style={{ "margin-bottom": "1rem", color: "var(--color-gray-800)" }}>
-                        Question alerts use --color-alert-question (cornflowerblue) for the accent
-                        color and heading text.
+                        Informational accents use --color-accent-info (cornflowerblue), including
+                        question alert headings and the history navigator's active marker.
                     </p>
                     <Question>
                         <p>
@@ -3172,7 +3172,7 @@ export const InformationColorUsage: Story = {
                             "font-size": "0.875rem",
                         }}
                     >
-                        <div>--alert-color: var(--color-alert-question);</div>
+                        <div>--alert-color: var(--color-accent-info);</div>
                         <div>border-left: 4px solid var(--alert-color);</div>
                         <div>color: var(--alert-color); {/* heading */}</div>
                     </div>
@@ -3231,7 +3231,7 @@ export const InformationColorUsage: Story = {
                             gap: "1.5rem",
                         }}
                     >
-                        <ColorSwatch value="--color-alert-question" />
+                        <ColorSwatch value="--color-accent-info" />
                         <ColorSwatch value="--color-alert-note" />
                     </div>
                 </div>

--- a/packages/ui-components/src/colors.stories.tsx
+++ b/packages/ui-components/src/colors.stories.tsx
@@ -535,21 +535,6 @@ export const ButtonColorsStudy: Story = {
                     <Button
                         style={{
                             color: "white",
-                            background: "var(--color-topos-primary)",
-                            border: "1px solid var(--color-topos-primary)",
-                        }}
-                        onMouseEnter={(e) => {
-                            e.currentTarget.style.background = "var(--color-topos-primary-hover)";
-                        }}
-                        onMouseLeave={(e) => {
-                            e.currentTarget.style.background = "var(--color-topos-primary)";
-                        }}
-                    >
-                        Topos Primary
-                    </Button>
-                    <Button
-                        style={{
-                            color: "white",
                             background: "var(--color-topos-secondary)",
                             border: "1px solid var(--color-topos-secondary)",
                         }}

--- a/packages/ui-components/src/colors.stories.tsx
+++ b/packages/ui-components/src/colors.stories.tsx
@@ -3189,8 +3189,8 @@ export const InformationColorUsage: Story = {
                         Alert Note Variant (alert.css)
                     </h2>
                     <p style={{ "margin-bottom": "1rem", color: "var(--color-gray-800)" }}>
-                        Note alerts use --color-alert-note (teal) for the accent color and heading
-                        text.
+                        Note alerts use --color-alert-note (Topos primary) for the accent color and
+                        heading text.
                     </p>
                     <Note>
                         <p>

--- a/packages/ui-components/src/colors.stories.tsx
+++ b/packages/ui-components/src/colors.stories.tsx
@@ -456,7 +456,7 @@ export const AllColors: Story = {
 
                 <ColorSection
                     title="Information"
-                    colors={["--color-accent-info", "--color-alert-note"]}
+                    colors={["--color-indicator", "--color-alert-question", "--color-alert-note"]}
                 />
 
                 <ColorSection
@@ -2595,9 +2595,9 @@ export const PositiveColorUsage: Story = {
                         Button Component (button.css)
                     </h2>
                     <p style={{ "margin-bottom": "1rem", color: "var(--color-gray-800)" }}>
-                        Positive buttons use --color-button-positive-base for background and
-                        --color-button-positive-border for border. On hover, they transition to
-                        --color-button-positive-hover.
+                        Positive buttons use the Topos primary palette: --color-button-positive-base
+                        for background and --color-button-positive-border for border. On hover, they
+                        transition to --color-button-positive-hover.
                     </p>
                     <div style={{ display: "flex", gap: "1rem", "align-items": "center" }}>
                         <Button variant="positive">Positive Button</Button>
@@ -2635,8 +2635,8 @@ export const PositiveColorUsage: Story = {
                     </h2>
                     <p style={{ "margin-bottom": "1rem", color: "var(--color-gray-800)" }}>
                         Positive icon buttons use transparent background by default. On hover, they
-                        use --color-icon-button-positive-hover for background and
-                        --color-icon-button-positive-text for color. On active, they use
+                        use Topos-primary-tinted --color-icon-button-positive-hover for background
+                        and --color-icon-button-positive-text for color. On active, they use
                         --color-icon-button-positive-active.
                     </p>
                     <div
@@ -3150,11 +3150,11 @@ export const InformationColorUsage: Story = {
                             "font-weight": "600",
                         }}
                     >
-                        Information Accent (alert.css, history_navigator.module.css)
+                        Indicator (alert.css, history_navigator.module.css)
                     </h2>
                     <p style={{ "margin-bottom": "1rem", color: "var(--color-gray-800)" }}>
-                        Informational accents use --color-accent-info (cornflowerblue), including
-                        question alert headings and the history navigator's active marker.
+                        Indicators use --color-indicator (cornflowerblue), with
+                        --color-alert-question as the alert-specific alias for question headings.
                     </p>
                     <Question>
                         <p>
@@ -3172,7 +3172,7 @@ export const InformationColorUsage: Story = {
                             "font-size": "0.875rem",
                         }}
                     >
-                        <div>--alert-color: var(--color-accent-info);</div>
+                        <div>--alert-color: var(--color-alert-question);</div>
                         <div>border-left: 4px solid var(--alert-color);</div>
                         <div>color: var(--alert-color); {/* heading */}</div>
                     </div>
@@ -3231,7 +3231,8 @@ export const InformationColorUsage: Story = {
                             gap: "1.5rem",
                         }}
                     >
-                        <ColorSwatch value="--color-accent-info" />
+                        <ColorSwatch value="--color-indicator" />
+                        <ColorSwatch value="--color-alert-question" />
                         <ColorSwatch value="--color-alert-note" />
                     </div>
                 </div>

--- a/packages/ui-components/src/foldable.stories.tsx
+++ b/packages/ui-components/src/foldable.stories.tsx
@@ -7,7 +7,7 @@ import { Foldable } from "./foldable";
 import { IconButton } from "./icon_button";
 
 const meta = {
-    title: "Foldable",
+    title: "Layout/Foldable",
     component: Foldable,
 } satisfies Meta<typeof Foldable>;
 

--- a/packages/ui-components/src/history_navigator.module.css
+++ b/packages/ui-components/src/history_navigator.module.css
@@ -58,7 +58,7 @@
     width: 10px;
     height: 10px;
     border-radius: 50%;
-    background-color: var(--color-alert-question);
+    background-color: var(--color-accent-info);
 }
 
 .timeCell {

--- a/packages/ui-components/src/history_navigator.module.css
+++ b/packages/ui-components/src/history_navigator.module.css
@@ -58,7 +58,7 @@
     width: 10px;
     height: 10px;
     border-radius: 50%;
-    background-color: var(--color-accent-info);
+    background-color: var(--color-indicator);
 }
 
 .timeCell {


### PR DESCRIPTION
I always felt the green clashes with the teal so this cuts it out replacing it with "Topos primary" teal. 


<img width="462" height="182" alt="image" src="https://github.com/user-attachments/assets/daa5035f-0921-4b52-840c-23f514a740bb" />



↓




<img width="672" height="96" alt="image" src="https://github.com/user-attachments/assets/51c05f94-8e0a-4881-9615-76f2bf855d45" />


<img width="564" height="482" alt="image" src="https://github.com/user-attachments/assets/f25384d3-aa2d-48a0-9b3a-ff62cce8b179" />
<img width="590" height="376" alt="image" src="https://github.com/user-attachments/assets/353032be-de5e-46ee-9b12-876d80895172" />

---

I also renamed the blue we use for indication to `--color-indicator`

<img width="202" height="301" alt="image" src="https://github.com/user-attachments/assets/526e2ea2-5f4a-4e6e-803e-434646f2bfbe" />
<img width="248" height="126" alt="image" src="https://github.com/user-attachments/assets/cca6fcc6-e6d1-44f1-b27e-050f85b3eb98" />


---

These two colors are aliased for our "question" and "note" alerts replacing a similar teal we were using previously.


<img width="800" height="428" alt="image" src="https://github.com/user-attachments/assets/a21c1d07-2531-435a-86b4-eaa8e2eb7e06" />
