### PR TITLE
Move Julia tests to own Github Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,26 +10,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  julia_tests:
-    name: julia tests
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        toolchain:
-          - stable
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Setup Julia
-        uses: julia-actions/setup-julia@v2
-        with:
-          version: '1'
-
-      - name: Tests
-        run : |
-          julia --project=packages/algjulia-interop -e 'import Pkg; Pkg.test()'
-
   catlog_tests:
     name: catlog tests
     runs-on: ubuntu-latest

--- a/.github/workflows/julia-tests.yml
+++ b/.github/workflows/julia-tests.yml
@@ -1,0 +1,29 @@
+name: julia-tests
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/algjulia-interop/**'
+      - '.github/workflows/julia-tests.yml'
+  pull_request:
+    paths:
+      - 'packages/algjulia-interop/**'
+      - '.github/workflows/julia-tests.yml'
+
+jobs:
+  julia-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Julia
+        uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+
+      - name: Tests
+        run: |
+          julia --project=packages/algjulia-interop -e 'import Pkg; Pkg.test()'

--- a/packages/algjulia-interop/README.md
+++ b/packages/algjulia-interop/README.md
@@ -3,7 +3,7 @@
 This small package makes functionality from
 [AlgebraicJulia](https://www.algebraicjulia.org/) available to CatColab. At this 
 time, only a [Catlab.jl](https://github.com/AlgebraicJulia/Catlab.jl) service is
-provided. Other packages (e.g. Decapodes.jl) will be added in the future.
+provided. Other packages (e.g. [Decapodes.jl](https://github.com/AlgebraicJulia/Decapodes.jl))) will be added in the future.
 
 ## Usage
 


### PR DESCRIPTION
Runs them only when anything in algjulia-interop package changes. Cleaner version of  #1294 . Closes #1293
