### PR TITLE
Move ui-component tests to own GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,31 +101,6 @@ jobs:
         run: |
           nix build .#rust-docs-check
 
-  ui_components_tests:
-    name: ui-components tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup NodeJS
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Install Playwright browser
-        run: pnpm --filter ./packages/ui-components exec playwright install chromium
-
-      - name: Run ui-components tests
-        run: pnpm --filter ./packages/ui-components run test
-
   npm_checks:
     name: npm checks
     runs-on: ubuntu-latest

--- a/.github/workflows/ui-components-tests.yml
+++ b/.github/workflows/ui-components-tests.yml
@@ -1,0 +1,46 @@
+name: ui-components-tests
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/ui-components/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/ui-components-tests.yml"
+  pull_request:
+    paths:
+      - "packages/ui-components/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/ui-components-tests.yml"
+
+jobs:
+  ui-components-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install dependencies
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+        run: pnpm install
+
+      - name: Install Playwright browser
+        run: pnpm --filter ./packages/ui-components exec playwright install --with-deps --no-shell chromium
+
+      - name: Run ui-components tests
+        run: pnpm --filter ./packages/ui-components run test

--- a/.github/workflows/ui-components-tests.yml
+++ b/.github/workflows/ui-components-tests.yml
@@ -34,13 +34,20 @@ jobs:
           node-version: 24
           cache: "pnpm"
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('packages/ui-components/pnpm-lock.yaml') }}
+
       - name: Install dependencies
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
         run: pnpm install
 
       - name: Install Playwright browser
-        run: pnpm --filter ./packages/ui-components exec playwright install --with-deps --no-shell chromium
+        run: pnpm --filter ./packages/ui-components exec playwright install --with-deps chromium-headless-shell
 
       - name: Run ui-components tests
         run: pnpm --filter ./packages/ui-components run test


### PR DESCRIPTION
So that they don't run on unrelated PRs. Also fixes an issue with installing chromium for these tests affecting CI runs on all PRs currently. 