### PR TITLE
Pin playwright to previous version to avoid CI hangs

### DIFF
--- a/.github/workflows/ui-components-tests.yml
+++ b/.github/workflows/ui-components-tests.yml
@@ -34,13 +34,6 @@ jobs:
           node-version: 24
           cache: "pnpm"
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('packages/ui-components/pnpm-lock.yaml') }}
-
       - name: Install dependencies
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -44,7 +44,7 @@
         "@vitest/browser-playwright": "^4.0.8",
         "@vitest/coverage-v8": "^4.0.8",
         "eslint-plugin-solid": "^0.14.5",
-        "playwright": "^1.56.1",
+        "playwright": "~1.60.0",
         "storybook": "^10.0.2",
         "storybook-solidjs-vite": "^10.0.5",
         "typescript": "^6.0.3",

--- a/packages/ui-components/pnpm-lock.yaml
+++ b/packages/ui-components/pnpm-lock.yaml
@@ -77,7 +77,7 @@ importers:
         version: 4.0.8(vite@7.2.2(@types/node@24.10.0))(vitest@4.0.8)
       '@vitest/browser-playwright':
         specifier: ^4.0.8
-        version: 4.0.8(playwright@1.56.1)(vite@7.2.2(@types/node@24.10.0))(vitest@4.0.8)
+        version: 4.0.8(playwright@1.60.0)(vite@7.2.2(@types/node@24.10.0))(vitest@4.0.8)
       '@vitest/coverage-v8':
         specifier: ^4.0.8
         version: 4.0.8(@vitest/browser@4.0.8(vite@7.2.2(@types/node@24.10.0))(vitest@4.0.8))(vitest@4.0.8)
@@ -85,8 +85,8 @@ importers:
         specifier: ^0.14.5
         version: 0.14.5(eslint@9.39.4)(typescript@6.0.3)
       playwright:
-        specifier: ^1.56.1
-        version: 1.56.1
+        specifier: ~1.60.0
+        version: 1.60.0
       storybook:
         specifier: ^10.0.2
         version: 10.0.2(@testing-library/dom@10.4.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.2.2(@types/node@24.10.0))
@@ -1613,13 +1613,13 @@ packages:
     resolution: {integrity: sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==}
     hasBin: true
 
-  playwright-core@1.56.1:
-    resolution: {integrity: sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.56.1:
-    resolution: {integrity: sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2629,7 +2629,7 @@ snapshots:
       ts-dedent: 2.2.0
     optionalDependencies:
       '@vitest/browser': 4.0.8(vite@7.2.2(@types/node@24.10.0))(vitest@4.0.8)
-      '@vitest/browser-playwright': 4.0.8(playwright@1.56.1)(vite@7.2.2(@types/node@24.10.0))(vitest@4.0.8)
+      '@vitest/browser-playwright': 4.0.8(playwright@1.60.0)(vite@7.2.2(@types/node@24.10.0))(vitest@4.0.8)
       '@vitest/runner': 4.0.8
       vitest: 4.0.8(@types/node@24.10.0)(@vitest/browser-playwright@4.0.8)
     transitivePeerDependencies:
@@ -2802,11 +2802,11 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@vitest/browser-playwright@4.0.8(playwright@1.56.1)(vite@7.2.2(@types/node@24.10.0))(vitest@4.0.8)':
+  '@vitest/browser-playwright@4.0.8(playwright@1.60.0)(vite@7.2.2(@types/node@24.10.0))(vitest@4.0.8)':
     dependencies:
       '@vitest/browser': 4.0.8(vite@7.2.2(@types/node@24.10.0))(vitest@4.0.8)
       '@vitest/mocker': 4.0.8(vite@7.2.2(@types/node@24.10.0))
-      playwright: 1.56.1
+      playwright: 1.60.0
       tinyrainbow: 3.0.3
       vitest: 4.0.8(@types/node@24.10.0)(@vitest/browser-playwright@4.0.8)
     transitivePeerDependencies:
@@ -3554,11 +3554,11 @@ snapshots:
     dependencies:
       pngjs: 7.0.0
 
-  playwright-core@1.56.1: {}
+  playwright-core@1.60.0: {}
 
-  playwright@1.56.1:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.56.1
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -3962,7 +3962,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.0
-      '@vitest/browser-playwright': 4.0.8(playwright@1.56.1)(vite@7.2.2(@types/node@24.10.0))(vitest@4.0.8)
+      '@vitest/browser-playwright': 4.0.8(playwright@1.60.0)(vite@7.2.2(@types/node@24.10.0))(vitest@4.0.8)
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
I thought #1296 included a fix but the issue is just intermittent. Maybe pinning playwright to the previous version could fix it.