### PR TITLE
Remove CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,0 @@
-# Build and CI infrastructure
-/.github/workflows/ @kasbah @jmoggr
-/infrastructure/ @kasbah @jmoggr
-*.nix @kasbah @jmoggr
-
-# Components and styling
-*.css @kasbah
-/packages/ui-components/ @kasbah


### PR DESCRIPTION
It was a nice idea, but it hasn't work out very well in practice. As implemented, this feature of GitHub creates too much noise.