### PR TITLE
Disable RFC PDF builds

### DIFF
--- a/rfc/0001.md
+++ b/rfc/0001.md
@@ -370,7 +370,6 @@ DOTS [@libkind-myers-2025].
 
 
 ### Instances
-\taxon{alternative}
 
 My original vision for "set-theoretic models" in CatColab is that they would
 exist one level lower in the system: as [instances](double-instances-2026) over

--- a/rfc/_quarto.yml
+++ b/rfc/_quarto.yml
@@ -32,14 +32,6 @@ format:
     number-sections: true
     date-format: YYYY-MM-DD
     csl: chicago-author-date.csl
-  pdf:
-    include-in-header:
-      text: |
-        \usepackage{mathtools}
-        \usepackage{tikz-cd}
-        \usepackage{quiver}
-        \usepackage{ebproof}
-        \ebproofnewstyle{small}{template=\footnotesize$\inserttext$}
 
 filters:
   - filters.lua

--- a/rfc/nonactionable/0005.md
+++ b/rfc/nonactionable/0005.md
@@ -9,8 +9,11 @@ aliases:
 tikz-preamble: |
   \DeclareMathOperator{\Mnd}{\textsf{Mnd}}
   \DeclareMathOperator{\Cat}{\textsf{Cat}}
-  \DeclareMathOperator{\Set}{\textsf{Set}}
+  \renewcommand{\Set}{\operatorname{\textsf{Set}}}
   \DeclareMathOperator{\Maybe}{Maybe}
+  \DeclareMathOperator{\Psh}{Psh}
+  \DeclareMathOperator{\eel}{\mathbb{E}l}
+  \DeclareMathOperator{\Mor}{Mor}
 
   \newlength{\ProArLineHeight}\setlength{\ProArLineHeight}{1.25ex}
 
@@ -49,18 +52,17 @@ tikz-preamble: |
     \draw ({#1}.center) ++(360-\pullbackangle:\pullbackradius) -- +(0,-\pullbackmarkerlength);
     \draw ({#1}.center) ++(270+\pullbackangle:\pullbackradius) -- +(\pullbackmarkerlength,0);
   }
-
 ---
 
 {{< include ../_macros.qmd >}}
 
-\DeclareMathOperator{\Mnd}{\textsf{Mnd}}
-\DeclareMathOperator{\Cat}{\textsf{Cat}}
-\DeclareMathOperator{\Set}{\textsf{Set}}
-\DeclareMathOperator{\Maybe}{Maybe}
-\DeclareMathOperator{\Psh}{Psh}
-\DeclareMathOperator{\eel}{\mathbb{E}l}
-\DeclareMathOperator{\Mor}{Mor}
+\newcommand{\Mnd}{\operatorname{\textsf{Mnd}}}
+\newcommand{\Cat}{\operatorname{\textsf{Cat}}}
+\renewcommand{\Set}{\operatorname{\textsf{Set}}}
+\newcommand{\Maybe}{\operatorname{Maybe}}
+\newcommand{\Psh}{\operatorname{Psh}}
+\newcommand{\eel}{\operatorname{\mathbb{E}l}}
+\newcommand{\Mor}{\operatorname{Mor}}
 
 ::: {.callout-warning}
 ### RFC status


### PR DESCRIPTION
This fixes the missing images in https://next.catcolab.org/rfc/nonactionable/0005