### PR TITLE
Re-add and fix `vite-plugin-monorepo-dedupe` tool

### DIFF
--- a/.github/workflows/vite-plugin-monorepo-dedupe.yml
+++ b/.github/workflows/vite-plugin-monorepo-dedupe.yml
@@ -1,0 +1,41 @@
+name: vite-plugin-monorepo-dedupe
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "tools/vite-plugin-monorepo-dedupe/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/vite-plugin-monorepo-dedupe-checks.yml"
+  pull_request:
+    paths:
+      - "tools/vite-plugin-monorepo-dedupe/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/vite-plugin-monorepo-dedupe-checks.yml"
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run vite-plugin-monorepo-dedupe checks
+        run: pnpm --filter ./tools/vite-plugin-monorepo-dedupe run ci

--- a/packages/frontend/default.nix
+++ b/packages/frontend/default.nix
@@ -40,6 +40,7 @@ let
     "packages/ui-components" = ../ui-components/pnpm-lock.yaml;
     "packages/document-methods" = ../document-methods/pnpm-lock.yaml;
     "packages/backend/pkg" = ../backend/pkg/pnpm-lock.yaml;
+    "tools/vite-plugin-monorepo-dedupe" = ../../tools/vite-plugin-monorepo-dedupe/pnpm-lock.yaml;
   };
 
   processedLocks = lib.mapAttrs (_: processLock) lockfilesToProcess;
@@ -75,6 +76,7 @@ let
         (lib.fileset.maybeMissing ../../patches)
         ../../packages/frontend
         ../../packages/ui-components
+        ../../tools/vite-plugin-monorepo-dedupe
         ../../packages/document-methods
         ../../packages/backend/pkg
       ];
@@ -203,6 +205,8 @@ let
         cp -r packages/backend $out/packages/
         cp -r packages/frontend $out/packages/
         cp -r packages/ui-components $out/packages/
+        mkdir -p $out/tools
+        cp -r tools/vite-plugin-monorepo-dedupe $out/tools/
         cp -r packages/document-methods $out/packages/
         mkdir -p $out/packages/document-types
         cp -r packages/document-types/pkg $out/packages/document-types/

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -77,6 +77,7 @@
         "uuid": "^13.0.0"
     },
     "devDependencies": {
+        "@catcolab-dev-tools/vite-plugin-monorepo-dedupe": "link:../../tools/vite-plugin-monorepo-dedupe",
         "@mdx-js/mdx": "^2.3.0",
         "@types/html-escaper": "^3.0.4",
         "@types/mdx": "^2.0.13",

--- a/packages/frontend/pnpm-lock.yaml
+++ b/packages/frontend/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
         specifier: ^13.0.0
         version: 13.0.0
     devDependencies:
+      '@catcolab-dev-tools/vite-plugin-monorepo-dedupe':
+        specifier: link:../../tools/vite-plugin-monorepo-dedupe
+        version: link:../../tools/vite-plugin-monorepo-dedupe
       '@mdx-js/mdx':
         specifier: ^2.3.0
         version: 2.3.0

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -1,6 +1,4 @@
-import { readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { monorepoDedupe } from "@catcolab-dev-tools/vite-plugin-monorepo-dedupe";
 import mdx from "@mdx-js/rollup";
 import rehypeKatex from "rehype-katex";
 import remarkMath from "remark-math";
@@ -8,13 +6,9 @@ import solid from "vite-plugin-solid";
 import wasm from "vite-plugin-wasm";
 import { defineConfig } from "vitest/config";
 
-// __dirname is not available in ES modules. The test:ci script uses --configLoader=runner
-// (required for readonly (Nix) environments), which runs Vite in ESM mode.
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
 export default defineConfig({
     plugins: [
+        monorepoDedupe(),
         wasm(),
         mdx({
             // https://mdxjs.com/docs/getting-started/#solid
@@ -29,9 +23,6 @@ export default defineConfig({
         chunkSizeWarningLimit: 2000,
         sourcemap: true,
         target: "es2022",
-    },
-    resolve: {
-        dedupe: getCommonDependencies(),
     },
     test: {
         // Run test files sequentially to prevent cross-test contamination via
@@ -52,24 +43,3 @@ export default defineConfig({
         },
     },
 });
-
-/**
- * Get common dependencies between frontend and ui-components packages.
- * Needed to link other packages that use Solid.js:
- * https://github.com/solidjs/solid/issues/1472
- */
-function getCommonDependencies(): string[] {
-    const frontendPkg = JSON.parse(readFileSync(resolve(__dirname, "./package.json"), "utf-8"));
-    const uiComponentsPkg = JSON.parse(
-        readFileSync(resolve(__dirname, "../ui-components/package.json"), "utf-8"),
-    );
-
-    const frontendDeps = new Set(Object.keys(frontendPkg.dependencies || {}));
-    const uiComponentsDeps = new Set(Object.keys(uiComponentsPkg.dependencies || {}));
-
-    // @ts-expect-error: intersection method does exist on Set in our
-    // vite.config target i.e. NodeJS
-    const commonDeps = frontendDeps.intersection(uiComponentsDeps);
-
-    return Array.from(commonDeps);
-}

--- a/packages/gaios/package.json
+++ b/packages/gaios/package.json
@@ -32,6 +32,7 @@
         "uuid": "^11.0.3"
     },
     "devDependencies": {
+        "@catcolab-dev-tools/vite-plugin-monorepo-dedupe": "link:../../tools/vite-plugin-monorepo-dedupe",
         "@types/react": "^18.3.3",
         "@types/uuid": "^10.0.0",
         "@vitejs/plugin-react": "^4.3.1",

--- a/packages/gaios/pnpm-lock.yaml
+++ b/packages/gaios/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
         specifier: ^11.0.3
         version: 11.1.0
     devDependencies:
+      '@catcolab-dev-tools/vite-plugin-monorepo-dedupe':
+        specifier: link:../../tools/vite-plugin-monorepo-dedupe
+        version: link:../../tools/vite-plugin-monorepo-dedupe
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.18
@@ -992,7 +995,6 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   globals@11.12.0:

--- a/packages/gaios/vite.config.ts
+++ b/packages/gaios/vite.config.ts
@@ -1,21 +1,12 @@
-import { readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { monorepoDedupe } from "@catcolab-dev-tools/vite-plugin-monorepo-dedupe";
 import { defineConfig } from "vite";
 import cssInjectedByJsPlugin from "vite-plugin-css-injected-by-js";
 import solid from "vite-plugin-solid";
 import wasm from "vite-plugin-wasm";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
 export default defineConfig({
     base: "./",
-    plugins: [wasm(), solid(), cssInjectedByJsPlugin()],
-
-    resolve: {
-        dedupe: getCommonDependencies(),
-    },
+    plugins: [monorepoDedupe(), wasm(), solid(), cssInjectedByJsPlugin()],
 
     build: {
         minify: false,
@@ -40,30 +31,3 @@ export default defineConfig({
         },
     },
 });
-
-/**
- * Get common dependencies between gaios, frontend, and ui-components packages.
- * Needed to link other packages that use Solid.js:
- * https://github.com/solidjs/solid/issues/1472
- */
-function getCommonDependencies(): string[] {
-    const gaiosPkg = JSON.parse(readFileSync(resolve(__dirname, "./package.json"), "utf-8"));
-    const frontendPkg = JSON.parse(
-        readFileSync(resolve(__dirname, "../frontend/package.json"), "utf-8"),
-    );
-    const uiComponentsPkg = JSON.parse(
-        readFileSync(resolve(__dirname, "../ui-components/package.json"), "utf-8"),
-    );
-
-    const gaiosDeps = new Set(Object.keys(gaiosPkg.dependencies || {}));
-    const frontendDeps = new Set(Object.keys(frontendPkg.dependencies || {}));
-    const uiComponentsDeps = new Set(Object.keys(uiComponentsPkg.dependencies || {}));
-
-    // @ts-expect-error: intersection method does exist on Set in our
-    // vite.config target i.e. NodeJS
-    const commonDeps = gaiosDeps
-        .intersection(frontendDeps)
-        .union(gaiosDeps.intersection(uiComponentsDeps));
-
-    return Array.from(commonDeps);
-}

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -31,6 +31,7 @@
         "solid-js": "^1.9.10"
     },
     "devDependencies": {
+        "@catcolab-dev-tools/vite-plugin-monorepo-dedupe": "link:../../tools/vite-plugin-monorepo-dedupe",
         "@chromatic-com/storybook": "^4.1.2",
         "@storybook/addon-a11y": "^10.0.2",
         "@storybook/addon-docs": "^10.0.2",

--- a/packages/ui-components/pnpm-lock.yaml
+++ b/packages/ui-components/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
         specifier: ^1.9.10
         version: 1.9.10
     devDependencies:
+      '@catcolab-dev-tools/vite-plugin-monorepo-dedupe':
+        specifier: link:../../tools/vite-plugin-monorepo-dedupe
+        version: link:../../tools/vite-plugin-monorepo-dedupe
       '@chromatic-com/storybook':
         specifier: ^4.1.2
         version: 4.1.2(storybook@10.0.2(@testing-library/dom@10.4.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.2.2(@types/node@24.10.0)))

--- a/packages/ui-components/vite.config.ts
+++ b/packages/ui-components/vite.config.ts
@@ -1,16 +1,16 @@
 /// <reference types="vitest/config" />
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { monorepoDedupe } from "@catcolab-dev-tools/vite-plugin-monorepo-dedupe";
 import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
 import { playwright } from "@vitest/browser-playwright";
 import { defineConfig } from "vite";
 
-const dirname =
-    typeof __dirname !== "undefined" ? __dirname : path.dirname(fileURLToPath(import.meta.url));
+const configDir = path.dirname(fileURLToPath(import.meta.url));
 
 // https://vite.dev/config/
 export default defineConfig({
-    plugins: [],
+    plugins: [monorepoDedupe()],
     define: {
         "process.env": {},
     },
@@ -22,7 +22,7 @@ export default defineConfig({
                     // The plugin will run tests for the stories defined in your Storybook config
                     // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
                     storybookTest({
-                        configDir: path.join(dirname, ".storybook"),
+                        configDir: path.join(configDir, ".storybook"),
                     }),
                 ],
                 test: {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,4 +10,4 @@ packages:
   - "packages/document-methods"
   - "packages/ui-components"
   - "packages/gaios"
-
+  - "tools/vite-plugin-monorepo-dedupe"

--- a/tools/vite-plugin-monorepo-dedupe/package.json
+++ b/tools/vite-plugin-monorepo-dedupe/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "@catcolab-dev-tools/vite-plugin-monorepo-dedupe",
+    "version": "0.0.0",
+    "private": true,
+    "type": "module",
+    "exports": {
+        ".": {
+            "types": "./src/index.ts",
+            "default": "./src/index.ts"
+        }
+    },
+    "scripts": {
+        "format": "oxfmt .",
+        "lint": "oxlint --fix && oxfmt .",
+        "check": "tsc && pnpm run lint",
+        "ci": "tsc && oxlint --deny-warnings && oxfmt --check ."
+    },
+    "devDependencies": {
+        "@types/node": "^24.0.0",
+        "typescript": "^6.0.3",
+        "vite": "^7.2.2"
+    }
+}

--- a/tools/vite-plugin-monorepo-dedupe/pnpm-lock.yaml
+++ b/tools/vite-plugin-monorepo-dedupe/pnpm-lock.yaml
@@ -1,0 +1,680 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.12.4
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^7.2.2
+        version: 7.3.3(@types/node@24.12.4)
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-android-arm-eabi@4.60.3':
+    resolution: {integrity: sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.3':
+    resolution: {integrity: sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.3':
+    resolution: {integrity: sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.3':
+    resolution: {integrity: sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.3':
+    resolution: {integrity: sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.3':
+    resolution: {integrity: sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
+    resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
+    resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.3':
+    resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.3':
+    resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.3':
+    resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.3':
+    resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
+    resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.3':
+    resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
+    resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.3':
+    resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.3':
+    resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.3':
+    resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.3':
+    resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.3':
+    resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.3':
+    resolution: {integrity: sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.3':
+    resolution: {integrity: sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.3':
+    resolution: {integrity: sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.3':
+    resolution: {integrity: sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.3':
+    resolution: {integrity: sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@24.12.4':
+    resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rollup@4.60.3:
+    resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  vite@7.3.3:
+    resolution: {integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.60.3':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.3':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@24.12.4':
+    dependencies:
+      undici-types: 7.16.0
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
+  nanoid@3.3.12: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rollup@4.60.3:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.3
+      '@rollup/rollup-android-arm64': 4.60.3
+      '@rollup/rollup-darwin-arm64': 4.60.3
+      '@rollup/rollup-darwin-x64': 4.60.3
+      '@rollup/rollup-freebsd-arm64': 4.60.3
+      '@rollup/rollup-freebsd-x64': 4.60.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.3
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.3
+      '@rollup/rollup-linux-arm64-gnu': 4.60.3
+      '@rollup/rollup-linux-arm64-musl': 4.60.3
+      '@rollup/rollup-linux-loong64-gnu': 4.60.3
+      '@rollup/rollup-linux-loong64-musl': 4.60.3
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.3
+      '@rollup/rollup-linux-ppc64-musl': 4.60.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.3
+      '@rollup/rollup-linux-riscv64-musl': 4.60.3
+      '@rollup/rollup-linux-s390x-gnu': 4.60.3
+      '@rollup/rollup-linux-x64-gnu': 4.60.3
+      '@rollup/rollup-linux-x64-musl': 4.60.3
+      '@rollup/rollup-openbsd-x64': 4.60.3
+      '@rollup/rollup-openharmony-arm64': 4.60.3
+      '@rollup/rollup-win32-arm64-msvc': 4.60.3
+      '@rollup/rollup-win32-ia32-msvc': 4.60.3
+      '@rollup/rollup-win32-x64-gnu': 4.60.3
+      '@rollup/rollup-win32-x64-msvc': 4.60.3
+      fsevents: 2.3.3
+
+  source-map-js@1.2.1: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  typescript@6.0.3: {}
+
+  undici-types@7.16.0: {}
+
+  vite@7.3.3(@types/node@24.12.4):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rollup: 4.60.3
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.12.4
+      fsevents: 2.3.3

--- a/tools/vite-plugin-monorepo-dedupe/src/index.ts
+++ b/tools/vite-plugin-monorepo-dedupe/src/index.ts
@@ -1,0 +1,291 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import type { Plugin } from "vite";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const dependencyFields = ["dependencies", "devDependencies", "peerDependencies"] as const;
+
+type DependencyField = (typeof dependencyFields)[number];
+
+type PackageJson = {
+    name?: string;
+} & Partial<Record<DependencyField, Record<string, string>>>;
+
+/**
+ * Dedupe dependencies from linked monorepo packages, recursively.
+ *
+ * This prevents linked packages from loading separate framework/runtime
+ * copies (e.g. Solid.js, see https://github.com/solidjs/solid/issues/1472).
+ *
+ * - The recursive crawl through `link:`/`file:`/`workspace:` edges is used only
+ *   to *discover* which package names matter; the final dedupe list is
+ *   intersected with the consumer package's own direct dependencies so that
+ *   packages the consumer doesn't import are never forced to a single copy.
+ * - When the same dependency appears with different version ranges across the
+ *   crawled packages, the plugin throws to fail the build.
+ */
+export function monorepoDedupe(): Plugin {
+    let intersectingDeps: string[] = [];
+    let isBuild = false;
+    return {
+        name: "@catcolab-dev-tools/vite-plugin-monorepo-dedupe",
+        // Use `config()` (not `configResolved()`) so the dedupe list is part of
+        // the user config Vite sees *before* it constructs its resolver.
+        config(_userConfig, env) {
+            // npm scripts invoke vite from the package directory, so cwd is the
+            // consumer package root.
+            const packageDir = process.cwd();
+            intersectingDeps = getIntersectingDeps(packageDir);
+            isBuild = env.command === "build";
+            return {
+                resolve: {
+                    dedupe: intersectingDeps,
+                },
+            };
+        },
+        generateBundle(_options, bundle) {
+            // Only enforce during `vite build`. Skip dev server and vitest, which
+            // have their own resolution graphs and may legitimately surface
+            // multiple install roots for test-only modules.
+            if (!isBuild) {
+                return;
+            }
+            const duplicates = findDuplicateInstallRoots(bundle, new Set(intersectingDeps));
+            if (duplicates.length === 0) {
+                return;
+            }
+            const formatted = duplicates
+                .map(
+                    ({ name, roots }) =>
+                        `  - ${name}:\n${roots.map((r) => `      ${r}`).join("\n")}`,
+                )
+                .join("\n");
+            this.error({
+                message:
+                    "[@catcolab-dev-tools/vite-plugin-monorepo-dedupe] dependencies bundled " +
+                    `from multiple install roots:\n${formatted}\n` +
+                    "This usually indicates that `resolve.dedupe` failed to collapse a linked " +
+                    "workspace dependency into a single copy. See " +
+                    "https://github.com/solidjs/solid/issues/1472 for one common cause.",
+            });
+        },
+    };
+}
+
+type DuplicateReport = { name: string; roots: string[] };
+
+/**
+ * Inspect every emitted chunk's module ids and group them by the
+ * `node_modules/<dep>` install root. If any watched dep is sourced from more
+ * than one root, the build has produced duplicate copies of that package.
+ */
+function findDuplicateInstallRoots(
+    bundle: Record<string, unknown>,
+    watched: Set<string>,
+): DuplicateReport[] {
+    const rootsByDep = new Map<string, Set<string>>();
+
+    // Matches the install root (group 1) and dep name (group 2) for a module id
+    // such as `/x/node_modules/.pnpm/solid-js@1.9.10/node_modules/solid-js/dist/solid.js`.
+    // Picks the *last* `node_modules/<dep>` segment so .pnpm-virtualised paths
+    // resolve to the per-version directory rather than the .pnpm root.
+    const installRootRegex = /^(.*\/node_modules\/(@[^/]+\/[^/]+|[^/]+))(?:\/|$)/;
+
+    for (const chunk of Object.values(bundle)) {
+        if (
+            chunk === null ||
+            typeof chunk !== "object" ||
+            !("modules" in chunk) ||
+            chunk.modules === null ||
+            typeof chunk.modules !== "object"
+        ) {
+            continue;
+        }
+        for (const id of Object.keys(chunk.modules as Record<string, unknown>)) {
+            // Find the *last* node_modules/<dep> segment.
+            const lastIdx = id.lastIndexOf("/node_modules/");
+            if (lastIdx === -1) {
+                continue;
+            }
+            const tail = id.slice(lastIdx);
+            const match = tail.match(installRootRegex);
+            if (match === null) {
+                throw new Error(
+                    "[@catcolab-dev-tools/vite-plugin-monorepo-dedupe] could not parse " +
+                        `install root from module id: ${id}`,
+                );
+            }
+            const installRootSuffix = match[1];
+            const depName = match[2];
+            if (installRootSuffix === undefined || depName === undefined) {
+                throw new Error(
+                    "[@catcolab-dev-tools/vite-plugin-monorepo-dedupe] install-root regex " +
+                        `matched without capture groups for module id: ${id}`,
+                );
+            }
+            if (!watched.has(depName)) {
+                continue;
+            }
+            const installRoot = id.slice(0, lastIdx) + installRootSuffix;
+            let roots = rootsByDep.get(depName);
+            if (roots === undefined) {
+                roots = new Set();
+                rootsByDep.set(depName, roots);
+            }
+            roots.add(installRoot);
+        }
+    }
+
+    const duplicates: DuplicateReport[] = [];
+    for (const [name, roots] of rootsByDep) {
+        if (roots.size > 1) {
+            duplicates.push({ name, roots: Array.from(roots).toSorted() });
+        }
+    }
+    duplicates.sort((a, b) => a.name.localeCompare(b.name));
+    return duplicates;
+}
+
+function getIntersectingDeps(packageDir: string): string[] {
+    const packageByName = getWorkspacePackages();
+    const dedupeVersions = new Map<string, Set<string>>();
+    const visitedPackages = new Set<string>();
+
+    const consumerPackage = readPackageJson(resolve(packageDir, "package.json"));
+    const consumerDepNames = new Set(getPackageDependencies(consumerPackage).map(([name]) => name));
+
+    addLinkedPackageDependencies(packageDir);
+
+    throwOnVersionConflicts(dedupeVersions);
+
+    const crawledDepNames = new Set(dedupeVersions.keys());
+    // @ts-expect-error: Set.prototype.intersection exists in our Node target
+    const dedupeNames: Set<string> = crawledDepNames.intersection(consumerDepNames);
+
+    return Array.from(dedupeNames).toSorted();
+
+    function addLinkedPackageDependencies(currentPackageDir: string) {
+        const currentPackage = readPackageJson(resolve(currentPackageDir, "package.json"));
+
+        for (const [dependencyName, dependencyVersion] of getPackageDependencies(currentPackage)) {
+            const linkedPackageDir = getLinkedPackageDir(
+                currentPackageDir,
+                packageByName,
+                dependencyName,
+                dependencyVersion,
+            );
+
+            if (linkedPackageDir === undefined) {
+                continue;
+            }
+
+            if (addPackageDependencyNames(linkedPackageDir)) {
+                addLinkedPackageDependencies(linkedPackageDir);
+            }
+        }
+    }
+
+    function addPackageDependencyNames(linkedPackageDir: string): boolean {
+        const realPackageDir = resolve(linkedPackageDir);
+        const packageJsonPath = resolve(realPackageDir, "package.json");
+        if (!existsSync(packageJsonPath)) {
+            return false;
+        }
+
+        if (visitedPackages.has(realPackageDir)) {
+            return false;
+        }
+        visitedPackages.add(realPackageDir);
+
+        for (const [dependencyName, dependencyVersion] of getPackageDependencies(
+            readPackageJson(packageJsonPath),
+        )) {
+            let versions = dedupeVersions.get(dependencyName);
+            if (versions === undefined) {
+                versions = new Set();
+                dedupeVersions.set(dependencyName, versions);
+            }
+            versions.add(dependencyVersion);
+        }
+
+        return true;
+    }
+}
+
+function throwOnVersionConflicts(dedupeVersions: Map<string, Set<string>>): void {
+    const conflicts: string[] = [];
+    for (const [name, versions] of dedupeVersions) {
+        const realVersions = Array.from(versions).filter((v) => !isLinkSpecifier(v));
+        if (realVersions.length > 1) {
+            conflicts.push(`  - ${name}: ${realVersions.join(", ")}`);
+        }
+    }
+    if (conflicts.length > 0) {
+        throw new Error(
+            "[@catcolab-dev-tools/vite-plugin-monorepo-dedupe] conflicting version ranges across linked workspace " +
+                `packages:\n${conflicts.join("\n")}\n` +
+                "Align the versions before deduping.",
+        );
+    }
+}
+
+function isLinkSpecifier(version: string): boolean {
+    return (
+        version.startsWith("link:") ||
+        version.startsWith("file:") ||
+        version.startsWith("workspace:")
+    );
+}
+
+function getWorkspacePackages(): Map<string, string> {
+    const packages = new Map<string, string>();
+
+    for (const workspaceRoot of ["packages", "tools"]) {
+        const workspaceDir = resolve(repoRoot, workspaceRoot);
+        if (!existsSync(workspaceDir)) {
+            continue;
+        }
+
+        for (const packageName of readdirSync(workspaceDir)) {
+            const packageDir = resolve(workspaceDir, packageName);
+            const packageJsonPath = resolve(packageDir, "package.json");
+            if (!existsSync(packageJsonPath)) {
+                continue;
+            }
+
+            const packageJson = readPackageJson(packageJsonPath);
+            if (packageJson.name !== undefined) {
+                packages.set(packageJson.name, packageDir);
+            }
+        }
+    }
+
+    return packages;
+}
+
+function getPackageDependencies(packageJson: PackageJson): [string, string][] {
+    return dependencyFields.flatMap((field) => Object.entries(packageJson[field] ?? {}));
+}
+
+function getLinkedPackageDir(
+    packageDir: string,
+    packageByName: Map<string, string>,
+    dependencyName: string,
+    dependencyVersion: string,
+): string | undefined {
+    if (dependencyVersion.startsWith("link:") || dependencyVersion.startsWith("file:")) {
+        return resolve(packageDir, dependencyVersion.replace(/^(link|file):/, ""));
+    }
+
+    if (dependencyVersion.startsWith("workspace:")) {
+        return packageByName.get(dependencyName);
+    }
+
+    return undefined;
+}
+
+function readPackageJson(packageJsonPath: string): PackageJson {
+    return JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+}

--- a/tools/vite-plugin-monorepo-dedupe/tsconfig.json
+++ b/tools/vite-plugin-monorepo-dedupe/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "ESNext",
+        "lib": ["ES2023"],
+        "types": ["node"],
+        "skipLibCheck": true,
+
+        "moduleResolution": "bundler",
+        "isolatedModules": true,
+        "noEmit": true,
+
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noFallthroughCasesInSwitch": true
+    },
+    "include": ["src"]
+}


### PR DESCRIPTION
Due to intricacies of how vite works the tools wasn't actually doing what I said it was doing. I added a post-build check to confirm the issue and fixed it. 

Based on #1314 to get CI not to hang.