### PR TITLE
Fix warning about unused roundtrip_json

### DIFF
--- a/packages/document-types/src/common_test.rs
+++ b/packages/document-types/src/common_test.rs
@@ -23,6 +23,7 @@ pub fn doc_to_json(doc: &Automerge) -> Value {
 }
 
 /// Roundtrip a JSON object through Automerge and back.
+#[cfg(feature = "property-tests")]
 pub fn roundtrip_json(json: &Value) -> Value {
     let doc = doc_from_json(json);
     doc_to_json(&doc)


### PR DESCRIPTION
Fixes this warning

```
warning: function `roundtrip_json` is never used
  --> packages/document-types/src/common_test.rs:26:8
   |
26 | pub fn roundtrip_json(json: &Value) -> Value {
   |        ^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
 ```