### PR TITLE
OBEE-8 user db: add nullable inference_{key,hash} to user's table, create migration

### DIFF
--- a/packages/migrator/src/migrations/m20260714000000_add_inference_keys.rs
+++ b/packages/migrator/src/migrations/m20260714000000_add_inference_keys.rs
@@ -1,0 +1,48 @@
+use sqlx::{PgConnection, Postgres};
+use sqlx_migrator::Operation;
+use sqlx_migrator::error::Error;
+use sqlx_migrator::migration;
+use sqlx_migrator::vec_box;
+
+pub(crate) struct AddInferenceKeys;
+
+migration!(
+    Postgres,
+    AddInferenceKeys,
+    "backend",
+    "20260714000000_add_inference_keys",
+    vec_box![],
+    vec_box![MigrationOperation]
+);
+
+struct MigrationOperation;
+#[async_trait::async_trait]
+impl Operation<Postgres> for MigrationOperation {
+    async fn up(&self, conn: &mut PgConnection) -> Result<(), Error> {
+        sqlx::query(
+            "
+            ALTER TABLE users
+            ADD COLUMN inference_key TEXT NULL,
+            ADD COLUMN inference_hash TEXT NULL;
+            ",
+        )
+        .execute(conn)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, conn: &mut PgConnection) -> Result<(), Error> {
+        sqlx::query(
+            "
+            ALTER TABLE users
+            DROP COLUMN inference_key,
+            DROP COLUMN inference_hash;
+            ",
+        )
+        .execute(conn)
+        .await?;
+
+        Ok(())
+    }
+}

--- a/packages/migrator/src/migrations/mod.rs
+++ b/packages/migrator/src/migrations/mod.rs
@@ -12,6 +12,7 @@ mod m20251006141026_get_ref_stubs;
 mod m20260124120000_add_user_fk_cascade;
 mod m20260320000000_add_user_state_doc_id;
 mod m20260414000000_snapshot_history;
+mod m20260714000000_add_inference_keys;
 
 pub fn migrations() -> Vec<Box<dyn Migration<Postgres>>> {
     vec_box![
@@ -25,5 +26,6 @@ pub fn migrations() -> Vec<Box<dyn Migration<Postgres>>> {
         m20260124120000_add_user_fk_cascade::AddUserFkCascade,
         m20260320000000_add_user_state_doc_id::AddUserStateDocId,
         m20260414000000_snapshot_history::SnapshotHistory,
+        m20260714000000_add_inference_keys::AddInferenceKeys,
     ]
 }


### PR DESCRIPTION
Part of the [LLM Integration](https://app.notion.com/p/toposinstitute/LLM-Integration-38269ce798648055aa78db0eef3c95dc) outcome, this is the first of ~5 PR's which adds the columns to the db that will see future use.

Forthcoming changes:
* [part two](https://app.notion.com/p/toposinstitute/LLM-Integration-2-5-Backend-service-39d69ce7986480a8b685d87e1aa8335a?source=copy_link)
* [part three](https://app.notion.com/p/toposinstitute/LLM-Integration-3-5-secret-addition-39d69ce7986480cd8865defaf0d547ec?source=copy_link)
* [part four](https://app.notion.com/p/toposinstitute/LLM-Integration-4-5-front-end-token-acquisition-39d69ce79864805d8b4fd9a7ac4a8b27?source=copy_link)
* [part five](https://app.notion.com/p/toposinstitute/LLM-Integration-5-5-FE-inferenc-39d69ce7986480fcad11d1c55129e60e?source=copy_link)