### PR TITLE
Correct behaviour for maximum path length in submodel search

### DIFF
--- a/packages/frontend/src/stdlib/analyses.tsx
+++ b/packages/frontend/src/stdlib/analyses.tsx
@@ -288,6 +288,7 @@ export function motifFinding(
         component: (props) => <SubmodelGraphs title={name} findSubmodels={findMotifs} {...props} />,
         initialContent: () => ({
             activeIndex: 0,
+            enableMaxPathLength: true,
             maxPathLength: 5,
         }),
     };

--- a/packages/frontend/src/stdlib/analyses/checker_types.ts
+++ b/packages/frontend/src/stdlib/analyses/checker_types.ts
@@ -15,10 +15,10 @@ export type MotifFindingAnalysisContent = {
     activeIndex: number;
 
     /** Whether or not to search up to a maximum length of paths. */
-    enableMaxPathLength: boolean;
+    enableMaxPathLength?: boolean;
 
     /** Maximum length of paths used in morphism search. */
-    maxPathLength: number | null;
+    maxPathLength?: number | null;
 };
 
 export type ReachabilityChecker = (model: DblModel, data: ReachabilityProblemData) => boolean;

--- a/packages/frontend/src/stdlib/analyses/checker_types.ts
+++ b/packages/frontend/src/stdlib/analyses/checker_types.ts
@@ -14,8 +14,11 @@ export type MotifFindingAnalysisContent = {
     /** Index of active submodel. */
     activeIndex: number;
 
+    /** Whether or not to search up to a maximum length of paths. */
+    enableMaxPathLength: boolean;
+
     /** Maximum length of paths used in morphism search. */
-    maxPathLength?: number | null;
+    maxPathLength: number | null;
 };
 
 export type ReachabilityChecker = (model: DblModel, data: ReachabilityProblemData) => boolean;

--- a/packages/frontend/src/stdlib/analyses/submodel_graphs.tsx
+++ b/packages/frontend/src/stdlib/analyses/submodel_graphs.tsx
@@ -107,15 +107,14 @@ export default function SubmodelGraphs(
                                 min="0"
                                 label="Maximum length of path"
                                 value={props.content.maxPathLength ?? ""}
-                                onChange={(evt) =>
-                                    props.changeContent((content) => {
-                                        content.maxPathLength =
-                                            evt.currentTarget.valueAsNumber > 0 &&
-                                            Number.isInteger(evt.currentTarget.valueAsNumber)
-                                                ? evt.currentTarget.valueAsNumber
-                                                : null;
-                                    })
-                                }
+                                onChange={(evt) => {
+                                    const value = evt.currentTarget.valueAsNumber;
+                                    if (value > 0 && Number.isInteger(value)) {
+                                        props.changeContent((content) => {
+                                            content.maxPathLength = value;
+                                        });
+                                    }
+                                }}
                             />
                         </Show>
                     </FormGroup>

--- a/packages/frontend/src/stdlib/analyses/submodel_graphs.tsx
+++ b/packages/frontend/src/stdlib/analyses/submodel_graphs.tsx
@@ -11,10 +11,6 @@ import { modelToGraph } from "./model_graph";
 
 import "./submodel_graphs.css";
 
-function isNumber(num: number | null | undefined): num is number {
-    return (num as number) !== undefined;
-}
-
 /** Find submodels of a model and visualize them as graphs. */
 export default function SubmodelGraphs(
     props: {
@@ -27,7 +23,7 @@ export default function SubmodelGraphs(
         // If `enableMaxPathLength` has not been set, then set it to be true iff `maxPathLength`
         // already has a (numerical) value.
         if (props.content.enableMaxPathLength === undefined) {
-            if (isNumber(props.content.maxPathLength)) {
+            if (props.content.maxPathLength != null) {
                 props.content.enableMaxPathLength = true;
             } else {
                 props.content.enableMaxPathLength = false;
@@ -44,7 +40,7 @@ export default function SubmodelGraphs(
             }
             return props.findSubmodels(validated.model, {
                 maxPathLength:
-                    enableMaxPathLength() && isNumber(props.content.maxPathLength)
+                    enableMaxPathLength() && props.content.maxPathLength != null
                         ? props.content.maxPathLength
                         : null,
             });

--- a/packages/frontend/src/stdlib/analyses/submodel_graphs.tsx
+++ b/packages/frontend/src/stdlib/analyses/submodel_graphs.tsx
@@ -25,7 +25,9 @@ export default function SubmodelGraphs(
                 return [];
             }
             return props.findSubmodels(validated.model, {
-                maxPathLength: props.content.maxPathLength ?? null,
+                maxPathLength: props.content.enableMaxPathLength
+                    ? props.content.maxPathLength
+                    : null,
             });
         },
         [],
@@ -80,11 +82,11 @@ export default function SubmodelGraphs(
                             checked={props.content.maxPathLength != null}
                             onChange={(evt) =>
                                 props.changeContent((content) => {
-                                    content.maxPathLength = evt.currentTarget.checked ? 1 : null;
+                                    content.enableMaxPathLength = evt.currentTarget.checked;
                                 })
                             }
                         />
-                        <Show when={props.content.maxPathLength != null}>
+                        <Show when={props.content.enableMaxPathLength}>
                             <InputField
                                 type="number"
                                 min="0"
@@ -92,7 +94,10 @@ export default function SubmodelGraphs(
                                 value={props.content.maxPathLength ?? ""}
                                 onChange={(evt) =>
                                     props.changeContent((content) => {
-                                        content.maxPathLength = evt.currentTarget.valueAsNumber;
+                                        content.maxPathLength =
+                                            evt.currentTarget.valueAsNumber > 0
+                                                ? evt.currentTarget.valueAsNumber
+                                                : null;
                                     })
                                 }
                             />

--- a/packages/frontend/src/stdlib/analyses/submodel_graphs.tsx
+++ b/packages/frontend/src/stdlib/analyses/submodel_graphs.tsx
@@ -11,6 +11,10 @@ import { modelToGraph } from "./model_graph";
 
 import "./submodel_graphs.css";
 
+function isNumber(length: number | null): length is number {
+    return (length as number) !== undefined;
+}
+
 /** Find submodels of a model and visualize them as graphs. */
 export default function SubmodelGraphs(
     props: {
@@ -18,6 +22,19 @@ export default function SubmodelGraphs(
         title?: string;
     } & ModelAnalysisProps<MotifFindingAnalysisContent>,
 ) {
+    // For compatibility with notebooks created before the `enableMaxPathLength` field was introduced.
+    function enableMaxPathLength(): boolean {
+        if (props.content.enableMaxPathLength === undefined) {
+            if (isNumber(props.content.maxPathLength)) {
+                return true;
+            } else {
+                return false;
+            }
+        } else {
+            return props.content.enableMaxPathLength;
+        }
+    }
+
     const submodels = createMemo<MotifOccurrence[]>(
         () => {
             const validated = props.liveModel.validatedModel();
@@ -25,9 +42,7 @@ export default function SubmodelGraphs(
                 return [];
             }
             return props.findSubmodels(validated.model, {
-                maxPathLength: props.content.enableMaxPathLength
-                    ? props.content.maxPathLength
-                    : null,
+                maxPathLength: enableMaxPathLength() ? props.content.maxPathLength : null,
             });
         },
         [],
@@ -79,14 +94,14 @@ export default function SubmodelGraphs(
                         <InputField
                             type="checkbox"
                             label="Limit length of paths"
-                            checked={props.content.maxPathLength != null}
+                            checked={enableMaxPathLength()}
                             onChange={(evt) =>
                                 props.changeContent((content) => {
                                     content.enableMaxPathLength = evt.currentTarget.checked;
                                 })
                             }
                         />
-                        <Show when={props.content.enableMaxPathLength}>
+                        <Show when={enableMaxPathLength()}>
                             <InputField
                                 type="number"
                                 min="0"
@@ -95,7 +110,8 @@ export default function SubmodelGraphs(
                                 onChange={(evt) =>
                                     props.changeContent((content) => {
                                         content.maxPathLength =
-                                            evt.currentTarget.valueAsNumber > 0
+                                            evt.currentTarget.valueAsNumber > 0 &&
+                                            Number.isInteger(evt.currentTarget.valueAsNumber)
                                                 ? evt.currentTarget.valueAsNumber
                                                 : null;
                                     })

--- a/packages/frontend/src/stdlib/analyses/submodel_graphs.tsx
+++ b/packages/frontend/src/stdlib/analyses/submodel_graphs.tsx
@@ -18,16 +18,13 @@ export default function SubmodelGraphs(
         title?: string;
     } & ModelAnalysisProps<MotifFindingAnalysisContent>,
 ) {
-    // For compatibility with notebooks created before the `enableMaxPathLength` field was introduced.
-    const enableMaxPathLength = () => {
-        // If `enableMaxPathLength` has not been set, then set it to be true iff `maxPathLength`
-        // already has a (numerical) value.
-        if (props.content.enableMaxPathLength === undefined) {
-            if (props.content.maxPathLength != null) {
-                props.content.enableMaxPathLength = true;
-            } else {
-                props.content.enableMaxPathLength = false;
-            }
+    // For compatibility with notebooks created before the `enableMaxPathLength`
+    // field was introduced.
+    const enableMaxPathLength = (): boolean => {
+        // If `enableMaxPathLength` has not been set, then take it to be true
+        // iff `maxPathLength` already has a (numerical) value.
+        if (props.content.enableMaxPathLength == null) {
+            return props.content.maxPathLength != null;
         }
         return props.content.enableMaxPathLength;
     };

--- a/packages/frontend/src/stdlib/analyses/submodel_graphs.tsx
+++ b/packages/frontend/src/stdlib/analyses/submodel_graphs.tsx
@@ -11,8 +11,8 @@ import { modelToGraph } from "./model_graph";
 
 import "./submodel_graphs.css";
 
-function isNumber(length: number | null): length is number {
-    return (length as number) !== undefined;
+function isNumber(num: number | null | undefined): num is number {
+    return (num as number) !== undefined;
 }
 
 /** Find submodels of a model and visualize them as graphs. */
@@ -23,17 +23,18 @@ export default function SubmodelGraphs(
     } & ModelAnalysisProps<MotifFindingAnalysisContent>,
 ) {
     // For compatibility with notebooks created before the `enableMaxPathLength` field was introduced.
-    function enableMaxPathLength(): boolean {
+    const enableMaxPathLength = () => {
+        // If `enableMaxPathLength` has not been set, then set it to be true iff `maxPathLength`
+        // already has a (numerical) value.
         if (props.content.enableMaxPathLength === undefined) {
             if (isNumber(props.content.maxPathLength)) {
-                return true;
+                props.content.enableMaxPathLength = true;
             } else {
-                return false;
+                props.content.enableMaxPathLength = false;
             }
-        } else {
-            return props.content.enableMaxPathLength;
         }
-    }
+        return props.content.enableMaxPathLength;
+    };
 
     const submodels = createMemo<MotifOccurrence[]>(
         () => {
@@ -42,7 +43,10 @@ export default function SubmodelGraphs(
                 return [];
             }
             return props.findSubmodels(validated.model, {
-                maxPathLength: enableMaxPathLength() ? props.content.maxPathLength : null,
+                maxPathLength:
+                    enableMaxPathLength() && isNumber(props.content.maxPathLength)
+                        ? props.content.maxPathLength
+                        : null,
             });
         },
         [],


### PR DESCRIPTION
Fixes #564 as well as an unreported bug (namely that enabling and then disabling the checkbox didn't actually disable it at all).