### PR TITLE
OBEE-9 inference key management: backend RPC and CLI subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,7 +225,7 @@ dependencies = [
  "rand 0.9.2",
  "rustc-hash",
  "serde",
- "sha2 0.11.0-rc.3",
+ "sha2 0.11.0",
  "smol_str",
  "thiserror 2.0.12",
  "tinyvec",
@@ -284,7 +294,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper 1.10.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -341,7 +351,7 @@ dependencies = [
  "firebase-auth",
  "futures-util",
  "http 1.3.1",
- "hyper 1.6.0",
+ "hyper 1.10.1",
  "jsonrpsee 0.24.9",
  "jsonrpsee-server 0.24.9",
  "migrator",
@@ -355,6 +365,7 @@ dependencies = [
  "sd-notify",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "sqlx",
  "sqlx_migrator",
  "test-strategy",
@@ -366,6 +377,7 @@ dependencies = [
  "tracing-subscriber",
  "ts-rs",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -436,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eb4cdd6cf1b31d671e9efe75c5d1ec614776856cefbe109ca373554a6d514f"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -776,6 +788,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,9 +888,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.9"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b8986f836d4aeb30ccf4c9d3bd562fd716074cfd7fc4a2948359fbd21ed809"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -950,6 +971,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,13 +1065,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.5"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf9423bafb058e4142194330c52273c343f8a5beb7176d052f0e73b17dd35b9"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.11.0",
+ "block-buffer 0.12.1",
  "const-oid 0.10.2",
- "crypto-common 0.2.0-rc.9",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1645,9 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1712,6 +1751,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1832,9 +1877,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.5"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f471e0a81b2f90ffc0cb2f951ae04da57de8baa46fa99112b062a5173a5088d0"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
@@ -1865,14 +1910,15 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
- "h2 0.4.10",
+ "futures-core",
+ "h2 0.4.15",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -1905,7 +1951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.3.1",
- "hyper 1.6.0",
+ "hyper 1.10.1",
  "hyper-util",
  "rustls 0.23.28",
  "rustls-pki-types",
@@ -1927,7 +1973,7 @@ dependencies = [
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
- "hyper 1.6.0",
+ "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -2315,7 +2361,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper 1.10.1",
  "hyper-util",
  "jsonrpsee-core 0.24.9",
  "jsonrpsee-types 0.24.9",
@@ -2342,7 +2388,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper 1.10.1",
  "hyper-util",
  "jsonrpsee-core 0.25.1",
  "jsonrpsee-types 0.25.1",
@@ -2844,6 +2890,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "ode_solvers"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3154,7 +3210,7 @@ dependencies = [
  "derive_more",
  "futures",
  "http 1.3.1",
- "hyper 1.6.0",
+ "hyper 1.10.1",
  "jsonrpsee 0.25.1",
  "lazy_static",
  "linkme",
@@ -3508,11 +3564,11 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
- "h2 0.4.10",
+ "h2 0.4.15",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper 1.10.1",
  "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
@@ -3982,7 +4038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -3993,19 +4049,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d43dc0354d88b791216bb5c1bfbb60c0814460cc653ae0ebd71f286d0bd927"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest 0.11.0-rc.5",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5056,9 +5112,9 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unarray"
@@ -5836,6 +5892,29 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.3.1",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/packages/backend/.sqlx/query-13b875477ba4e0eb7cf5a310e8a07cf103c8d4af7cc296ea251742e0fe0c4401.json
+++ b/packages/backend/.sqlx/query-13b875477ba4e0eb7cf5a310e8a07cf103c8d4af7cc296ea251742e0fe0c4401.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT inference_key FROM users WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "inference_key",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "13b875477ba4e0eb7cf5a310e8a07cf103c8d4af7cc296ea251742e0fe0c4401"
+}

--- a/packages/backend/.sqlx/query-290e00be0039134dd57ad22719a3b29e63a7e931cc897a62b24fcd407772d346.json
+++ b/packages/backend/.sqlx/query-290e00be0039134dd57ad22719a3b29e63a7e931cc897a62b24fcd407772d346.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE users SET inference_key = $2, inference_hash = $3 WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "290e00be0039134dd57ad22719a3b29e63a7e931cc897a62b24fcd407772d346"
+}

--- a/packages/backend/.sqlx/query-4f429b999cd8a710ea8a9856fdf3cd51d96cfc2abc6426aeed54300ada0d3f42.json
+++ b/packages/backend/.sqlx/query-4f429b999cd8a710ea8a9856fdf3cd51d96cfc2abc6426aeed54300ada0d3f42.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, inference_hash FROM users WHERE id = $1 OR username = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "inference_hash",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "4f429b999cd8a710ea8a9856fdf3cd51d96cfc2abc6426aeed54300ada0d3f42"
+}

--- a/packages/backend/.sqlx/query-bde1204507aa9fec004395f2fc028985e56cc48490795d881282b5b00f016681.json
+++ b/packages/backend/.sqlx/query-bde1204507aa9fec004395f2fc028985e56cc48490795d881282b5b00f016681.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE users SET inference_key = NULL, inference_hash = NULL WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "bde1204507aa9fec004395f2fc028985e56cc48490795d881282b5b00f016681"
+}

--- a/packages/backend/Cargo.toml
+++ b/packages/backend/Cargo.toml
@@ -58,9 +58,13 @@ proptest = { version = "1.9.0", optional = true }
 proptest-arbitrary-interop = { version = "0.1", optional = true }
 test-strategy = { version = "0.4", optional = true }
 ts-rs = "11.1.0"
+sha2 = "0.11.0"
 
 [lints.rust]
 missing_docs = "warn"
 
 [lints.clippy]
 doc_paragraphs_missing_punctuation = "warn"
+
+[dev-dependencies]
+wiremock = "0.6.5"

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -18,7 +18,7 @@ You can find the auto-generated documentation for this Rust crate at [next.catco
     ```
 
     - Directly in the shell:
-  
+
     ```sh
     createdb -h localhost -p 5432 -U USER_NAME catcolab
     ```
@@ -126,5 +126,4 @@ To generate a timestamp for the migration filename, run:
 date -u +"%Y%m%d%H%M%S"
 ```
 
-Don't forget to run `cargo sqlx prepare` in `packages/backend` after making schema changes!
-
+Don't forget to run `cargo sqlx prepare -- --all-targets --features integration-tests,property-tests` in `packages/backend` after making schema changes!

--- a/packages/backend/src/app.rs
+++ b/packages/backend/src/app.rs
@@ -51,6 +51,15 @@ pub struct AppState {
 
     /// Base URL for the Julia compute service, if configured.
     pub julia_url: Option<String>,
+
+    /// OpenRouter provisioning key for minting per-user inference keys.
+    /// `None` when `OPENROUTER_PROVISIONING_KEY` is not set, in which case
+    /// inference-related operations return `AppError::InferenceUnavailable`.
+    pub openrouter_provisioning_key: Option<String>,
+
+    /// Base URL for the OpenRouter key-management API. In production this is
+    /// the public endpoint; tests override it to point at a mock server.
+    pub openrouter_base_url: String,
 }
 
 /// Context available to RPC procedures.
@@ -102,4 +111,12 @@ pub enum AppError {
     /// document ref.
     #[error("Not authorized to access ref: {0}")]
     Forbidden(Uuid),
+
+    /// Error from the OpenRouter key-management API.
+    #[error("OpenRouter error: {0}")]
+    OpenRouter(String),
+
+    /// The inference service is not configured.
+    #[error("Inference service is unavailable")]
+    InferenceUnavailable,
 }

--- a/packages/backend/src/inference.rs
+++ b/packages/backend/src/inference.rs
@@ -1,0 +1,210 @@
+//! OpenRouter inference key management.
+//!
+//! Creates OpenRouter child keys per user and persists them in the `users`
+//! table. The stable key `hash` is stored alongside the secret so that keys can
+//! be invalidated via the OpenRouter API, `DELETE /keys/{hash}`. We leverage
+//! the OpenRouter API to put credit cap and refresh windows on the keys.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::app::{AppCtx, AppError};
+
+/// Spending limit per user key, in USD.
+const KEY_LIMIT: f64 = 5.0;
+/// Reset period for the spending limit.
+const KEY_LIMIT_RESET: &str = "daily";
+
+/// The base URL for the OpenRouter key-management API.
+pub const OPENROUTER_API_URL: &str = "https://openrouter.ai/api/v1";
+
+/// Request body for `POST /keys` (create a child key).
+#[derive(Serialize)]
+struct CreateKeyRequest {
+    name: String,
+    limit: f64,
+    limit_reset: String,
+}
+
+/// The `data` object nested inside a `POST /keys` response.
+#[derive(Deserialize)]
+struct CreateKeyData {
+    hash: String,
+}
+
+/// Response from `POST /keys`.
+#[derive(Deserialize)]
+struct CreateKeyResponse {
+    key: String,
+    data: CreateKeyData,
+}
+
+/// Return the user's existing inference key, or create a new one.
+pub async fn get_inference_key(ctx: &AppCtx) -> Result<String, AppError> {
+    let Some(user) = &ctx.user else {
+        return Err(AppError::Unauthorized);
+    };
+
+    let provisioning_key = ctx
+        .state
+        .openrouter_provisioning_key
+        .as_ref()
+        .ok_or(AppError::InferenceUnavailable)?;
+
+    get_or_create_key(
+        &ctx.state.db,
+        &ctx.state.http_client,
+        &ctx.state.openrouter_base_url,
+        provisioning_key,
+        &user.user_id,
+    )
+    .await
+}
+
+/// Invalidate a user's inference key, either by Firebase UID or username.
+pub async fn invalidate_inference_key(
+    db: &sqlx::PgPool,
+    http_client: &reqwest::Client,
+    base_url: &str,
+    provisioning_key: &str,
+    identifier: &str,
+) -> Result<(), AppError> {
+    let row = sqlx::query!(
+        "SELECT id, inference_hash FROM users WHERE id = $1 OR username = $1",
+        identifier,
+    )
+    .fetch_optional(db)
+    .await?;
+
+    let Some(row) = row else {
+        return Ok(());
+    };
+
+    let Some(hash) = row.inference_hash else {
+        return Ok(());
+    };
+
+    openrouter_delete_key(http_client, provisioning_key, base_url, &hash).await?;
+
+    sqlx::query!(
+        "UPDATE users SET inference_key = NULL, inference_hash = NULL WHERE id = $1",
+        row.id,
+    )
+    .execute(db)
+    .await?;
+
+    Ok(())
+}
+
+/// Create a new child key via `POST /keys`.
+async fn get_or_create_key(
+    db: &sqlx::PgPool,
+    http_client: &reqwest::Client,
+    base_url: &str,
+    provisioning_key: &str,
+    user_id: &str,
+) -> Result<String, AppError> {
+    let existing_key: Option<String> =
+        sqlx::query_scalar!("SELECT inference_key FROM users WHERE id = $1", user_id,)
+            .fetch_one(db)
+            .await?;
+
+    if let Some(key) = existing_key {
+        return Ok(key);
+    }
+
+    let response = openrouter_create_key(
+        http_client,
+        provisioning_key,
+        base_url,
+        &key_name(user_id, provisioning_key),
+    )
+    .await?;
+
+    sqlx::query!(
+        "UPDATE users SET inference_key = $2, inference_hash = $3 WHERE id = $1",
+        user_id,
+        response.key,
+        response.data.hash,
+    )
+    .execute(db)
+    .await?;
+
+    Ok(response.key)
+}
+
+/// Create a key using OpenRouter's API.
+async fn openrouter_create_key(
+    client: &reqwest::Client,
+    provisioning_key: &str,
+    base_url: &str,
+    name: &str,
+) -> Result<CreateKeyResponse, AppError> {
+    let request = CreateKeyRequest {
+        name: name.to_string(),
+        limit: KEY_LIMIT,
+        limit_reset: KEY_LIMIT_RESET.to_string(),
+    };
+
+    let body = serde_json::to_vec(&request)
+        .map_err(|e| AppError::OpenRouter(format!("failed to serialize request: {e}")))?;
+
+    let response = client
+        .post(format!("{base_url}/keys"))
+        .bearer_auth(provisioning_key)
+        .header("Content-Type", "application/json")
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| AppError::OpenRouter(e.to_string()))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(AppError::OpenRouter(format!("OpenRouter returned {status}: {body}")));
+    }
+
+    let bytes = response.bytes().await.map_err(|e| AppError::OpenRouter(e.to_string()))?;
+
+    serde_json::from_slice::<CreateKeyResponse>(&bytes)
+        .map_err(|e| AppError::OpenRouter(format!("failed to parse key response: {e}")))
+}
+
+/// Delete a child key via OpenRouter's API.
+///
+/// A `404` response is treated as success: the key is already gone (e.g.
+/// deleted out-of-band), which is the desired end state, so the caller may
+/// still clear its local reference.
+async fn openrouter_delete_key(
+    client: &reqwest::Client,
+    provisioning_key: &str,
+    base_url: &str,
+    hash: &str,
+) -> Result<(), AppError> {
+    let response = client
+        .delete(format!("{base_url}/keys/{hash}"))
+        .bearer_auth(provisioning_key)
+        .send()
+        .await
+        .map_err(|e| AppError::OpenRouter(e.to_string()))?;
+
+    let status = response.status();
+
+    if status.is_success() || status.as_u16() == 404 {
+        return Ok(());
+    }
+
+    let body = response.text().await.unwrap_or_default();
+    Err(AppError::OpenRouter(format!("OpenRouter returned {status}: {body}")))
+}
+
+/// Turn a FireBase user id into a stable name that does not leak details
+/// externally.
+fn key_name(user_id: &str, provisioning_key: &str) -> String {
+    let hash = Sha256::new()
+        .chain_update(user_id.as_bytes())
+        .chain_update(provisioning_key.as_bytes())
+        .finalize();
+    let hex: String = hash[..8].iter().map(|b| format!("{b:02x}")).collect();
+    format!("catcolab:{hex}")
+}

--- a/packages/backend/src/lib.rs
+++ b/packages/backend/src/lib.rs
@@ -18,6 +18,9 @@ pub mod document;
 /// RPC service for the backend.
 pub mod rpc;
 
+/// OpenRouter inference key management.
+pub mod inference;
+
 /// Storage backend for Automerge documents.
 pub mod storage;
 

--- a/packages/backend/src/main.rs
+++ b/packages/backend/src/main.rs
@@ -20,7 +20,7 @@ use tower_http::cors::CorsLayer;
 use tracing::{error, info};
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 
-use backend::{app, auth, rpc, storage, user_state};
+use backend::{app, auth, inference, rpc, storage, user_state};
 
 /// Port for the web server providing the RPC API.
 fn web_port() -> String {
@@ -43,6 +43,11 @@ enum Command {
     Serve,
     /// Generate TypeScript bindings for the RPC API.
     GenerateBindings,
+    /// Invalidate inference keys for the given users.
+    InvalidateInferenceKeys {
+        /// User identifiers (usernames or Firebase UIDs).
+        identifiers: Vec<String>,
+    },
 }
 
 #[tokio::main]
@@ -102,6 +107,34 @@ async fn main() {
 
         Command::GenerateBindings => unreachable!(),
 
+        Command::InvalidateInferenceKeys { identifiers } => {
+            let http_client = reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(120))
+                .build()
+                .expect("Failed to build HTTP client");
+
+            let provisioning_key =
+                dotenvy::var("OPENROUTER_PROVISIONING_KEY").ok().unwrap_or_else(|| {
+                    error!("OPENROUTER_PROVISIONING_KEY not set; cannot invalidate keys");
+                    std::process::exit(1);
+                });
+
+            for identifier in &identifiers {
+                match inference::invalidate_inference_key(
+                    &db,
+                    &http_client,
+                    inference::OPENROUTER_API_URL,
+                    &provisioning_key,
+                    identifier,
+                )
+                .await
+                {
+                    Ok(()) => info!("Invalidated inference key for: {identifier}"),
+                    Err(e) => error!("Failed to invalidate inference key for {identifier}: {e}"),
+                }
+            }
+        }
+
         Command::Serve => {
             info!("Applying database migrations...");
             let mut conn = db.acquire().await.expect("Failed to acquire DB connection");
@@ -140,6 +173,8 @@ async fn main() {
                 initialized_user_states: Arc::new(RwLock::new(HashMap::new())),
                 http_client,
                 julia_url,
+                openrouter_provisioning_key: dotenvy::var("OPENROUTER_PROVISIONING_KEY").ok(),
+                openrouter_base_url: inference::OPENROUTER_API_URL.to_string(),
             };
 
             // We need to wrap FirebaseAuth in an Arc because if it's ever dropped the process which updates it's

--- a/packages/backend/src/rpc.rs
+++ b/packages/backend/src/rpc.rs
@@ -10,7 +10,7 @@ use super::app::{AppCtx, AppError, AppState, RefMsg};
 use super::auth::{NewPermissions, PermissionLevel, Permissions};
 use super::ref_actor::{ensure_ref_actor, send_to_actor};
 use super::user_state::get_or_create_user_state_doc;
-use super::{auth, document as doc, user};
+use super::{auth, document as doc, inference, user};
 
 /// Create router for RPC API.
 pub fn router() -> Router<AppState> {
@@ -29,6 +29,7 @@ pub fn router() -> Router<AppState> {
         .handler(get_active_user_profile)
         .handler(set_active_user_profile)
         .handler(get_user_state_doc_id)
+        .handler(get_inference_key)
 }
 
 #[handler(mutation)]
@@ -164,6 +165,11 @@ async fn get_active_user_profile(ctx: AppCtx) -> RpcResult<user::UserProfile> {
     user::get_active_user_profile(ctx).await.into()
 }
 
+#[handler(query)]
+async fn get_inference_key(ctx: AppCtx) -> RpcResult<String> {
+    inference::get_inference_key(&ctx).await.into()
+}
+
 #[handler(mutation)]
 async fn set_active_user_profile(ctx: AppCtx, user: user::UserProfile) -> RpcResult<()> {
     user::set_active_user_profile(ctx, user).await.into()
@@ -196,6 +202,8 @@ impl<T> From<AppError> for RpcResult<T> {
             AppError::Unauthorized => StatusCode::UNAUTHORIZED,
             AppError::Forbidden(_) => StatusCode::FORBIDDEN,
             AppError::NotFound(_) | AppError::Db(sqlx::Error::RowNotFound) => StatusCode::NOT_FOUND,
+            AppError::OpenRouter(_) => StatusCode::BAD_GATEWAY,
+            AppError::InferenceUnavailable => StatusCode::SERVICE_UNAVAILABLE,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
         let message = error.to_string();

--- a/packages/backend/tests/common/test_utils.rs
+++ b/packages/backend/tests/common/test_utils.rs
@@ -49,6 +49,8 @@ pub async fn create_test_app_state(pool: PgPool) -> AppState {
         initialized_user_states: Arc::new(RwLock::new(HashMap::new())),
         http_client: reqwest::Client::new(),
         julia_url: None,
+        openrouter_provisioning_key: None,
+        openrouter_base_url: backend::inference::OPENROUTER_API_URL.to_string(),
     }
 }
 
@@ -69,6 +71,8 @@ pub fn create_test_firebase_user(user_id: &str) -> FirebaseUser {
     .expect("Failed to create test FirebaseUser")
 }
 
+// This function is not used in all consuming binaries of test_utils.
+#[allow(dead_code)]
 pub fn create_test_document_content(name: &str) -> serde_json::Value {
     json!({
         "version": "1",

--- a/packages/backend/tests/inference_tests.rs
+++ b/packages/backend/tests/inference_tests.rs
@@ -1,0 +1,289 @@
+//! Integration tests for OpenRouter inference key management.
+//!
+//!
+//! These tests require a running PostgreSQL database, and mock real response
+//! transcripts recorded from OpenRouter.
+
+#[cfg(feature = "integration-tests")]
+mod common;
+
+#[cfg(feature = "integration-tests")]
+mod integration_tests {
+    use crate::common::test_utils::{
+        create_test_app_state, create_test_firebase_user, ensure_user_exists, run_migrations,
+    };
+    use backend::app::{AppCtx, AppError, AppState};
+    use backend::inference;
+    use sqlx::PgPool;
+    use uuid::Uuid;
+    use wiremock::matchers::{body_partial_json, header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// A censored OpenRouter plaintext key (real shape: `sk-or-v1-...`).
+    const FAKE_KEY: &str = "sk-or-v1-testkeyredacted0000000000000000000000000000000000000000";
+    /// A censored OpenRouter key hash (real shape: 64-char hex).
+    const FAKE_HASH: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    /// The provisioning key the tests configure on `AppState`; the wiremock
+    /// matchers assert it is sent as a bearer token.
+    const PROVISIONING_KEY: &str = "test-provisioning-key";
+
+    /// Build a `POST /keys` 201 response body matching the real shape.
+    fn create_key_response_body() -> serde_json::Value {
+        serde_json::json!({
+            "data": {
+                "hash": FAKE_HASH,
+                "name": "catcolab:RECORDING",
+                "label": "sk-or-v1-test...e47",
+                "disabled": false,
+                "limit": 5,
+                "limit_remaining": 5,
+                "limit_reset": "daily",
+                "include_byok_in_limit": false,
+                "usage": 0,
+                "usage_daily": 0,
+                "usage_weekly": 0,
+                "usage_monthly": 0,
+                "byok_usage": 0,
+                "byok_usage_daily": 0,
+                "byok_usage_weekly": 0,
+                "byok_usage_monthly": 0,
+                "created_at": "2026-07-15T13:35:18.151Z",
+                "updated_at": null,
+                "expires_at": null,
+                "creator_user_id": "user_REDACTED",
+                "workspace_id": "REDACTED"
+            },
+            "key": FAKE_KEY
+        })
+    }
+
+    /// The `DELETE /keys/{hash}` 200 body recorded from OpenRouter.
+    fn delete_ok_body() -> serde_json::Value {
+        serde_json::json!({"deleted": true})
+    }
+
+    /// The `DELETE /keys/{hash}` 404 body recorded from OpenRouter.
+    fn delete_not_found_body() -> serde_json::Value {
+        serde_json::json!({"error": {"message": "API key not found", "code": 404}})
+    }
+
+    /// Mount a `POST /keys` mock returning a 201 with the censored create
+    /// response, asserting it is called exactly `n` times.
+    async fn mount_create_key(server: &MockServer, n: u64) {
+        Mock::given(method("POST"))
+            .and(path("/keys"))
+            .and(header("authorization", format!("Bearer {PROVISIONING_KEY}")))
+            .and(body_partial_json(serde_json::json!({"limit": 5.0, "limit_reset": "daily"})))
+            .respond_with(ResponseTemplate::new(201).set_body_json(create_key_response_body()))
+            .expect(n)
+            .mount(server)
+            .await;
+    }
+
+    /// Mount a `DELETE /keys/{hash}` mock returning a 200, asserting `n` calls.
+    async fn mount_delete_ok(server: &MockServer, n: u64) {
+        Mock::given(method("DELETE"))
+            .and(path(format!("/keys/{FAKE_HASH}")))
+            .and(header("authorization", format!("Bearer {PROVISIONING_KEY}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(delete_ok_body()))
+            .expect(n)
+            .mount(server)
+            .await;
+    }
+
+    /// Build an `AppState` whose OpenRouter client is wired to the mock at
+    /// `server.uri()`.
+    async fn state_for(server: &MockServer, pool: PgPool) -> AppState {
+        let mut state = create_test_app_state(pool).await;
+        state.openrouter_provisioning_key = Some(PROVISIONING_KEY.to_string());
+        state.openrouter_base_url = server.uri();
+        state
+    }
+
+    /// Seed a `users` row with an existing inference key/hash, as if a key had
+    /// already been created.
+    async fn seed_user_with_key(pool: &PgPool, user_id: &str) {
+        ensure_user_exists(pool, user_id).await.expect("Failed to create user");
+        sqlx::query("UPDATE users SET inference_key = $2, inference_hash = $3 WHERE id = $1")
+            .bind(user_id)
+            .bind(FAKE_KEY)
+            .bind(FAKE_HASH)
+            .execute(pool)
+            .await
+            .expect("Failed to seed inference key");
+    }
+
+    /// Read the persisted `(inference_key, inference_hash)` pair for a user.
+    async fn persisted_key(pool: &PgPool, user_id: &str) -> (Option<String>, Option<String>) {
+        sqlx::query_as("SELECT inference_key, inference_hash FROM users WHERE id = $1")
+            .bind(user_id)
+            .fetch_one(pool)
+            .await
+            .expect("Failed to read inference key")
+    }
+
+    /// A cached key is returned without contacting OpenRouter.
+    #[sqlx::test]
+    async fn get_inference_key_returns_cached_without_calling_openrouter(
+        pool: PgPool,
+    ) -> sqlx::Result<()> {
+        run_migrations(&pool).await?;
+
+        let server = MockServer::start().await;
+        let state = state_for(&server, pool.clone()).await;
+
+        let user_id = format!("test_user_{}", Uuid::now_v7());
+        seed_user_with_key(&pool, &user_id).await;
+
+        let ctx = AppCtx {
+            state: state.clone(),
+            user: Some(create_test_firebase_user(&user_id)),
+        };
+
+        let key = inference::get_inference_key(&ctx).await.expect("cached key should be returned");
+        assert_eq!(key, FAKE_KEY);
+
+        // No OpenRouter request should have been made.
+        assert!(
+            server.received_requests().await.unwrap().is_empty(),
+            "expected no OpenRouter calls for a cached key"
+        );
+
+        Ok(())
+    }
+
+    /// A missing key is created, persisted, and returned.
+    #[sqlx::test]
+    async fn get_inference_key_mints_and_persists(pool: PgPool) -> sqlx::Result<()> {
+        run_migrations(&pool).await?;
+
+        let server = MockServer::start().await;
+        mount_create_key(&server, 1).await;
+        let state = state_for(&server, pool.clone()).await;
+
+        let user_id = format!("test_user_{}", Uuid::now_v7());
+        ensure_user_exists(&pool, &user_id).await.expect("Failed to create user");
+
+        let ctx = AppCtx {
+            state: state.clone(),
+            user: Some(create_test_firebase_user(&user_id)),
+        };
+
+        let key = inference::get_inference_key(&ctx).await.expect("key should be minted");
+        assert_eq!(key, FAKE_KEY);
+
+        let (persisted_key, persisted_hash) = persisted_key(&pool, &user_id).await;
+        assert_eq!(persisted_key.as_deref(), Some(FAKE_KEY));
+        assert_eq!(persisted_hash.as_deref(), Some(FAKE_HASH));
+
+        server.verify().await;
+        Ok(())
+    }
+
+    /// A failed creation propagates `AppError::OpenRouter` and writes nothing.
+    #[sqlx::test]
+    async fn get_inference_key_propagates_openrouter_error(pool: PgPool) -> sqlx::Result<()> {
+        run_migrations(&pool).await?;
+
+        let server = MockServer::start().await;
+        // Censored `POST /keys` 400 body recorded from OpenRouter (ZodError on a
+        // bad `limit` type).
+        Mock::given(method("POST"))
+            .and(path("/keys"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "success": false,
+                "error": {
+                    "name": "ZodError",
+                    "message": "Invalid input: expected number, received string"
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let state = state_for(&server, pool.clone()).await;
+
+        let user_id = format!("test_user_{}", Uuid::now_v7());
+        ensure_user_exists(&pool, &user_id).await.expect("Failed to create user");
+
+        let ctx = AppCtx {
+            state: state.clone(),
+            user: Some(create_test_firebase_user(&user_id)),
+        };
+
+        let err = inference::get_inference_key(&ctx).await.expect_err("mint should fail");
+        assert!(matches!(err, AppError::OpenRouter(_)), "got {err:?}");
+
+        let (k, h) = persisted_key(&pool, &user_id).await;
+        assert!(k.is_none() && h.is_none(), "no key should be persisted on error");
+
+        server.verify().await;
+        Ok(())
+    }
+
+    /// Invalidating an existing key nulls the DB columns and deletes remotely.
+    #[sqlx::test]
+    async fn invalidate_inference_key_annuls_and_persists(pool: PgPool) -> sqlx::Result<()> {
+        run_migrations(&pool).await?;
+
+        let server = MockServer::start().await;
+        mount_delete_ok(&server, 1).await;
+        let state = state_for(&server, pool.clone()).await;
+
+        let user_id = format!("test_user_{}", Uuid::now_v7());
+        seed_user_with_key(&pool, &user_id).await;
+        assert_eq!(persisted_key(&pool, &user_id).await.0.as_deref(), Some(FAKE_KEY));
+
+        inference::invalidate_inference_key(
+            &pool,
+            &state.http_client,
+            &state.openrouter_base_url,
+            PROVISIONING_KEY,
+            &user_id,
+        )
+        .await
+        .expect("invalidation should succeed");
+
+        let (k, h) = persisted_key(&pool, &user_id).await;
+        assert!(k.is_none() && h.is_none(), "columns should be nulled after invalidation");
+
+        server.verify().await;
+        Ok(())
+    }
+
+    /// Invalidating a key that OpenRouter no longer knows about (404) is a
+    /// success and the local data is still nulled.
+    #[sqlx::test]
+    async fn invalidate_inference_key_handles_already_deleted_key(
+        pool: PgPool,
+    ) -> sqlx::Result<()> {
+        run_migrations(&pool).await?;
+
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(format!("/keys/{FAKE_HASH}")))
+            .respond_with(ResponseTemplate::new(404).set_body_json(delete_not_found_body()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let state = state_for(&server, pool.clone()).await;
+
+        let user_id = format!("test_user_{}", Uuid::now_v7());
+        seed_user_with_key(&pool, &user_id).await;
+
+        inference::invalidate_inference_key(
+            &pool,
+            &state.http_client,
+            &state.openrouter_base_url,
+            PROVISIONING_KEY,
+            &user_id,
+        )
+        .await
+        .expect("404 should be handled gracefully");
+
+        let (k, h) = persisted_key(&pool, &user_id).await;
+        assert!(k.is_none() && h.is_none(), "columns should still be nulled on 404");
+
+        server.verify().await;
+        Ok(())
+    }
+}

--- a/packages/backend/tests/user_state_tests.rs
+++ b/packages/backend/tests/user_state_tests.rs
@@ -1113,6 +1113,8 @@ mod integration_tests {
                 initialized_user_states: Arc::new(RwLock::new(HashMap::new())),
                 http_client: reqwest::Client::new(),
                 julia_url: None,
+                openrouter_provisioning_key: None,
+                openrouter_base_url: backend::inference::OPENROUTER_API_URL.to_string(),
             };
 
             let expected_state =


### PR DESCRIPTION
This change depends on #1338.

If there's a way to have github only show the relative diff between this and #1338  i don't know it, other than making the target of this PR that branch which is not desirable.

(this change is large because of sqlx cache regeneration and Cargo changes for pulling in sha2)

## Design decisions

* OpenRouter is in charge of controlling the spending cap and refresh period for this cap, per key
* We hand users their raw inference keys, this does mean that a malicious user could extract these keys from their browser
  * alternatives here are drastically more complex, and would involve us standing up an inference forwarding service so that we could interpose our own keys
* Keys are valid for eternity
  * alternatives here for key roll-over introduce more front-end complexity to do with session invalidation
* Functionality is gated behind an environment variable `OPENROUTER_PROVISIONING_KEY` which is currently unset, so RPC/cli interaction will fail with appropriate errors.

## Implementation details

Add functionality to populate the columns `inference_{key, hash}` in the `user` table through `get_inference_key` endpoint. This reads the key out from the table if it exists, or otherwise reaches out to OpenRouter to create a new one. The constants controlling this are present in `inference.rs`:

```rust
/// Spending limit per user key, in USD.
const KEY_LIMIT: f64 = 5.0;
/// Reset period for the speding limit.
const KEY_LIMIT_RESET: &str = "daily";
/// The base URL for the OpenRouter key-management API.
pub const OPENROUTER_API_URL: &str = "https://openrouter.ai/api/v1";
```

Additionally add "invalidateinferencekeys" subcommand for the backend binary which takes usernames or firebase UIDs and invalidates the keys on OpenRouter, and nulls the column in the DB.

## Tests

This change introduces mock tests using `wiremock` with (censored) transcripts recorded by me. To run them do `cargo test --features integration-tests --test inference_tests`.