### PR TITLE
Fix JSON serialization of rich text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,6 +527,7 @@ version = "0.1.0"
 dependencies = [
  "automerge",
  "autosurgeon",
+ "getrandom 0.3.3",
  "proptest",
  "serde",
  "serde-wasm-bindgen",

--- a/packages/backend/src/document.rs
+++ b/packages/backend/src/document.rs
@@ -3,7 +3,9 @@
 use crate::app::{AppCtx, AppError, AppState};
 use crate::ref_actor::ensure_ref_actor;
 use crate::user_state_updates::{update_ref_for_users, update_user_state};
-use catcolab_document_types::automerge_json::{hydrate_to_json, populate_automerge_from_json};
+use catcolab_document_types::automerge_json::{
+    hydrate_to_json_with_rich_text, populate_automerge_from_json,
+};
 use catcolab_document_types::automerge_util::copy_doc_at_heads;
 use chrono::{DateTime, Utc};
 use samod::DocumentId;
@@ -144,10 +146,10 @@ pub async fn create_snapshot(state: AppState, ref_id: Uuid) -> Result<(), AppErr
 
     let (heads, doc_content) = doc_handle.with_document(|doc| {
         let heads: Vec<Vec<u8>> = doc.get_heads().iter().map(|h| h.0.to_vec()).collect();
-        let hydrated = doc.hydrate(None);
-        let doc_content = hydrate_to_json(&hydrated);
-        (heads, doc_content)
-    });
+        let doc_content = hydrate_to_json_with_rich_text(doc)
+            .map_err(|e| AppError::Invalid(format!("Failed to serialize document: {:?}", e)))?;
+        Ok::<_, AppError>((heads, doc_content))
+    })?;
 
     sqlx::query(
         "

--- a/packages/document-types/.cargo/config.toml
+++ b/packages/document-types/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/packages/document-types/Cargo.toml
+++ b/packages/document-types/Cargo.toml
@@ -11,12 +11,13 @@ name = "migrate_examples"
 path = "src/bin/migrate_examples.rs"
 
 [features]
-backend = ["dep:automerge", "dep:autosurgeon", "dep:ts-rs"]
+backend = ["dep:autosurgeon", "dep:ts-rs"]
 property-tests = ["backend", "dep:proptest", "dep:test-strategy"]
 
 [dependencies]
-automerge = { version = "0.8.0", optional = true }
+automerge = "0.8.0"
 autosurgeon = { version = "0.11.0", optional = true }
+getrandom = { version = "0.3", features = ["wasm_js"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"
 serde_json = "1.0.143"

--- a/packages/document-types/src/automerge_json.rs
+++ b/packages/document-types/src/automerge_json.rs
@@ -1,16 +1,130 @@
 //! Utilities for converting between JSON values and Automerge documents.
 
 use automerge::hydrate;
+use automerge::marks::{MarkSet, UpdateSpansConfig};
 use automerge::transaction::Transactable;
-use serde_json::Value;
+use automerge::{ScalarValue, Span};
+use serde_json::{Map as JsonMap, Value};
+use std::collections::HashMap;
+use std::sync::Arc;
 
-/// Insert a JSON value into a map property.
-fn insert_value_into_map<'a>(
+/// The JSON property name under which rich-text content is stored in a cell.
+const RICH_TEXT_KEY: &str = "content";
+
+/// Convert a JSON value into an Automerge `ScalarValue` (for marks/attrs).
+fn json_to_scalar(v: &Value) -> ScalarValue {
+    match v {
+        Value::String(s) => ScalarValue::Str(s.as_str().into()),
+        Value::Bool(b) => ScalarValue::Boolean(*b),
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                ScalarValue::Int(i)
+            } else if let Some(f) = n.as_f64() {
+                ScalarValue::F64(f)
+            } else {
+                ScalarValue::Null
+            }
+        }
+        Value::Null => ScalarValue::Null,
+        // Marks and block attributes are expected to be scalars; fall back to
+        // a JSON-encoded string for anything structured so no data is dropped.
+        other => ScalarValue::Str(other.to_string().into()),
+    }
+}
+
+/// Convert a JSON value into a `hydrate::Value` (for block marker maps).
+fn json_to_hydrate_value(v: &Value) -> hydrate::Value {
+    match v {
+        Value::Object(obj) => {
+            let map: HashMap<String, hydrate::Value> =
+                obj.iter().map(|(k, val)| (k.clone(), json_to_hydrate_value(val))).collect();
+            hydrate::Value::Map(hydrate::Map::from(map))
+        }
+        Value::Array(arr) => {
+            let items: Vec<hydrate::Value> = arr.iter().map(json_to_hydrate_value).collect();
+            hydrate::Value::List(hydrate::List::from(items))
+        }
+        scalar => hydrate::Value::Scalar(json_to_scalar(scalar)),
+    }
+}
+
+/// Convert a JSON spans array into a vector of Automerge `Span`s.
+fn json_to_spans(value: &Value) -> Vec<Span> {
+    let arr = match value.as_array() {
+        Some(arr) => arr,
+        None => return Vec::new(),
+    };
+    let mut spans = Vec::with_capacity(arr.len());
+    for item in arr {
+        let Some(obj) = item.as_object() else {
+            continue;
+        };
+        match obj.get("type").and_then(Value::as_str) {
+            Some("text") => {
+                let text = obj.get("value").and_then(Value::as_str).unwrap_or("").to_string();
+                let marks = obj.get("marks").and_then(Value::as_object).and_then(|marks_obj| {
+                    if marks_obj.is_empty() {
+                        None
+                    } else {
+                        let set: MarkSet = marks_obj
+                            .iter()
+                            .map(|(name, v)| (name.clone(), json_to_scalar(v)))
+                            .collect();
+                        Some(Arc::new(set))
+                    }
+                });
+                spans.push(Span::Text { text, marks });
+            }
+            Some("block") => {
+                if let Some(block_obj) = obj.get("block").and_then(Value::as_object) {
+                    let map: HashMap<String, hydrate::Value> = block_obj
+                        .iter()
+                        .map(|(k, v)| (k.clone(), json_to_hydrate_value(v)))
+                        .collect();
+                    spans.push(Span::Block(hydrate::Map::from(map)));
+                }
+            }
+            _ => {}
+        }
+    }
+    spans
+}
+
+/// Insert a rich-text spans array as an Automerge `Text` object under `key`.
+fn insert_spans_into_map<'a>(
     tx: &mut automerge::transaction::Transaction<'a>,
     parent: &automerge::ObjId,
     key: &str,
     value: &Value,
 ) -> Result<(), automerge::AutomergeError> {
+    let text_id = tx.put_object(parent, key, automerge::ObjType::Text)?;
+    let spans = json_to_spans(value);
+    tx.update_spans(&text_id, UpdateSpansConfig::default(), spans)
+}
+
+/// Returns `true` if the JSON object is a rich-text cell (`tag == "rich-text"`).
+fn json_is_rich_text_cell(map: &JsonMap<String, Value>) -> bool {
+    map.get("tag").and_then(Value::as_str) == Some(RICH_TEXT_CELL_TAG)
+}
+
+/// Insert a JSON value into a map property.
+///
+/// `parent_is_rich_text_cell` indicates whether `parent` is a rich-text cell,
+/// in which case a `content` array is materialized as an Automerge `Text`
+/// object (with marks and block markers) rather than a plain `List`.
+fn insert_value_into_map<'a>(
+    tx: &mut automerge::transaction::Transaction<'a>,
+    parent: &automerge::ObjId,
+    key: &str,
+    value: &Value,
+    parent_is_rich_text_cell: bool,
+) -> Result<(), automerge::AutomergeError> {
+    // Inside a rich-text cell, the `content` array (including an empty one) is
+    // always materialized as a Text object, never a plain List.
+    if parent_is_rich_text_cell && key == RICH_TEXT_KEY && value.is_array() {
+        return insert_spans_into_map(tx, parent, key, value);
+    }
+
     match value {
         Value::String(s) => {
             // Use ObjType::Text instead of scalar string to avoid ImmutableString in JavaScript
@@ -32,8 +146,9 @@ fn insert_value_into_map<'a>(
         }
         Value::Object(map) => {
             let obj_id = tx.put_object(parent, key, automerge::ObjType::Map)?;
+            let is_rich_text = json_is_rich_text_cell(map);
             for (nested_key, nested_val) in map {
-                insert_value_into_map(tx, &obj_id, nested_key.as_str(), nested_val)?;
+                insert_value_into_map(tx, &obj_id, nested_key.as_str(), nested_val, is_rich_text)?;
             }
         }
         Value::Array(arr) => {
@@ -74,8 +189,9 @@ fn insert_value_into_list<'a>(
         }
         Value::Object(map) => {
             let obj_id = tx.insert_object(parent, index, automerge::ObjType::Map)?;
+            let is_rich_text = json_is_rich_text_cell(map);
             for (nested_key, nested_val) in map {
-                insert_value_into_map(tx, &obj_id, nested_key.as_str(), nested_val)?;
+                insert_value_into_map(tx, &obj_id, nested_key.as_str(), nested_val, is_rich_text)?;
             }
         }
         Value::Array(arr) => {
@@ -110,8 +226,9 @@ pub fn populate_automerge_from_json<'a>(
         });
     };
 
+    let is_rich_text = json_is_rich_text_cell(map);
     for (key, val) in map {
-        insert_value_into_map(tx, &obj_id, key.as_str(), val)?;
+        insert_value_into_map(tx, &obj_id, key.as_str(), val, is_rich_text)?;
     }
 
     Ok(())
@@ -132,6 +249,129 @@ pub fn hydrate_to_json(value: &hydrate::Value) -> Value {
             Value::Array(l.iter().map(|list_value| hydrate_to_json(&list_value.value)).collect())
         }
         hydrate::Value::Text(t) => Value::String(t.to_string()),
+    }
+}
+
+/// Serialize an Automerge `Text` object to a JSON spans array, preserving marks
+/// and block markers (headings, lists, `math_inline`, `math_display`, ...).
+fn text_spans_to_json(
+    doc: &impl automerge::ReadDoc,
+    text_id: &automerge::ObjId,
+) -> Result<Value, automerge::AutomergeError> {
+    let mut out = Vec::new();
+    for span in doc.spans(text_id)? {
+        match span {
+            Span::Text { text, marks } => {
+                let mut obj = JsonMap::new();
+                obj.insert("type".to_string(), Value::String("text".to_string()));
+                obj.insert("value".to_string(), Value::String(text));
+                if let Some(marks) = marks {
+                    let mut marks_json = JsonMap::new();
+                    for (name, value) in marks.iter() {
+                        marks_json.insert(name.to_string(), scalar_to_json(value));
+                    }
+                    if !marks_json.is_empty() {
+                        obj.insert("marks".to_string(), Value::Object(marks_json));
+                    }
+                }
+                out.push(Value::Object(obj));
+            }
+            Span::Block(map) => {
+                let mut obj = JsonMap::new();
+                obj.insert("type".to_string(), Value::String("block".to_string()));
+                obj.insert("block".to_string(), hydrate_to_json(&hydrate::Value::Map(map)));
+                out.push(Value::Object(obj));
+            }
+        }
+    }
+    Ok(Value::Array(out))
+}
+
+/// Serialize a whole Automerge document to JSON, converting rich-text `Text`
+/// objects (stored under the `content` property) into structured spans
+/// arrays so that marks and block markers survive the round-trip.
+///
+/// Unlike [`hydrate_to_json`], which flattens every `Text` to a plain string,
+/// this reads spans directly from the document.
+pub fn hydrate_to_json_with_rich_text(
+    doc: &impl automerge::ReadDoc,
+) -> Result<Value, automerge::AutomergeError> {
+    map_to_json(doc, &automerge::ROOT)
+}
+
+/// The discriminator tag identifying a rich-text notebook cell.
+const RICH_TEXT_CELL_TAG: &str = "rich-text";
+
+/// Returns `true` if the map object `obj_id` is a rich-text cell, i.e. it has a
+/// scalar string property `tag` equal to [`RICH_TEXT_CELL_TAG`].
+fn is_rich_text_cell(
+    doc: &impl automerge::ReadDoc,
+    obj_id: &automerge::ObjId,
+) -> Result<bool, automerge::AutomergeError> {
+    match doc.get(obj_id, "tag")? {
+        Some((automerge::Value::Scalar(s), _)) => match s.as_ref() {
+            ScalarValue::Str(tag) => Ok(tag == RICH_TEXT_CELL_TAG),
+            _ => Ok(false),
+        },
+        // The tag may be stored as a Text object rather than a scalar string.
+        Some((automerge::Value::Object(automerge::ObjType::Text), tag_id)) => {
+            Ok(doc.text(&tag_id)? == RICH_TEXT_CELL_TAG)
+        }
+        _ => Ok(false),
+    }
+}
+
+fn map_to_json(
+    doc: &impl automerge::ReadDoc,
+    obj_id: &automerge::ObjId,
+) -> Result<Value, automerge::AutomergeError> {
+    let rich_text_cell = is_rich_text_cell(doc, obj_id)?;
+    let mut map = JsonMap::new();
+    for key in doc.keys(obj_id) {
+        if let Some((value, child_id)) = doc.get(obj_id, &key)? {
+            // Only the `content` of a rich-text cell is serialized as spans.
+            let as_spans = rich_text_cell && key == RICH_TEXT_KEY;
+            map.insert(key.clone(), value_to_json(doc, &value, &child_id, as_spans)?);
+        }
+    }
+    Ok(Value::Object(map))
+}
+
+fn list_to_json(
+    doc: &impl automerge::ReadDoc,
+    obj_id: &automerge::ObjId,
+) -> Result<Value, automerge::AutomergeError> {
+    let len = doc.length(obj_id);
+    let mut arr = Vec::with_capacity(len);
+    for i in 0..len {
+        if let Some((value, child_id)) = doc.get(obj_id, i)? {
+            arr.push(value_to_json(doc, &value, &child_id, false)?);
+        }
+    }
+    Ok(Value::Array(arr))
+}
+
+fn value_to_json(
+    doc: &impl automerge::ReadDoc,
+    value: &automerge::Value<'_>,
+    obj_id: &automerge::ObjId,
+    as_spans: bool,
+) -> Result<Value, automerge::AutomergeError> {
+    use automerge::ObjType;
+    match value {
+        automerge::Value::Object(ObjType::Text) => {
+            // Rich-text cell content becomes a spans array; every other Text
+            // object (e.g. a `Basic` judgment's string) is a plain string.
+            if as_spans {
+                text_spans_to_json(doc, obj_id)
+            } else {
+                Ok(Value::String(doc.text(obj_id)?))
+            }
+        }
+        automerge::Value::Object(ObjType::Map) => map_to_json(doc, obj_id),
+        automerge::Value::Object(ObjType::List) => list_to_json(doc, obj_id),
+        automerge::Value::Object(ObjType::Table) => map_to_json(doc, obj_id),
+        automerge::Value::Scalar(s) => Ok(scalar_to_json(s)),
     }
 }
 
@@ -162,10 +402,10 @@ fn scalar_to_json(s: &automerge::ScalarValue) -> Value {
 }
 
 #[cfg(all(test, feature = "property-tests"))]
-mod tests {
+mod property_tests {
     use super::*;
     use crate::common_test::roundtrip_json;
-    use crate::v1::notebook::ModelNotebook;
+    use crate::current::notebook::ModelNotebook;
     use automerge::Automerge;
     use test_strategy::proptest;
 
@@ -184,5 +424,142 @@ mod tests {
         let mut doc = Automerge::new();
         let result = doc.transact(|tx| populate_automerge_from_json(tx, automerge::ROOT, &json));
         proptest::prop_assert!(result.is_err());
+    }
+}
+
+/// Unit tests for lossless rich-text (spans) round-tripping through JSON,
+/// including marks (bold) and LaTeX math block markers.
+///
+/// Folded in from the original feasibility spike: these exercise the real
+/// production conversion (`populate_automerge_from_json` /
+/// `hydrate_doc_to_json`) rather than standalone helpers.
+#[cfg(all(test, feature = "backend"))]
+mod rich_text_tests {
+    use super::*;
+    use automerge::ReadDoc;
+    use serde_json::json;
+
+    /// Build a rich-text cell whose `content` is a spans array with a bold run,
+    /// an inline-math block marker, and trailing text.
+    ///
+    /// The block shape (`type` / `attrs` / `parents`) mirrors what the
+    /// `@automerge/prosemirror` binding emits for a `math_inline` node.
+    fn sample_cell_json() -> Value {
+        json!({
+            "tag": "rich-text",
+            "id": "00000000-0000-0000-0000-000000000001",
+            "content": [
+                { "type": "text", "value": "E = ", "marks": { "strong": true } },
+                {
+                    "type": "block",
+                    "block": {
+                        "type": "math_inline",
+                        "attrs": { "tex": "mc^2" },
+                        "parents": []
+                    }
+                },
+                { "type": "text", "value": " (mass-energy)" }
+            ]
+        })
+    }
+
+    /// Wrap a cell in a minimal document so the rich-text `tag` context is
+    /// present (rich-text content is only recognized inside a tagged cell).
+    fn doc_with_cell(cell: Value) -> Value {
+        json!({ "cell": cell })
+    }
+
+    /// Rich-text content survives a JSON → Automerge → JSON round-trip with
+    /// marks and the math `tex` attribute intact.
+    #[test]
+    fn rich_text_spans_roundtrip_through_json() {
+        let json = doc_with_cell(sample_cell_json());
+
+        let mut doc = automerge::Automerge::new();
+        doc.transact(|tx| populate_automerge_from_json(tx, automerge::ROOT, &json))
+            .unwrap();
+
+        // The cell's `content` must be a real Automerge Text object, not a List.
+        let (_, cell_id) = doc.get(automerge::ROOT, "cell").unwrap().unwrap();
+        let (value, _) = doc.get(&cell_id, "content").unwrap().unwrap();
+        assert!(
+            matches!(value, automerge::Value::Object(automerge::ObjType::Text)),
+            "content should be a Text object, got {value:?}"
+        );
+
+        let result = hydrate_to_json_with_rich_text(&doc).unwrap();
+        assert_eq!(json, result);
+    }
+
+    /// The serialized shape carries the expected marks and math attributes.
+    #[test]
+    fn rich_text_json_has_expected_shape() {
+        let json = doc_with_cell(sample_cell_json());
+        let mut doc = automerge::Automerge::new();
+        doc.transact(|tx| populate_automerge_from_json(tx, automerge::ROOT, &json))
+            .unwrap();
+
+        let result = hydrate_to_json_with_rich_text(&doc).unwrap();
+        let spans = result["cell"]["content"].as_array().expect("spans array");
+
+        assert_eq!(spans[0]["type"], "text");
+        assert_eq!(spans[0]["marks"]["strong"], true);
+
+        let block = spans.iter().find(|s| s["type"] == "block").expect("a block span");
+        assert_eq!(block["block"]["type"], "math_inline");
+        assert_eq!(block["block"]["attrs"]["tex"], "mc^2");
+    }
+
+    /// A plain (unmarked) text span round-trips without gaining a `marks` key.
+    #[test]
+    fn plain_text_span_has_no_marks_key() {
+        let json = doc_with_cell(json!({
+            "tag": "rich-text",
+            "id": "00000000-0000-0000-0000-000000000002",
+            "content": [ { "type": "text", "value": "plain" } ]
+        }));
+        let mut doc = automerge::Automerge::new();
+        doc.transact(|tx| populate_automerge_from_json(tx, automerge::ROOT, &json))
+            .unwrap();
+
+        let result = hydrate_to_json_with_rich_text(&doc).unwrap();
+        assert_eq!(json, result);
+        assert!(result["cell"]["content"][0].get("marks").is_none());
+    }
+
+    /// String content is accepted and normalized to spans.
+    #[test]
+    fn legacy_rich_text_string_serializes_as_spans() {
+        let json = doc_with_cell(json!({
+            "tag": "rich-text",
+            "id": "00000000-0000-0000-0000-000000000004",
+            "content": "legacy text"
+        }));
+        let mut doc = automerge::Automerge::new();
+        doc.transact(|tx| populate_automerge_from_json(tx, automerge::ROOT, &json))
+            .unwrap();
+
+        let result = hydrate_to_json_with_rich_text(&doc).unwrap();
+        assert_eq!(result["cell"]["content"], json!([{ "type": "text", "value": "legacy text" }]));
+    }
+
+    /// A `content` string that is NOT inside a rich-text cell (e.g. a `Basic`
+    /// model judgment) round-trips as a plain string, not a spans array.
+    #[test]
+    fn non_rich_text_content_string_is_unaffected() {
+        let json = json!({
+            "cell": {
+                "tag": "formal",
+                "id": "00000000-0000-0000-0000-000000000003",
+                "content": { "tag": "Basic", "content": "some object name" }
+            }
+        });
+        let mut doc = automerge::Automerge::new();
+        doc.transact(|tx| populate_automerge_from_json(tx, automerge::ROOT, &json))
+            .unwrap();
+
+        let result = hydrate_to_json_with_rich_text(&doc).unwrap();
+        assert_eq!(json, result);
+        assert_eq!(result["cell"]["content"]["content"], "some object name");
     }
 }

--- a/packages/document-types/src/automerge_util.rs
+++ b/packages/document-types/src/automerge_util.rs
@@ -363,7 +363,7 @@ mod tests {
 mod property_tests {
     use super::*;
     use crate::common_test::{doc_from_json, doc_to_json};
-    use crate::v1::notebook::ModelNotebook;
+    use crate::current::notebook::ModelNotebook;
     use automerge::ReadDoc;
     use test_strategy::proptest;
 

--- a/packages/document-types/src/common_test.rs
+++ b/packages/document-types/src/common_test.rs
@@ -3,7 +3,7 @@
 use automerge::Automerge;
 use serde_json::Value;
 
-use crate::automerge_json::{hydrate_to_json, populate_automerge_from_json};
+use crate::automerge_json::{hydrate_to_json_with_rich_text, populate_automerge_from_json};
 
 /// Create an Automerge doc populated from a JSON object.
 pub fn doc_from_json(value: &Value) -> Automerge {
@@ -18,8 +18,7 @@ pub fn doc_from_json(value: &Value) -> Automerge {
 
 /// Read the current doc state back as JSON.
 pub fn doc_to_json(doc: &Automerge) -> Value {
-    let value = doc.hydrate(None);
-    hydrate_to_json(&value)
+    hydrate_to_json_with_rich_text(doc).unwrap()
 }
 
 /// Roundtrip a JSON object through Automerge and back.

--- a/packages/document-types/src/lib.rs
+++ b/packages/document-types/src/lib.rs
@@ -7,7 +7,6 @@ mod v0;
 pub mod v1;
 pub mod v2;
 
-#[cfg(feature = "backend")]
 pub mod automerge_json;
 
 #[cfg(feature = "backend")]
@@ -118,6 +117,19 @@ pub fn migrate_document(input: JsValue) -> Result<JsValue, JsValue> {
         .map_err(|e| JsValue::from_str(&format!("serialize error: {e}")))?;
 
     Ok(output)
+}
+
+/// Serialize an Automerge document to JSON, encoding rich-text spans.
+#[wasm_bindgen(js_name = "serializeAutomergeDocument")]
+pub fn serialize_automerge_document(input: &[u8]) -> Result<JsValue, JsValue> {
+    let doc = automerge::Automerge::load(input)
+        .map_err(|e| JsValue::from_str(&format!("Automerge load error: {e}")))?;
+    let value = automerge_json::hydrate_to_json_with_rich_text(&doc)
+        .map_err(|e| JsValue::from_str(&format!("Automerge serialization error: {e}")))?;
+
+    value
+        .serialize(&Serializer::json_compatible())
+        .map_err(|e| JsValue::from_str(&format!("serialize error: {e}")))
 }
 
 #[cfg(test)]

--- a/packages/document-types/src/v2/cell.rs
+++ b/packages/document-types/src/v2/cell.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use tsify::{Tsify, declare};
 use uuid::Uuid;
 
+use super::rich_text::RichTextContent;
 use crate::v1;
 
 /// A cell in a notebook.
@@ -13,7 +14,7 @@ use crate::v1;
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub enum NotebookCell<T> {
     #[serde(rename = "rich-text")]
-    RichText { id: Uuid, content: String },
+    RichText { id: Uuid, content: RichTextContent },
     #[serde(rename = "formal")]
     Formal { id: Uuid, content: T },
 }
@@ -30,7 +31,7 @@ impl<T> NotebookCell<T> {
     pub fn migrate_from_v1(old: v1::NotebookCell<T>) -> Option<Self> {
         match old {
             v1::NotebookCell::RichText { id, content } => {
-                Some(NotebookCell::RichText { id, content })
+                Some(NotebookCell::RichText { id, content: content.into() })
             }
             v1::NotebookCell::Formal { id, content } => Some(NotebookCell::Formal { id, content }),
             v1::NotebookCell::Stem { .. } => None,
@@ -42,6 +43,7 @@ impl<T> NotebookCell<T> {
 #[cfg(feature = "property-tests")]
 pub(crate) mod arbitrary {
     use super::*;
+    use crate::v2::rich_text::arbitrary::arb_rich_text;
     use proptest::prelude::*;
     use uuid::Uuid;
 
@@ -54,7 +56,7 @@ pub(crate) mod arbitrary {
         arb_t: impl Strategy<Value = T> + Clone + 'static,
     ) -> BoxedStrategy<NotebookCell<T>> {
         prop_oneof![
-            (arb_uuid(), any::<String>())
+            (arb_uuid(), arb_rich_text())
                 .prop_map(|(id, content)| NotebookCell::RichText { id, content }),
             (arb_uuid(), arb_t).prop_map(|(id, content)| NotebookCell::Formal { id, content }),
         ]

--- a/packages/document-types/src/v2/mod.rs
+++ b/packages/document-types/src/v2/mod.rs
@@ -5,6 +5,7 @@ pub use v1::{analysis, api, diagram_judgment, model, model_judgment, path, theor
 pub mod cell;
 pub mod document;
 pub mod notebook;
+pub mod rich_text;
 
 pub use analysis::*;
 pub use api::*;
@@ -14,16 +15,31 @@ pub use document::*;
 pub use model::*;
 pub use model_judgment::*;
 pub use notebook::*;
+pub use rich_text::*;
 pub use theory::*;
 
 #[cfg(test)]
 mod test {
     use super::document::Document;
     use crate::test_utils::test_example_documents;
+    use serde_json::json;
 
     #[test]
     fn test_v2_examples() {
         test_example_documents::<Document, _>("examples/v2", |_, _| {});
+    }
+
+    #[test]
+    fn rich_text_accepts_live_strings_and_serialized_spans() {
+        let string: super::RichTextContent = serde_json::from_value(json!("hello")).unwrap();
+        assert_eq!(string, super::RichTextContent::String("hello".to_owned()));
+
+        let spans: super::RichTextContent = serde_json::from_value(json!([
+            { "type": "text", "value": "hello", "marks": { "strong": true } },
+            { "type": "block", "block": { "type": "math_inline", "tex": "x^2" } }
+        ]))
+        .unwrap();
+        assert!(matches!(spans, super::RichTextContent::Spans(_)));
     }
 }
 

--- a/packages/document-types/src/v2/rich_text.rs
+++ b/packages/document-types/src/v2/rich_text.rs
@@ -1,0 +1,99 @@
+//! Rich-text values.
+//!
+//! Live Automerge documents materialize `Text` as strings, while our
+//! JSON serialization emits lossless spans.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use tsify::Tsify;
+
+/// Rich text in either its live/legacy string form or serialized spans form.
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
+#[serde(untagged)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub enum RichTextContent {
+    String(String),
+    Spans(Vec<RichTextSpan>),
+}
+
+impl From<String> for RichTextContent {
+    fn from(value: String) -> Self {
+        RichTextContent::String(value)
+    }
+}
+
+/// A single span of serialized rich-text content.
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
+#[serde(tag = "type")]
+#[tsify(into_wasm_abi, from_wasm_abi, hashmap_as_object)]
+pub enum RichTextSpan {
+    #[serde(rename = "text")]
+    Text {
+        value: String,
+        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        marks: HashMap<String, Value>,
+    },
+    #[serde(rename = "block")]
+    Block { block: HashMap<String, Value> },
+}
+
+impl RichTextSpan {
+    pub fn text(value: impl Into<String>) -> Self {
+        RichTextSpan::Text {
+            value: value.into(),
+            marks: HashMap::new(),
+        }
+    }
+}
+
+#[cfg(feature = "property-tests")]
+pub(crate) mod arbitrary {
+    use super::*;
+    use proptest::prelude::*;
+    use serde_json::json;
+
+    fn arb_text_run() -> BoxedStrategy<RichTextSpan> {
+        ("[a-zA-Z0-9 ]{1,20}", any::<bool>())
+            .prop_map(|(text, bold)| {
+                if bold {
+                    RichTextSpan::Text {
+                        value: text,
+                        marks: HashMap::from([("strong".to_string(), json!(true))]),
+                    }
+                } else {
+                    RichTextSpan::text(text)
+                }
+            })
+            .boxed()
+    }
+
+    fn arb_math_block() -> BoxedStrategy<RichTextSpan> {
+        "[a-zA-Z0-9^ ]{0,20}"
+            .prop_map(|tex| RichTextSpan::Block {
+                block: HashMap::from([
+                    ("type".to_string(), json!("math_inline")),
+                    ("tex".to_string(), json!(tex)),
+                ]),
+            })
+            .boxed()
+    }
+
+    pub fn arb_rich_text() -> BoxedStrategy<RichTextContent> {
+        prop::collection::vec((arb_text_run(), arb_math_block()), 0..4)
+            .prop_flat_map(|pairs| {
+                proptest::option::of(arb_text_run()).prop_map(move |trailing| {
+                    let mut spans = Vec::new();
+                    for (text, block) in &pairs {
+                        spans.push(text.clone());
+                        spans.push(block.clone());
+                    }
+                    if let Some(text) = trailing {
+                        spans.push(text);
+                    }
+                    RichTextContent::Spans(spans)
+                })
+            })
+            .boxed()
+    }
+}

--- a/packages/frontend/src/page/document_menu.tsx
+++ b/packages/frontend/src/page/document_menu.tsx
@@ -123,9 +123,9 @@ export function DocumentMenu(props: {
                     <Show when={showSeparator()}>
                         <MenuSeparator />
                     </Show>
-                    <DuplicateMenuItem doc={props.liveDoc.doc} />
-                    <ExportJSONMenuItem doc={props.liveDoc.doc} />
-                    <CopyJSONMenuItem doc={props.liveDoc.doc} />
+                    <DuplicateMenuItem liveDoc={props.liveDoc} />
+                    <ExportJSONMenuItem liveDoc={props.liveDoc} />
+                    <CopyJSONMenuItem liveDoc={props.liveDoc} />
                     <MenuSeparator />
                     <Switch>
                         <Match when={canRestore()}>

--- a/packages/frontend/src/page/menubar.tsx
+++ b/packages/frontend/src/page/menubar.tsx
@@ -1,3 +1,4 @@
+import { next as Automerge } from "@automerge/automerge";
 import Popover from "@corvu/popover";
 import { useNavigate } from "@solidjs/router";
 import { getAuth, signOut } from "firebase/auth";
@@ -20,9 +21,11 @@ import { useAuth, useFirebaseApp } from "solid-firebase";
 import { type JSX, Show, useContext } from "solid-js";
 import invariant from "tiny-invariant";
 
+import { serializeAutomergeDocument } from "catcolab-document-types";
 import { IconButton } from "catcolab-ui-components";
 import type { Document } from "catlog-wasm";
 import { useApi } from "../api";
+import type { LiveDoc } from "../api/document";
 import { createModel } from "../model/document";
 import { TheoryLibraryContext } from "../theory";
 import { downloadJson } from "../util/json_export";
@@ -166,19 +169,22 @@ export function NewModelItem() {
 }
 
 /** Menu item to duplicate a document. */
-export function DuplicateMenuItem(props: { doc: Document }) {
+export function DuplicateMenuItem(props: { liveDoc: LiveDoc }) {
     const api = useApi();
     const navigate = useNavigate();
 
     const onDuplicate = async () => {
-        const newRef = await api.duplicateDoc(props.doc);
-        navigate(`/${props.doc.type}/${newRef}`);
+        const doc = serializeAutomergeDocument(
+            Automerge.save(props.liveDoc.docHandle.doc()),
+        ) as Document;
+        const newRef = await api.duplicateDoc(doc);
+        navigate(`/${doc.type}/${newRef}`);
     };
 
     return (
         <MenuItem onSelect={onDuplicate}>
             <Copy />
-            <MenuItemLabel>{`Duplicate ${props.doc.type}`}</MenuItemLabel>
+            <MenuItemLabel>{`Duplicate ${props.liveDoc.doc.type}`}</MenuItemLabel>
         </MenuItem>
     );
 }
@@ -197,25 +203,35 @@ export function ImportMenuItem() {
 }
 
 /** Menu item to export document as JSON. */
-export function ExportJSONMenuItem(props: { doc: Document }) {
-    const onExportJSON = () => downloadJson(JSON.stringify(props.doc), `${props.doc.name}.json`);
+export function ExportJSONMenuItem(props: { liveDoc: LiveDoc }) {
+    const onExportJSON = () => {
+        const doc = serializeAutomergeDocument(
+            Automerge.save(props.liveDoc.docHandle.doc()),
+        ) as Document;
+        downloadJson(JSON.stringify(doc), `${doc.name}.json`);
+    };
 
     return (
         <MenuItem onSelect={onExportJSON}>
             <Export />
-            <MenuItemLabel>{`Export ${props.doc.type}`}</MenuItemLabel>
+            <MenuItemLabel>{`Export ${props.liveDoc.doc.type}`}</MenuItemLabel>
         </MenuItem>
     );
 }
 
 /** Menu item to copy document to clipboard in JSON format. */
-export function CopyJSONMenuItem(props: { doc: Document }) {
-    const onCopyJSON = () => navigator.clipboard.writeText(JSON.stringify(props.doc));
+export function CopyJSONMenuItem(props: { liveDoc: LiveDoc }) {
+    const onCopyJSON = () =>
+        navigator.clipboard.writeText(
+            JSON.stringify(
+                serializeAutomergeDocument(Automerge.save(props.liveDoc.docHandle.doc())),
+            ),
+        );
 
     return (
         <MenuItem onSelect={onCopyJSON}>
             <CopyToClipboard />
-            <MenuItemLabel>{`Copy ${props.doc.type} to clipboard`}</MenuItemLabel>
+            <MenuItemLabel>{`Copy ${props.liveDoc.doc.type} to clipboard`}</MenuItemLabel>
         </MenuItem>
     );
 }

--- a/packages/frontend/src/user/permissions.tsx
+++ b/packages/frontend/src/user/permissions.tsx
@@ -1,3 +1,4 @@
+import { next as Automerge } from "@automerge/automerge";
 import { useNavigate } from "@solidjs/router";
 import { getAuth, signOut } from "firebase/auth";
 import Copy from "lucide-solid/icons/copy";
@@ -22,6 +23,7 @@ import { createStore, produce } from "solid-js/store";
 import invariant from "tiny-invariant";
 
 import type { NewPermissions, PermissionLevel, Permissions, UserSummary } from "catcolab-api";
+import { serializeAutomergeDocument } from "catcolab-document-types";
 import {
     Button,
     Dialog,
@@ -242,7 +244,7 @@ export const PermissionsButton = (props: { liveDoc: LiveDoc; docRef: DocRef }) =
                 <OwnerPermissionsButton refId={props.docRef.refId} docName={docName()} />
             </Match>
             <Match when={[anyone(), user()].every((level) => level === null || level === "Read")}>
-                <ReadonlyPermissionsButton doc={props.liveDoc.doc} docName={docName()} />
+                <ReadonlyPermissionsButton liveDoc={props.liveDoc} docName={docName()} />
             </Match>
         </Switch>
     );
@@ -301,14 +303,17 @@ const AnonPermissionsTrigger = (props: ComponentProps<"button">) => {
     );
 };
 
-const ReadonlyPermissionsButton = (props: { doc: Document; docName: string }) => {
+const ReadonlyPermissionsButton = (props: { liveDoc: LiveDoc; docName: string }) => {
     const [open, setOpen] = createSignal(false);
     const api = useApi();
     const navigate = useNavigate();
 
     const onDuplicateDocument = async () => {
-        const newRef = await api.duplicateDoc(props.doc);
-        navigate(`/${props.doc.type}/${newRef}`);
+        const doc = serializeAutomergeDocument(
+            Automerge.save(props.liveDoc.docHandle.doc()),
+        ) as Document;
+        const newRef = await api.duplicateDoc(doc);
+        navigate(`/${doc.type}/${newRef}`);
     };
 
     return (
@@ -328,7 +333,7 @@ const ReadonlyPermissionsButton = (props: { doc: Document; docName: string }) =>
                     <span>
                         <Button type="button" variant="utility" onClick={onDuplicateDocument}>
                             <Copy />
-                            Duplicate {props.doc.type}
+                            Duplicate {props.liveDoc.doc.type}
                         </Button>
                     </span>
                     <span class="duplicate-button-height-text"> to make permanent changes.</span>

--- a/packages/frontend/src/util/serialize_document.test.ts
+++ b/packages/frontend/src/util/serialize_document.test.ts
@@ -1,0 +1,96 @@
+import { next as Automerge } from "@automerge/automerge";
+import type { DocHandle } from "@automerge/automerge-repo";
+import { Repo } from "@automerge/automerge-repo";
+import { assert, describe, test } from "vitest";
+
+import { Model, type ModelDocument, Nb } from "catcolab-document-methods";
+import { serializeAutomergeDocument, type Document } from "catcolab-document-types";
+
+// Dummy Automerge repo with no networking or storage.
+const repo = new Repo();
+
+describe("serializeAutomergeDocument", () => {
+    test("serializes rich-text content as spans, not a flattened string", () => {
+        const modelDoc = Model.newModelDocument({ theory: "empty" });
+        Nb.appendCell(modelDoc.notebook, Nb.newRichTextCell());
+        const cellId = modelDoc.notebook.cellOrder[0]!;
+
+        const docHandle: DocHandle<ModelDocument> = repo.create(modelDoc);
+
+        // Build rich-text content directly in the Automerge document, the way
+        // the ProseMirror binding does: a paragraph block, some text, a bold
+        // run, and an inline-math block marker.
+        const contentPath = ["notebook", "cellContents", cellId, "content"];
+        docHandle.change((doc) => {
+            Automerge.splitBlock(doc, contentPath, 0, {
+                type: "paragraph",
+                parents: [],
+                attrs: {},
+            });
+            Automerge.splice(doc, contentPath, 1, 0, "E = ");
+            // Mark "E = " as bold.
+            Automerge.mark(doc, contentPath, { start: 1, end: 5, expand: "none" }, "strong", true);
+            Automerge.splitBlock(doc, contentPath, 5, {
+                type: "math_inline",
+                parents: [],
+                attrs: { tex: "mc^2" },
+            });
+        });
+
+        const serialized = serializeAutomergeDocument(
+            Automerge.save((docHandle as DocHandle<Document>).doc()),
+        ) as Document;
+
+        const cell = serialized.notebook.cellContents[cellId];
+        assert(cell?.tag === "rich-text");
+        const spans = cell.content;
+
+        // Content must be a spans array, never a flattened string.
+        assert(Array.isArray(spans), "content should be a spans array");
+        assert(
+            !spans.some((s) => typeof s !== "object"),
+            "spans must be objects, not raw string fragments",
+        );
+
+        // There should be a bold text span carrying "E = ".
+        const boldText = spans.find(
+            (s) => s.type === "text" && s.value === "E = " && s.marks?.strong === true,
+        );
+        assert(boldText, "expected a bold text span 'E = '");
+
+        // There should be an inline-math block marker preserving its tex
+        // (stored under the block's `attrs`).
+        const mathBlock = spans.find(
+            (s) =>
+                s.type === "block" &&
+                s.block.type === "math_inline" &&
+                (s.block.attrs as Record<string, unknown> | undefined)?.tex === "mc^2",
+        );
+        assert(mathBlock, "expected an inline-math block span with tex 'mc^2'");
+    });
+
+    test("produces JSON without U+FFFC object-replacement characters", () => {
+        const modelDoc = Model.newModelDocument({ theory: "empty" });
+        Nb.appendCell(modelDoc.notebook, Nb.newRichTextCell());
+        const cellId = modelDoc.notebook.cellOrder[0]!;
+
+        const docHandle: DocHandle<ModelDocument> = repo.create(modelDoc);
+        const contentPath = ["notebook", "cellContents", cellId, "content"];
+        docHandle.change((doc) => {
+            Automerge.splitBlock(doc, contentPath, 0, {
+                type: "paragraph",
+                parents: [],
+                attrs: {},
+            });
+            Automerge.splice(doc, contentPath, 1, 0, "hello world");
+        });
+
+        const json = JSON.stringify(
+            serializeAutomergeDocument(Automerge.save((docHandle as DocHandle<Document>).doc())),
+        );
+        assert(
+            !json.includes("\ufffc"),
+            "serialized JSON must not contain U+FFFC placeholders from a flattened Text object",
+        );
+    });
+});


### PR DESCRIPTION
This gives our v2 document-types an alternative rich text representation used solely for serialization. The live Automerge docs are unaffected. This alternative representation encodes Automerge spans into JSON so our export/import/duplicate no longer break rich text. 

Due to pulling in Automerge for serialization it adds ~1mb to the document-types WASM blob. 


<details>
<summary>example JSON</summary>

```json
{
    "name": "",
    "notebook": {
        "cellContents": {
            "019f66b4-a773-732a-bcbd-bd06dcea4af9": {
                "content": [
                    {
                        "block": {
                            "attrs": {},
                            "isEmbed": false,
                            "parents": [],
                            "type": "paragraph"
                        },
                        "type": "block"
                    },
                    { "marks": { "strong": true }, "type": "text", "value": "beautiful" },
                    {
                        "block": {
                            "attrs": {},
                            "isEmbed": false,
                            "parents": [],
                            "type": "paragraph"
                        },
                        "type": "block"
                    },
                    {
                        "block": {
                            "attrs": {},
                            "isEmbed": false,
                            "parents": [],
                            "type": "math_display"
                        },
                        "type": "block"
                    },
                    { "type": "text", "value": "\\LaTeX" }
                ],
                "id": "019f66b4-a773-732a-bcbd-bd06dcea4af9",
                "tag": "rich-text"
            }
        },
        "cellOrder": ["019f66b4-a773-732a-bcbd-bd06dcea4af9"]
    },
    "theory": "empty",
    "type": "model",
    "version": "2"
}
```