### PR TITLE
Fixed random seed for stochastic mass-action

### DIFF
--- a/packages/catlog/src/stdlib/analyses/stochastic/mass_action.rs
+++ b/packages/catlog/src/stdlib/analyses/stochastic/mass_action.rs
@@ -22,7 +22,7 @@ use tsify::Tsify;
 #[cfg_attr(feature = "serde-wasm", derive(Tsify))]
 #[cfg_attr(
     feature = "serde-wasm",
-    tsify(into_wasm_abi, from_wasm_abi, hashmap_as_object)
+    tsify(into_wasm_abi, from_wasm_abi, hashmap_as_object, missing_as_null)
 )]
 pub struct StochasticMassActionProblemData {
     /// Map from morphism IDs to rate coefficients (nonnegative reals).
@@ -31,6 +31,9 @@ pub struct StochasticMassActionProblemData {
     /// Map from object IDs to initial values (nonnegative integers).
     #[cfg_attr(feature = "serde", serde(rename = "initialValues"))]
     pub initial_values: HashMap<QualifiedName, u32>,
+
+    /// Optional fixed seed, for reproducibility.
+    pub seed: Option<u64>,
 
     /// Duration of simulation.
     pub duration: f32,
@@ -105,7 +108,10 @@ impl PetriNetStochasticMassActionAnalysis {
             .iter()
             .map(|id| data.initial_values.get(id).copied().unwrap_or_default() as isize)
             .collect();
-        let mut problem = gillespie::Gillespie::new(initial, false);
+        let mut problem = match data.seed {
+            Some(seed) => gillespie::Gillespie::new_with_seed(initial, false, seed),
+            None => gillespie::Gillespie::new(initial, false),
+        };
 
         for mor in model.mor_generators_with_type(&self.transition_mor_type) {
             let (inputs, outputs) = transition_interface(model, &mor);
@@ -167,6 +173,7 @@ mod tests {
                 (name("I"), 1),
                 (name("R"), 0),
             ]),
+            seed: None,
             duration: 10f32,
         };
         let sys =

--- a/packages/frontend/src/stdlib/analyses.tsx
+++ b/packages/frontend/src/stdlib/analyses.tsx
@@ -249,6 +249,7 @@ export function stochasticMassAction(
         initialContent: () => ({
             rates: {},
             initialValues: {},
+            seed: null,
             duration: 10,
         }),
     };

--- a/packages/frontend/src/stdlib/analyses/stochastic_mass_action.tsx
+++ b/packages/frontend/src/stdlib/analyses/stochastic_mass_action.tsx
@@ -8,6 +8,8 @@ import {
     FixedTableEditor,
     Foldable,
     IconButton,
+    CheckboxField,
+    FormGroup,
 } from "catcolab-ui-components";
 import type {
     DblModel,
@@ -122,7 +124,16 @@ export default function StochasticMassAction(
 
     return (
         <div class="simulation">
-            <BlockTitle title={props.title} actions={RerunButton()} />
+            <BlockTitle
+                title={props.title}
+                settingsPane={
+                    <StochasticMassActionConfigForm
+                        config={props.content}
+                        changeConfig={props.changeContent}
+                        useSetSeed={props.content.seed === null}
+                    />
+                }
+                actions={RerunButton()} />
             <Foldable title="Parameters" defaultExpanded>
                 <div class="parameters">
                     <FixedTableEditor rows={obGenerators()} schema={obSchema} />
@@ -132,5 +143,33 @@ export default function StochasticMassAction(
             </Foldable>
             <ODEResultPlot result={plotResult()} />
         </div>
+    );
+}
+
+
+/** Form to configure a mass-action analysis. */
+export function StochasticMassActionConfigForm(props: {
+    config: StochasticMassActionProblemData;
+    changeConfig: (f: (config: StochasticMassActionProblemData) => void) => void;
+    useSetSeed: boolean;
+}) {
+    return (
+        <FormGroup compact style={{ "min-width": "286px" }}>
+            <CheckboxField
+                label="Set random seed"
+                checked={props.config.seed !== null}
+                onChange={(evt) => {
+                    props.changeConfig((content) => {
+                        if (evt.currentTarget.checked) {
+                            // TODO: this should work for e.g. 18446744073709551615
+                            content.seed = 12;
+                        } else {
+                            content.seed = null;
+                        }
+                    });
+                }}
+            />
+            {/*TODO: form to set custom seed*/}
+        </FormGroup>
     );
 }

--- a/packages/frontend/src/stdlib/analyses/stochastic_mass_action.tsx
+++ b/packages/frontend/src/stdlib/analyses/stochastic_mass_action.tsx
@@ -1,5 +1,5 @@
 import RotateCcw from "lucide-solid/icons/rotate-ccw";
-import { createMemo, createSignal } from "solid-js";
+import { createMemo, createSignal, Show } from "solid-js";
 
 import {
     BlockTitle,
@@ -115,12 +115,14 @@ export default function StochasticMassAction(
     );
 
     const RerunButton = () => (
-        <IconButton
-            onClick={() => setRerunCount((count) => count + 1)}
-            tooltip="Re-run the stochastic simulation"
-        >
-            <RotateCcw size={16} />
-        </IconButton>
+        <Show when={props.content.seed == null}>
+            <IconButton
+                onClick={() => setRerunCount((count) => count + 1)}
+                tooltip="Re-run the stochastic simulation"
+            >
+                <RotateCcw size={16} />
+            </IconButton>
+        </Show>
     );
 
     return (

--- a/packages/frontend/src/stdlib/analyses/stochastic_mass_action.tsx
+++ b/packages/frontend/src/stdlib/analyses/stochastic_mass_action.tsx
@@ -178,14 +178,13 @@ export function StochasticMassActionConfigForm(props: {
                 }}
             />
             <InputField
+                type="number"
                 label="Random seed"
                 value={props.config.seed ?? ""}
                 onChange={(evt) => {
                     const value = Number(evt.currentTarget.value);
                     if (Number.isInteger(value) && value >= 0) {
                         props.changeConfig((content) => {
-                            // TODO: fix reactivity, so that this reruns the simulation on key-up
-                            //       (at the moment it requires hitting the enter key)
                             content.seed = value;
                         });
                     }

--- a/packages/frontend/src/stdlib/analyses/stochastic_mass_action.tsx
+++ b/packages/frontend/src/stdlib/analyses/stochastic_mass_action.tsx
@@ -10,6 +10,7 @@ import {
     IconButton,
     CheckboxField,
     FormGroup,
+    InputField,
 } from "catcolab-ui-components";
 import type {
     DblModel,
@@ -156,12 +157,12 @@ export function StochasticMassActionConfigForm(props: {
     return (
         <FormGroup compact style={{ "min-width": "286px" }}>
             <CheckboxField
-                label="Set random seed"
+                label="Fixed random seed"
                 checked={props.config.seed !== null}
                 onChange={(evt) => {
                     props.changeConfig((content) => {
                         if (evt.currentTarget.checked) {
-                            // TODO: this should work for e.g. 18446744073709551615
+                            // TODO: replace this with something using Math.random()
                             content.seed = 12;
                         } else {
                             content.seed = null;
@@ -169,7 +170,18 @@ export function StochasticMassActionConfigForm(props: {
                     });
                 }}
             />
-            {/*TODO: form to set custom seed*/}
+            <InputField
+                label="Random seed"
+                value={props.config.seed ?? ""}
+                onChange={(evt) => {
+                    const value = evt.currentTarget.valueAsNumber;
+                    if (Number.isInteger(value) && value >= 0) {
+                        props.changeConfig((content) => {
+                            content.seed = value;
+                        })
+                    }
+                }}
+            />
         </FormGroup>
     );
 }

--- a/packages/frontend/src/stdlib/analyses/stochastic_mass_action.tsx
+++ b/packages/frontend/src/stdlib/analyses/stochastic_mass_action.tsx
@@ -38,6 +38,14 @@ export default function StochasticMassAction(
 ) {
     const elaboratedModel = () => props.liveModel.elaboratedModel();
 
+    // For backwards compatibility with notebooks created before the `seed` field was introduced.
+    const seed = () => {
+        if (props.content.seed === undefined) {
+            props.content.seed = null;
+        }
+        return props.content.seed;
+    };
+
     const obGenerators = createMemo<QualifiedName[]>(() => {
         const model = elaboratedModel();
         if (!model) {
@@ -131,10 +139,11 @@ export default function StochasticMassAction(
                     <StochasticMassActionConfigForm
                         config={props.content}
                         changeConfig={props.changeContent}
-                        useSetSeed={props.content.seed === null}
+                        useSetSeed={seed() === null}
                     />
                 }
-                actions={RerunButton()} />
+                actions={RerunButton()}
+            />
             <Foldable title="Parameters" defaultExpanded>
                 <div class="parameters">
                     <FixedTableEditor rows={obGenerators()} schema={obSchema} />
@@ -146,7 +155,6 @@ export default function StochasticMassAction(
         </div>
     );
 }
-
 
 /** Form to configure a mass-action analysis. */
 export function StochasticMassActionConfigForm(props: {
@@ -162,8 +170,7 @@ export function StochasticMassActionConfigForm(props: {
                 onChange={(evt) => {
                     props.changeConfig((content) => {
                         if (evt.currentTarget.checked) {
-                            // TODO: replace this with something using Math.random()
-                            content.seed = 12;
+                            content.seed = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
                         } else {
                             content.seed = null;
                         }
@@ -174,11 +181,13 @@ export function StochasticMassActionConfigForm(props: {
                 label="Random seed"
                 value={props.config.seed ?? ""}
                 onChange={(evt) => {
-                    const value = evt.currentTarget.valueAsNumber;
+                    const value = Number(evt.currentTarget.value);
                     if (Number.isInteger(value) && value >= 0) {
                         props.changeConfig((content) => {
+                            // TODO: fix reactivity, so that this reruns the simulation on key-up
+                            //       (at the moment it requires hitting the enter key)
                             content.seed = value;
-                        })
+                        });
                     }
                 }}
             />

--- a/packages/frontend/src/stdlib/analyses/stochastic_mass_action.tsx
+++ b/packages/frontend/src/stdlib/analyses/stochastic_mass_action.tsx
@@ -38,14 +38,6 @@ export default function StochasticMassAction(
 ) {
     const elaboratedModel = () => props.liveModel.elaboratedModel();
 
-    // For backwards compatibility with notebooks created before the `seed` field was introduced.
-    const seed = () => {
-        if (props.content.seed === undefined) {
-            props.content.seed = null;
-        }
-        return props.content.seed;
-    };
-
     const obGenerators = createMemo<QualifiedName[]>(() => {
         const model = elaboratedModel();
         if (!model) {
@@ -139,7 +131,6 @@ export default function StochasticMassAction(
                     <StochasticMassActionConfigForm
                         config={props.content}
                         changeConfig={props.changeContent}
-                        useSetSeed={seed() === null}
                     />
                 }
                 actions={RerunButton()}
@@ -160,13 +151,12 @@ export default function StochasticMassAction(
 export function StochasticMassActionConfigForm(props: {
     config: StochasticMassActionProblemData;
     changeConfig: (f: (config: StochasticMassActionProblemData) => void) => void;
-    useSetSeed: boolean;
 }) {
     return (
-        <FormGroup compact style={{ "min-width": "286px" }}>
+        <FormGroup compact>
             <CheckboxField
                 label="Fixed random seed"
-                checked={props.config.seed !== null}
+                checked={props.config.seed != null}
                 onChange={(evt) => {
                     props.changeConfig((content) => {
                         if (evt.currentTarget.checked) {


### PR DESCRIPTION
Allow for a fixed random seed to be set for stochastic mass-action analyses. (I thought that this closed an old issue, but it turns out that we never actually made a GitHub issue for this, instead only writing it down in a DM)

to-do:
- [x] fix reactivity