### PR TITLE
OBEE-11 FE: inference key provider and gated RPC tests

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import { ErrorBoundaryDialog } from "./page/error_boundary";
 import { PageContainer } from "./page/page_container";
 import { stdTheories } from "./stdlib";
 import { TheoryLibraryContext } from "./theory";
+import { InferenceKeyProvider } from "./user/inference_key_provider";
 import { UserStateProvider } from "./user/user_state_provider";
 
 const serverUrl = import.meta.env.VITE_SERVER_URL;
@@ -52,6 +53,7 @@ const Root = (props: RouteSectionProps) => {
                     [TheoryLibraryContext, theories],
                     [ModelLibraryContext, models],
                     UserStateProvider,
+                    InferenceKeyProvider,
                 ]}
             >
                 <MetaProvider>

--- a/packages/frontend/src/api/inference_rpc.test.ts
+++ b/packages/frontend/src/api/inference_rpc.test.ts
@@ -1,0 +1,63 @@
+import { type FirebaseOptions, initializeApp } from "firebase/app";
+import { deleteUser, getAuth, signInWithEmailAndPassword, signOut } from "firebase/auth";
+import invariant from "tiny-invariant";
+import { afterAll, assert, describe, test } from "vitest";
+
+import { initTestUserAuth } from "../util/test_util.ts";
+import { createFetchWithAuth, createRpcClient, unwrap, unwrapErr } from "./rpc.ts";
+
+// These tests exercise the live `get_inference_key` RPC, which creates
+// OpenRouter child keys when a provisioning key is configured. They are skipped
+// unless `VITE_RUN_INFERENCE_TESTS=1` is set, so they run locally but not in
+// CI. To run them, ensure you have a backend running; they work both with and
+// without `OPENROUTER_PROVISIONING_KEY` set.
+const enabled = import.meta.env.VITE_RUN_INFERENCE_TESTS === "1";
+
+const serverUrl = import.meta.env.VITE_SERVER_URL;
+const firebaseOptions = JSON.parse(import.meta.env.VITE_FIREBASE_OPTIONS) as FirebaseOptions;
+
+const firebaseApp = initializeApp(firebaseOptions);
+const rpc = createRpcClient(serverUrl, createFetchWithAuth(firebaseApp));
+
+(enabled ? describe : describe.skip)("RPC for inference keys", async () => {
+    const auth = getAuth(firebaseApp);
+    const email = "test-inference-key@catcolab.org";
+    const password = "foobar";
+    await initTestUserAuth(auth, email, password);
+
+    const user = auth.currentUser;
+    invariant(user);
+    afterAll(async () => user && (await deleteUser(user)));
+
+    unwrap(await rpc.sign_up_or_sign_in.mutate());
+
+    const authResult = await rpc.get_inference_key.query();
+    test.sequential("should return a key, or report inference unavailable", () => {
+        if (authResult.tag === "Ok") {
+            assert.ok(authResult.content.length > 0, "key should be a non-empty string");
+        } else {
+            assert.strictEqual(
+                authResult.code,
+                503,
+                "only expected authenticated error is inference unavailable (503)",
+            );
+        }
+    });
+
+    const secondResult = await rpc.get_inference_key.query();
+    test.sequential("should return the same value on a second call", () => {
+        assert.strictEqual(secondResult.tag, authResult.tag);
+        if (authResult.tag === "Ok" && secondResult.tag === "Ok") {
+            assert.strictEqual(secondResult.content, authResult.content);
+        }
+    });
+
+    await signOut(auth);
+
+    const unauthResult = await rpc.get_inference_key.query();
+    test.sequential("should prohibit key retrieval when unauthenticated", () => {
+        assert.strictEqual(unwrapErr(unauthResult).code, 401);
+    });
+
+    await signInWithEmailAndPassword(auth, email, password);
+});

--- a/packages/frontend/src/user/inference_key_context.tsx
+++ b/packages/frontend/src/user/inference_key_context.tsx
@@ -1,0 +1,20 @@
+import { type Resource, createContext, useContext } from "solid-js";
+import invariant from "tiny-invariant";
+
+/** Resolved value of the inference key resource.
+
+`Unavailable` is a normal state---the backend has no inference configured
+(HTTP 503, `InferenceUnavailable`)---and is distinct from an error, which
+surfaces on the resource's `error` property rather than as a value.
+ */
+export type InferenceKeyResult = { tag: "Ready"; key: string } | { tag: "Unavailable" };
+
+/** Context for the authenticated user's inference key resource. */
+export const InferenceKeyContext = createContext<Resource<InferenceKeyResult>>();
+
+/** Retrieve the inference key resource from application context. */
+export function useInferenceKey(): Resource<InferenceKeyResult> {
+    const key = useContext(InferenceKeyContext);
+    invariant(key !== undefined, "Inference key should be provided as context");
+    return key;
+}

--- a/packages/frontend/src/user/inference_key_provider.tsx
+++ b/packages/frontend/src/user/inference_key_provider.tsx
@@ -1,0 +1,40 @@
+import { getAuth } from "firebase/auth";
+import { useAuth, useFirebaseApp } from "solid-firebase";
+import { type JSX, createEffect, createResource } from "solid-js";
+
+import { useApi } from "../api";
+import { type InferenceKeyResult, InferenceKeyContext } from "./inference_key_context";
+
+/** Provides the authenticated user's inference key. */
+export function InferenceKeyProvider(props: { children: JSX.Element }) {
+    const api = useApi();
+    const firebaseApp = useFirebaseApp();
+    const auth = useAuth(getAuth(firebaseApp));
+
+    const [inferenceKey, { mutate }] = createResource(
+        () => auth.data?.uid ?? null,
+        async () => {
+            const result = await api.rpc.get_inference_key.query();
+            if (result.tag === "Ok") {
+                return { tag: "Ready", key: result.content } as InferenceKeyResult;
+            }
+            if (result.code === 503) {
+                return { tag: "Unavailable" } as InferenceKeyResult;
+            }
+            throw new Error(result.message);
+        },
+    );
+
+    // clear the resource explicitly on sign-out
+    createEffect(() => {
+        if (auth.data == null) {
+            mutate(undefined);
+        }
+    });
+
+    return (
+        <InferenceKeyContext.Provider value={inferenceKey}>
+            {props.children}
+        </InferenceKeyContext.Provider>
+    );
+}

--- a/packages/frontend/src/vite-env.d.ts
+++ b/packages/frontend/src/vite-env.d.ts
@@ -6,6 +6,7 @@ interface ImportMetaEnv {
     readonly VITE_AUTOMERGE_REPO_URL: string;
     readonly VITE_FIREBASE_OPTIONS: string;
     readonly VITE_JULIA_URL?: string;
+    readonly VITE_RUN_INFERENCE_TESTS?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
This changes depends on #1340 .

If there's a way to have github only show the relative diff between this and #1340 i don't know it, other than making the target of this PR that branch which is not desirable.

## Design decisions

* Following #1340, the key is not written into the user-state Automerge doc. It is session-scoped state delivered by the RPC end-point. We may choose to revisit this
decision in the future.

* The inference key is held per-session in a Solid resource keyed on the Firebase user id, following the user state pattern.

## Implementation details

Add `InferenceKeyProvider` / `InferenceKeyContext` to the `MultiProvider` in `App.tsx`, mirroring the existing `UserStateProvider` / `UserStateContext` pair. The only
notable features here are treating a back-end running without inference availability as a normal value, and explicit sign-out clearing.

The intended usage is through `useInferenceKey()` by matching on the resource's `state` / `tag` to distinguish `loading`, `ready`, `unavailable`, and `errored`.

## Tests

Add `src/api/inference_rpc.test.ts`, an integration test for the `get_inference_key` RPC. It is gated by `VITE_RUN_INFERENCE_TESTS=1` so it runs locally (with a stood-up backend + DB + OPENROUTER_PROVISIONING_KEY) but not in CI. There is future work here to discuss how, if at all, we would want this to run in the CI.

I have verified this manually, to obtain an `OPENROUTER_PROVISIONING_KEY` login/signup for a personal account and create one at https://openrouter.ai/settings/management-keys .

Run with: `VITE_RUN_INFERENCE_TESTS=1 pnpm test`