### PR TITLE
OBEE-14 Action API: Initial tests for model notebooks of schema & olog

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -11,7 +11,7 @@
         "customGroups": [
             {
                 "groupName": "workspace",
-                "elementNamePattern": ["catcolab-ui-components", "catcolab-api", "catlog-wasm", "catcolab-document-types", "catcolab-document-methods"],
+                "elementNamePattern": ["catcolab-ui-components", "catcolab-api", "catlog-wasm", "catcolab-document-types", "catcolab-document-methods", "catcolab-documents", "catcolab-logics"],
             },
         ],
         "groups": [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,10 @@ members = ["packages/*"]
 exclude = [
   "packages/algjulia-interop",
   "packages/document-methods",
+  "packages/documents",
   "packages/frontend",
   "packages/gaios",
+  "packages/logics",
   "packages/ui-components",
 ]
 

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -95,4 +95,13 @@ export default defineConfig({
             },
         ],
     },
+    overrides: [
+        {
+            files: ["packages/documents/test/**/*.{ts,tsx}", "packages/logics/test/**/*.ts"],
+            rules: {
+                // These RFC-derived suites specify packages that have not been implemented yet.
+                "vitest/no-disabled-tests": "off",
+            },
+        },
+    ],
 });

--- a/packages/documents/package.json
+++ b/packages/documents/package.json
@@ -1,0 +1,47 @@
+{
+    "name": "catcolab-documents",
+    "version": "0.1.0",
+    "private": true,
+    "license": "MIT",
+    "type": "module",
+    "exports": {
+        ".": "./src/index.ts",
+        "./*": "./src/*"
+    },
+    "scripts": {
+        "format": "oxfmt .",
+        "lint": "oxlint --fix && oxfmt .",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "check": "tsc -p tsconfig.test.json && pnpm run lint",
+        "ci": "oxlint --deny-warnings && oxfmt --check ."
+    },
+    "dependencies": {
+        "catcolab-document-types": "link:../document-types/pkg",
+        "catlog-wasm": "link:../catlog-wasm/dist/pkg-browser",
+        "uuid": "^13.0.0"
+    },
+    "devDependencies": {
+        "@automerge/automerge": "^3.3.1",
+        "@automerge/automerge-repo": "^2.5.5",
+        "@automerge/automerge-repo-solid-primitives": "^2.0.0",
+        "@automerge/prosemirror": "^0.2.0",
+        "@catcolab-dev-tools/vite-plugin-monorepo-dedupe": "link:../../tools/vite-plugin-monorepo-dedupe",
+        "@standard-schema/spec": "^1.1.0",
+        "@tsconfig/strictest": "^2.0.8",
+        "@types/node": "^24.0.0",
+        "@types/uuid": "^10.0.0",
+        "catcolab-documents": "workspace:*",
+        "catcolab-logics": "workspace:*",
+        "happy-dom": "^20.0.0",
+        "prosemirror-model": "^1.25.9",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-view": "^1.41.9",
+        "solid-js": "^1.9.10",
+        "typescript": "^6.0.3",
+        "vite": "^7.2.2",
+        "vite-plugin-solid": "^2.11.10",
+        "vite-plugin-wasm": "^3.5.0",
+        "vitest": "^4.0.8"
+    }
+}

--- a/packages/documents/pnpm-lock.yaml
+++ b/packages/documents/pnpm-lock.yaml
@@ -1,0 +1,1863 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      catcolab-document-types:
+        specifier: link:../document-types/pkg
+        version: link:../document-types/pkg
+      catlog-wasm:
+        specifier: link:../catlog-wasm/dist/pkg-browser
+        version: link:../catlog-wasm/dist/pkg-browser
+      uuid:
+        specifier: ^13.0.0
+        version: 13.0.2
+    devDependencies:
+      '@automerge/automerge':
+        specifier: ^3.3.1
+        version: 3.3.1
+      '@automerge/automerge-repo':
+        specifier: ^2.5.5
+        version: 2.5.6
+      '@automerge/automerge-repo-solid-primitives':
+        specifier: ^2.0.0
+        version: 2.5.6(@automerge/automerge@3.3.1)(solid-js@1.9.14)
+      '@automerge/prosemirror':
+        specifier: ^0.2.0
+        version: 0.2.0
+      '@catcolab-dev-tools/vite-plugin-monorepo-dedupe':
+        specifier: link:../../tools/vite-plugin-monorepo-dedupe
+        version: link:../../tools/vite-plugin-monorepo-dedupe
+      '@standard-schema/spec':
+        specifier: ^1.1.0
+        version: 1.1.0
+      '@tsconfig/strictest':
+        specifier: ^2.0.8
+        version: 2.0.8
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.13.3
+      '@types/uuid':
+        specifier: ^10.0.0
+        version: 10.0.0
+      catcolab-documents:
+        specifier: workspace:*
+        version: 'link:'
+      catcolab-logics:
+        specifier: workspace:*
+        version: link:../logics
+      happy-dom:
+        specifier: ^20.0.0
+        version: 20.10.6
+      prosemirror-model:
+        specifier: ^1.25.9
+        version: 1.25.10
+      prosemirror-state:
+        specifier: ^1.4.4
+        version: 1.4.4
+      prosemirror-view:
+        specifier: ^1.41.9
+        version: 1.42.0
+      solid-js:
+        specifier: ^1.9.10
+        version: 1.9.14
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^7.2.2
+        version: 7.3.6(@types/node@24.13.3)
+      vite-plugin-solid:
+        specifier: ^2.11.10
+        version: 2.11.12(solid-js@1.9.14)(vite@7.3.6(@types/node@24.13.3))
+      vite-plugin-wasm:
+        specifier: ^3.5.0
+        version: 3.6.0(vite@7.3.6(@types/node@24.13.3))
+      vitest:
+        specifier: ^4.0.8
+        version: 4.1.10(@types/node@24.13.3)(happy-dom@20.10.6)(vite@7.3.6(@types/node@24.13.3))
+
+packages:
+
+  '@automerge/automerge-repo-solid-primitives@2.5.6':
+    resolution: {integrity: sha512-jwxktGP36AhxpPc9d3qi/k9WS7lIRqjfdWhn6i/Mzc6qe47COHe2QBvdDrDo6FTbFBoRz7+H5fyx3e2tfBIXfA==}
+    peerDependencies:
+      '@automerge/automerge': ^3.0.0
+      solid-js: ^1.9.4
+
+  '@automerge/automerge-repo@2.5.6':
+    resolution: {integrity: sha512-ZXM6TOAwm192g3+zIxYvlB+Z3O00NP+psErOwvbSype8fFO+dhc8tB/jPwfZJqmn1ULUz5w7gssKEynwcYFRSA==}
+
+  '@automerge/automerge@3.3.1':
+    resolution: {integrity: sha512-ZnVHlUCPB9w3CFlqWe/ex2q3JIpJ5g0jAlxpX4NxHpjad/WwnyeUM3hQC+IrPO1P5kPX18agxesnXBVUA/qlvg==}
+
+  '@automerge/prosemirror@0.2.0':
+    resolution: {integrity: sha512-Mixxftvfs12tKi7DsStobrQxFayoLJXhEjbrnmNnaQbMzwHrUzuwac+OUvw6ujbtXaulWX+JE8hAuHFAGRDsvQ==}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.18.6':
+    resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-syntax-jsx@7.29.7':
+    resolution: {integrity: sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@cbor-extract/cbor-extract-darwin-arm64@2.2.2':
+    resolution: {integrity: sha512-ZKZ/F8US7JR92J4DMct6cLW/Y66o2K576+zjlEN/MevH70bFIsB10wkZEQPLzl2oNh2SMGy55xpJ9JoBRl5DOA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cbor-extract/cbor-extract-darwin-x64@2.2.2':
+    resolution: {integrity: sha512-32b1mgc+P61Js+KW9VZv/c+xRw5EfmOcPx990JbCBSkYJFY0l25VinvyyWfl+3KjibQmAcYwmyzKF9J4DyKP/Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cbor-extract/cbor-extract-linux-arm64@2.2.2':
+    resolution: {integrity: sha512-wfqgzqCAy/Vn8i6WVIh7qZd0DdBFaWBjPdB6ma+Wihcjv0gHqD/mw3ouVv7kbbUNrab6dKEx/w3xQZEdeXIlzg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cbor-extract/cbor-extract-linux-arm@2.2.2':
+    resolution: {integrity: sha512-tNg0za41TpQfkhWjptD+0gSD2fggMiDCSacuIeELyb2xZhr7PrhPe5h66Jc67B/5dmpIhI2QOUtv4SBsricyYQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@cbor-extract/cbor-extract-linux-x64@2.2.2':
+    resolution: {integrity: sha512-rpiLnVEsqtPJ+mXTdx1rfz4RtUGYIUg2rUAZgd1KjiC1SehYUSkJN7Yh+aVfSjvCGtVP0/bfkQkXpPXKbmSUaA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@cbor-extract/cbor-extract-win32-x64@2.2.2':
+    resolution: {integrity: sha512-dI+9P7cfWxkTQ+oE+7Aa6onEn92PHgfWXZivjNheCRmTBDBf2fx6RyTi0cmgpYLnD1KLZK9ZYrMxaPZ4oiXhGA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tsconfig/strictest@2.0.8':
+    resolution: {integrity: sha512-XnQ7vNz5HRN0r88GYf1J9JJjqtZPiHt2woGJOo2dYqyHGGcd6OLGqSlBB6p1j9mpzja6Oe5BoPqWmeDx6X9rLw==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  babel-plugin-jsx-dom-expressions@0.40.7:
+    resolution: {integrity: sha512-/O6JWUmjv03OI9lL2ry9bUjpD5S3PclM55RRJEyCdcFZ5W2SEA/59d+l2hNsk3gI6kiWRdRPdOtqZmsQzFN1pQ==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+
+  babel-preset-solid@1.9.12:
+    resolution: {integrity: sha512-LLqnuKVDlKpyBlMPcH6qEvs/wmS9a+NczppxJ3ryS/c0O5IiSFOIBQi9GzyiGDSbcJpx4Gr87jyFTos1MyEuWg==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      solid-js: ^1.9.12
+    peerDependenciesMeta:
+      solid-js:
+        optional: true
+
+  base-x@4.0.1:
+    resolution: {integrity: sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==}
+
+  baseline-browser-mapping@2.10.42:
+    resolution: {integrity: sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  browserslist@4.28.5:
+    resolution: {integrity: sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  bs58@5.0.0:
+    resolution: {integrity: sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==}
+
+  bs58check@3.0.1:
+    resolution: {integrity: sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==}
+
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
+
+  caniuse-lite@1.0.30001803:
+    resolution: {integrity: sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==}
+
+  cbor-extract@2.2.2:
+    resolution: {integrity: sha512-hlSxxI9XO2yQfe9g6msd3g4xCfDqK5T5P0fRMLuaLHhxn4ViPrm+a+MUfhrvH2W962RGxcBwEGzLQyjbDG1gng==}
+    hasBin: true
+
+  cbor-x@1.6.4:
+    resolution: {integrity: sha512-UGKHjp6RHC6QuZ2yy5LCKm7MojM4716DwoSaqwQpaH4DvZvbBTGcoDNTiG9Y2lByXZYFEs9WRkS5tLl96IrF1Q==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  electron-to-chromium@1.5.389:
+    resolution: {integrity: sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  happy-dom@20.10.6:
+    resolution: {integrity: sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==}
+    engines: {node: '>=20.0.0'}
+
+  html-entities@2.3.3:
+    resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
+
+  is-what@4.1.16:
+    resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
+    engines: {node: '>=12.13'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  merge-anything@5.1.7:
+    resolution: {integrity: sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ==}
+    engines: {node: '>=12.13'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-gyp-build-optional-packages@5.1.1:
+    resolution: {integrity: sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==}
+    hasBin: true
+
+  node-releases@2.0.50:
+    resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
+    engines: {node: '>=18'}
+
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
+  ordered-map@0.1.0:
+    resolution: {integrity: sha512-ttpssyEqKXIeTapKeFTFG+oUCnrC+Fmyy1DPjys0vPJtccBE3baKDFTbJPDuKd9/XHbnKKe+KPQKTzBLri6Mtw==}
+
+  orderedmap@2.1.1:
+    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prosemirror-changeset@2.4.1:
+    resolution: {integrity: sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==}
+
+  prosemirror-history@1.5.0:
+    resolution: {integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==}
+
+  prosemirror-model@1.25.10:
+    resolution: {integrity: sha512-9n6rH4DbJU1eH4SxLt6Y0HhJIo6cZsb7DJ/30uob1hOKPeO6TAaMWI2tc7kwR92BjfPOU2fFHWbZLovLi3XQfA==}
+
+  prosemirror-schema-basic@1.2.4:
+    resolution: {integrity: sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==}
+
+  prosemirror-schema-list@1.5.1:
+    resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
+
+  prosemirror-state@1.4.4:
+    resolution: {integrity: sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==}
+
+  prosemirror-transform@1.12.0:
+    resolution: {integrity: sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==}
+
+  prosemirror-view@1.42.0:
+    resolution: {integrity: sha512-N54DF3OXNWDuP81G1kbfCys8ZzIjuL1VnvJ2mk5STSu/fNxWIcX/EutQLA3s9KR/2wVhgDi4hzBB/1fINVxk0A==}
+
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rope-sequence@1.3.4:
+    resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  seroval-plugins@1.5.4:
+    resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.5.4:
+    resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
+    engines: {node: '>=10'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  solid-js@1.9.14:
+    resolution: {integrity: sha512-sAEXC0Kk0S1EDg+8ysEWJDbYhA3RRoEjwuySUGlKIemeo0I5YZfOyumNjNs9Sv3y2nmhD+0rW66ag2HsMuQiGQ==}
+
+  solid-refresh@0.6.3:
+    resolution: {integrity: sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==}
+    peerDependencies:
+      solid-js: ^1.3
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  uuid@13.0.2:
+    resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
+    hasBin: true
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
+  vite-plugin-solid@2.11.12:
+    resolution: {integrity: sha512-FgjPcx2OwX9h6f28jli7A4bG7PP3te8uyakE5iqsmpq3Jqi1TWLgSroC9N6cMfGRU2zXsl4Q6ISvTr2VL0QHpA==}
+    peerDependencies:
+      '@testing-library/jest-dom': ^5.16.6 || ^5.17.0 || ^6.*
+      solid-js: ^1.7.2
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@testing-library/jest-dom':
+        optional: true
+
+  vite-plugin-wasm@3.6.0:
+    resolution: {integrity: sha512-mL/QPziiIA4RAA6DkaZZzOstdwbW5jO4Vz7Zenj0wieKWBlNvIvX5L5ljum9lcUX0ShNfBgCNLKTjNkRVVqcsw==}
+    peerDependencies:
+      vite: ^2 || ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitefu@1.1.3:
+    resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xstate@5.32.4:
+    resolution: {integrity: sha512-E5WtDB8DBs2ZWliz2Ry9XfbSZTbBRcK/cwefBot04qQ/L5SLP16xpnTDU4/ZFXuXFhNxi7JP2RhuoGwBnM+S4A==}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+snapshots:
+
+  '@automerge/automerge-repo-solid-primitives@2.5.6(@automerge/automerge@3.3.1)(solid-js@1.9.14)':
+    dependencies:
+      '@automerge/automerge': 3.3.1
+      solid-js: 1.9.14
+
+  '@automerge/automerge-repo@2.5.6':
+    dependencies:
+      '@automerge/automerge': 3.3.1
+      bs58check: 3.0.1
+      cbor-x: 1.6.4
+      debug: 4.4.3
+      eventemitter3: 5.0.4
+      fast-sha256: 1.3.0
+      uuid: 9.0.1
+      xstate: 5.32.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@automerge/automerge@3.3.1': {}
+
+  '@automerge/prosemirror@0.2.0':
+    dependencies:
+      '@automerge/automerge': 3.3.1
+      ordered-map: 0.1.0
+      prosemirror-changeset: 2.4.1
+      prosemirror-history: 1.5.0
+      prosemirror-model: 1.25.10
+      prosemirror-schema-basic: 1.2.4
+      prosemirror-schema-list: 1.5.1
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.0
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.5
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.18.6':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@cbor-extract/cbor-extract-darwin-arm64@2.2.2':
+    optional: true
+
+  '@cbor-extract/cbor-extract-darwin-x64@2.2.2':
+    optional: true
+
+  '@cbor-extract/cbor-extract-linux-arm64@2.2.2':
+    optional: true
+
+  '@cbor-extract/cbor-extract-linux-arm@2.2.2':
+    optional: true
+
+  '@cbor-extract/cbor-extract-linux-x64@2.2.2':
+    optional: true
+
+  '@cbor-extract/cbor-extract-win32-x64@2.2.2':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@noble/hashes@1.8.0': {}
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tsconfig/strictest@2.0.8': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@24.13.3':
+    dependencies:
+      undici-types: 7.18.2
+
+  '@types/uuid@10.0.0': {}
+
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 24.13.3
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@24.13.3))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@24.13.3)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  assertion-error@2.0.1: {}
+
+  babel-plugin-jsx-dom-expressions@0.40.7(@babel/core@7.29.7):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      '@babel/types': 7.29.7
+      html-entities: 2.3.3
+      parse5: 7.3.0
+
+  babel-preset-solid@1.9.12(@babel/core@7.29.7)(solid-js@1.9.14):
+    dependencies:
+      '@babel/core': 7.29.7
+      babel-plugin-jsx-dom-expressions: 0.40.7(@babel/core@7.29.7)
+    optionalDependencies:
+      solid-js: 1.9.14
+
+  base-x@4.0.1: {}
+
+  baseline-browser-mapping@2.10.42: {}
+
+  browserslist@4.28.5:
+    dependencies:
+      baseline-browser-mapping: 2.10.42
+      caniuse-lite: 1.0.30001803
+      electron-to-chromium: 1.5.389
+      node-releases: 2.0.50
+      update-browserslist-db: 1.2.3(browserslist@4.28.5)
+
+  bs58@5.0.0:
+    dependencies:
+      base-x: 4.0.1
+
+  bs58check@3.0.1:
+    dependencies:
+      '@noble/hashes': 1.8.0
+      bs58: 5.0.0
+
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 24.13.3
+
+  caniuse-lite@1.0.30001803: {}
+
+  cbor-extract@2.2.2:
+    dependencies:
+      node-gyp-build-optional-packages: 5.1.1
+    optionalDependencies:
+      '@cbor-extract/cbor-extract-darwin-arm64': 2.2.2
+      '@cbor-extract/cbor-extract-darwin-x64': 2.2.2
+      '@cbor-extract/cbor-extract-linux-arm': 2.2.2
+      '@cbor-extract/cbor-extract-linux-arm64': 2.2.2
+      '@cbor-extract/cbor-extract-linux-x64': 2.2.2
+      '@cbor-extract/cbor-extract-win32-x64': 2.2.2
+    optional: true
+
+  cbor-x@1.6.4:
+    optionalDependencies:
+      cbor-extract: 2.2.2
+
+  chai@6.2.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  csstype@3.2.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  detect-libc@2.1.2:
+    optional: true
+
+  electron-to-chromium@1.5.389: {}
+
+  entities@6.0.1: {}
+
+  entities@7.0.1: {}
+
+  es-module-lexer@2.3.0: {}
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
+  escalade@3.2.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  eventemitter3@5.0.4: {}
+
+  expect-type@1.4.0: {}
+
+  fast-sha256@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  happy-dom@20.10.6:
+    dependencies:
+      '@types/node': 24.13.3
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  html-entities@2.3.3: {}
+
+  is-what@4.1.16: {}
+
+  js-tokens@4.0.0: {}
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  merge-anything@5.1.7:
+    dependencies:
+      is-what: 4.1.16
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.15: {}
+
+  node-gyp-build-optional-packages@5.1.1:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
+
+  node-releases@2.0.50: {}
+
+  obug@2.1.3: {}
+
+  ordered-map@0.1.0: {}
+
+  orderedmap@2.1.1: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  postcss@8.5.16:
+    dependencies:
+      nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  prosemirror-changeset@2.4.1:
+    dependencies:
+      prosemirror-transform: 1.12.0
+
+  prosemirror-history@1.5.0:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.0
+      rope-sequence: 1.3.4
+
+  prosemirror-model@1.25.10:
+    dependencies:
+      orderedmap: 2.1.1
+
+  prosemirror-schema-basic@1.2.4:
+    dependencies:
+      prosemirror-model: 1.25.10
+
+  prosemirror-schema-list@1.5.1:
+    dependencies:
+      prosemirror-model: 1.25.10
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-state@1.4.4:
+    dependencies:
+      prosemirror-model: 1.25.10
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.0
+
+  prosemirror-transform@1.12.0:
+    dependencies:
+      prosemirror-model: 1.25.10
+
+  prosemirror-view@1.42.0:
+    dependencies:
+      prosemirror-model: 1.25.10
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  rollup@4.62.2:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
+      fsevents: 2.3.3
+
+  rope-sequence@1.3.4: {}
+
+  semver@6.3.1: {}
+
+  seroval-plugins@1.5.4(seroval@1.5.4):
+    dependencies:
+      seroval: 1.5.4
+
+  seroval@1.5.4: {}
+
+  siginfo@2.0.0: {}
+
+  solid-js@1.9.14:
+    dependencies:
+      csstype: 3.2.3
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
+
+  solid-refresh@0.6.3(solid-js@1.9.14):
+    dependencies:
+      '@babel/generator': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/types': 7.29.7
+      solid-js: 1.9.14
+    transitivePeerDependencies:
+      - supports-color
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
+
+  typescript@6.0.3: {}
+
+  undici-types@7.18.2: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.5):
+    dependencies:
+      browserslist: 4.28.5
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  uuid@13.0.2: {}
+
+  uuid@9.0.1: {}
+
+  vite-plugin-solid@2.11.12(solid-js@1.9.14)(vite@7.3.6(@types/node@24.13.3)):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@types/babel__core': 7.20.5
+      babel-preset-solid: 1.9.12(@babel/core@7.29.7)(solid-js@1.9.14)
+      merge-anything: 5.1.7
+      solid-js: 1.9.14
+      solid-refresh: 0.6.3(solid-js@1.9.14)
+      vite: 7.3.6(@types/node@24.13.3)
+      vitefu: 1.1.3(vite@7.3.6(@types/node@24.13.3))
+    transitivePeerDependencies:
+      - supports-color
+
+  vite-plugin-wasm@3.6.0(vite@7.3.6(@types/node@24.13.3)):
+    dependencies:
+      vite: 7.3.6(@types/node@24.13.3)
+
+  vite@7.3.6(@types/node@24.13.3):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rollup: 4.62.2
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.3
+      fsevents: 2.3.3
+
+  vitefu@1.1.3(vite@7.3.6(@types/node@24.13.3)):
+    optionalDependencies:
+      vite: 7.3.6(@types/node@24.13.3)
+
+  vitest@4.1.10(@types/node@24.13.3)(happy-dom@20.10.6)(vite@7.3.6(@types/node@24.13.3)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@24.13.3))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.6(@types/node@24.13.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.3
+      happy-dom: 20.10.6
+    transitivePeerDependencies:
+      - msw
+
+  whatwg-mimetype@3.0.0: {}
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  ws@8.21.0: {}
+
+  xstate@5.32.4: {}
+
+  yallist@3.1.1: {}

--- a/packages/documents/test/cell-operations.test.ts
+++ b/packages/documents/test/cell-operations.test.ts
@@ -1,0 +1,139 @@
+import { SimpleOlog, Type } from "catcolab-logics/simple-olog";
+import { describe, expect, test } from "vitest";
+
+// RFC-0006 "Further details on notebook editing": duplicating, re-ordering and
+// deleting cells, getting a cell by id, and subscribing to changes.
+import { createBinder, RichText } from "catcolab-documents";
+
+async function threeObjectNotebook() {
+    const binder = createBinder();
+    const notebook = await binder.createNotebook(SimpleOlog, { title: "An Olog" });
+
+    const a = notebook.add(Type, { label: "A" });
+    const b = notebook.add(Type, { label: "B" });
+    const c = notebook.add(Type, { label: "C" });
+
+    function names() {
+        return notebook
+            .cellsOf(Type)
+            .map((cell) => cell.label)
+            .join(", ");
+    }
+
+    return { notebook, a, b, c, names };
+}
+
+describe.skip("duplicating cells", () => {
+    test("copies keep the shape, get fresh identities and update independently", async () => {
+        const binder = createBinder();
+        const notebook = await binder.createNotebook(SimpleOlog, { title: "An Olog" });
+
+        const a = notebook.add(Type, { label: "A" });
+        const b = a.duplicate();
+        b.update({
+            label: `B (copy of ${a.label})`,
+        });
+
+        expect(a.label).toBe("A");
+        expect(b.label).toBe("B (copy of A)");
+        expect(b.id).not.toBe(a.id);
+        expect(notebook.cellsOf(Type).length).toBe(2);
+    });
+});
+
+describe.skip("re-ordering cells", () => {
+    test("moveUp and moveDown shift a cell one position; moveTo moves to an index", async () => {
+        const { a, b, c, names } = await threeObjectNotebook();
+
+        c.moveUp();
+        expect(names()).toBe("A, C, B");
+
+        a.moveDown();
+        expect(names()).toBe("C, A, B");
+
+        b.moveTo(0);
+        expect(names()).toBe("B, C, A");
+    });
+
+    test("impossible moves are silent no-ops and out-of-range targets clamp", async () => {
+        const { a, b, c, names } = await threeObjectNotebook();
+
+        a.moveUp();
+        c.moveDown();
+        expect(names()).toBe("A, B, C");
+
+        b.moveTo(99);
+        expect(names()).toBe("A, C, B");
+    });
+});
+
+describe.skip("deleting cells", () => {
+    test("deleting a cell removes it from the notebook's order and contents", async () => {
+        const { b, names } = await threeObjectNotebook();
+
+        expect(names()).toBe("A, B, C");
+        b.delete();
+        expect(names()).toBe("A, C");
+    });
+
+    test("rich-text cells can be deleted in the same way", async () => {
+        const { notebook } = await threeObjectNotebook();
+
+        const note = notebook.add(RichText, { content: "A note." });
+        expect(notebook.cells().length).toBe(4);
+        note.delete();
+        expect(notebook.cells().length).toBe(3);
+    });
+
+    test("after deletion, reading fields off the stale handle returns undefined", async () => {
+        const { b } = await threeObjectNotebook();
+
+        b.delete();
+        expect(b.label).toBeUndefined();
+    });
+
+    test("deleting an already-deleted cell is a silent no-op", async () => {
+        const { b, names } = await threeObjectNotebook();
+
+        b.delete();
+        b.delete();
+        expect(names()).toBe("A, C");
+    });
+});
+
+describe.skip("getting a cell by id", () => {
+    test("get retrieves a cell by id, filtered by the type of cell", async () => {
+        const { notebook, a } = await threeObjectNotebook();
+
+        const retrievedA = notebook.get(Type, a.id);
+        expect(retrievedA.tag).toBe("Ok");
+        if (retrievedA.tag !== "Ok") {
+            return;
+        }
+        expect(retrievedA.content.label).toBe("A");
+    });
+});
+
+describe.skip("subscribing to changes", () => {
+    test("onChange triggers on any change to the notebook, with no arguments", async () => {
+        const { notebook, a } = await threeObjectNotebook();
+
+        const calls: unknown[][] = [];
+        const unsubscribe = notebook.onChange((...args: unknown[]) => {
+            calls.push(args);
+        });
+
+        a.update({ label: "A2" });
+        expect(calls.length).toBeGreaterThan(0);
+        expect(calls[0]).toEqual([]);
+
+        const before = calls.length;
+        notebook.add(Type, { label: "D" });
+        expect(calls.length).toBeGreaterThan(before);
+
+        unsubscribe();
+        const afterUnsubscribe = calls.length;
+        notebook.add(Type, { label: "E" });
+        expect(calls.length).toBe(afterUnsubscribe);
+    });
+});

--- a/packages/documents/test/cells.test.ts
+++ b/packages/documents/test/cells.test.ts
@@ -1,0 +1,97 @@
+import { Aspect, SimpleOlog, Type } from "catcolab-logics/simple-olog";
+import { Entity, Mapping, SimpleSchema } from "catcolab-logics/simple-schema";
+import { describe, expect, test } from "vitest";
+
+// RFC-0006 "Iterating through cells".
+//
+// A `cells` method iterates through all cells of the notebook; `cellsOf`
+// filters by cell type (or by `Shape`, covered in shapes.test.ts). Neither
+// recurses into instantiations.
+import { CellKind, createBinder, Instantiation, RichText } from "catcolab-documents";
+
+describe.skip("iterating through cells", () => {
+    test("cells() iterates all cells with kind discriminants", async () => {
+        const binder = createBinder();
+        const notebook = await binder.createNotebook(SimpleOlog, { title: "An Olog" });
+
+        const intro = notebook.add(RichText, { content: "We define a simple olog." });
+        const source = notebook.add(Type, { label: "A" });
+        const target = notebook.add(Type, { label: "B" });
+        const arrow = notebook.add(Aspect, { label: "has", from: source, to: target });
+
+        notebook.update({ title: "A simple Olog example" });
+        intro.update({
+            content: "We define a simple olog with two objects and one arrow.",
+        });
+        source.update({ label: "Source" });
+        arrow.update({ label: "has as", from: source, to: target });
+
+        const lines: string[] = [];
+        for (const cell of notebook.cells()) {
+            switch (cell.kind) {
+                case CellKind.RichText:
+                    lines.push(`text: ${cell.content}`);
+                    break;
+                case CellKind.Object:
+                    lines.push(`object: ${cell.label} type: ${cell.type.obType.content}`);
+                    break;
+                case CellKind.Morphism:
+                    lines.push(`morphism: ${cell.label} type tag: ${cell.type.morType.tag}`);
+                    break;
+            }
+        }
+
+        expect(lines).toEqual([
+            "text: We define a simple olog with two objects and one arrow.",
+            "object: Source type: Object",
+            "object: B type: Object",
+            "morphism: has as type tag: Hom",
+        ]);
+    });
+
+    test("cellsOf() filters cells by cell type", async () => {
+        const binder = createBinder();
+        const notebook = await binder.createNotebook(SimpleSchema, { title: "Example schema" });
+
+        const person = notebook.add(Entity, { label: "Person" });
+        const company = notebook.add(Entity, { label: "Company" });
+
+        notebook.add(Mapping, { label: "employer", from: person, to: company });
+
+        const entities = notebook.cellsOf(Entity);
+        const mappings = notebook.cellsOf(Mapping);
+
+        expect(entities.map((cell) => cell.label).join(", ")).toBe("Person, Company");
+        expect(mappings.map((cell) => cell.label).join(", ")).toBe("employer");
+    });
+
+    test("cells and cellsOf do not recurse into instantiations", async () => {
+        const binder = createBinder();
+        const notebook = await binder.createNotebook(SimpleSchema, { title: "Example schema" });
+
+        const person = notebook.add(Entity, { label: "Person" });
+        const company = notebook.add(Entity, { label: "Company" });
+        notebook.add(Mapping, { label: "employer", from: person, to: company });
+
+        const anotherSchema = await binder.createNotebook(SimpleSchema, {
+            title: "Another schema",
+        });
+        const enterprise = anotherSchema.add(Entity, { label: "Enterprise" });
+        const building = anotherSchema.add(Entity, { label: "Building" });
+        anotherSchema.add(Mapping, { label: "owner", from: enterprise, to: building });
+
+        notebook.add(Instantiation, {
+            label: "ImportedSchema",
+            model: anotherSchema,
+            specializations: [{ object: enterprise, as: company }],
+        });
+
+        const instantiations = notebook.cellsOf(Instantiation);
+        const entities = notebook.cellsOf(Entity);
+        const mappings = notebook.cellsOf(Mapping);
+
+        expect(instantiations.map((cell) => cell.label).join(", ")).toBe("ImportedSchema");
+        expect(entities.map((cell) => cell.label).join(", ")).toBe("Person, Company");
+        expect(mappings.map((cell) => cell.label).join(", ")).toBe("employer");
+    });
+});

--- a/packages/documents/test/creating-and-editing.test.ts
+++ b/packages/documents/test/creating-and-editing.test.ts
@@ -1,0 +1,90 @@
+import { Aspect, SimpleOlog, Type } from "catcolab-logics/simple-olog";
+import { describe, expect, test } from "vitest";
+
+// RFC-0006 "Creating notebooks" and "Editing notebooks".
+//
+// All documents are created through a binder instance. Calling `createBinder()`
+// with no arguments uses a plain in-memory store for documents. All cells are
+// added with a single `add` method: `RichText` for prose, or an object/morphism
+// type from the logic for formal cells.
+import { createBinder, RichText } from "catcolab-documents";
+
+describe.skip("creating and editing notebooks", () => {
+    test("createNotebook creates a titled notebook for a logic", async () => {
+        const binder = createBinder();
+        const notebook = await binder.createNotebook(SimpleOlog, { title: "An Olog" });
+
+        expect(notebook.title).toBe("An Olog");
+        expect(notebook.document.theory).toBe("simple-olog");
+        expect(notebook.cells().length).toBe(0);
+    });
+
+    test("cells are added with a single `add` method", async () => {
+        const binder = createBinder();
+        const notebook = await binder.createNotebook(SimpleOlog, { title: "An Olog" });
+
+        const intro = notebook.add(RichText, { content: "We define a simple olog." });
+
+        const source = notebook.add(Type, { label: "A" });
+        const target = notebook.add(Type, { label: "B" });
+        const arrow = notebook.add(Aspect, { label: "has", from: source, to: target });
+
+        expect(intro.content).toBe("We define a simple olog.");
+        expect(source.label).toBe("A");
+        expect(target.label).toBe("B");
+        expect(arrow.label).toBe("has");
+        expect(arrow.from?.id).toBe(source.id);
+        expect(arrow.to?.id).toBe(target.id);
+        expect(notebook.cells().length).toBe(4);
+    });
+
+    test("the notebook and any cell can be updated", async () => {
+        const binder = createBinder();
+        const notebook = await binder.createNotebook(SimpleOlog, { title: "An Olog" });
+
+        const intro = notebook.add(RichText, { content: "We define a simple olog." });
+        const source = notebook.add(Type, { label: "A" });
+        const target = notebook.add(Type, { label: "B" });
+        const arrow = notebook.add(Aspect, { label: "has", from: source, to: target });
+
+        notebook.update({ title: "A simple Olog example" });
+
+        intro.update({
+            content: "We define a simple olog with two objects and one arrow.",
+        });
+
+        source.update({
+            label: "Source",
+        });
+
+        arrow.update({
+            label: "has as",
+            from: source,
+            to: target,
+        });
+
+        expect(notebook.title).toBe("A simple Olog example");
+        expect(intro.content).toBe("We define a simple olog with two objects and one arrow.");
+        expect(source.label).toBe("Source");
+        expect(arrow.label).toBe("has as");
+        expect(arrow.from?.id).toBe(source.id);
+        expect(arrow.to?.id).toBe(target.id);
+    });
+
+    test("partial updates leave the other fields intact", async () => {
+        const binder = createBinder();
+        const notebook = await binder.createNotebook(SimpleOlog, { title: "An Olog" });
+
+        const source = notebook.add(Type, { label: "A" });
+        const target = notebook.add(Type, { label: "B" });
+        const arrow = notebook.add(Aspect, { label: "has", from: source, to: target });
+
+        arrow.update({
+            label: "has as example",
+        });
+
+        expect(arrow.label).toBe("has as example");
+        expect(arrow.from?.id).toBe(source.id);
+        expect(arrow.to?.id).toBe(target.id);
+    });
+});

--- a/packages/documents/test/diagrams.test.ts
+++ b/packages/documents/test/diagrams.test.ts
@@ -1,0 +1,54 @@
+import { Aspect, SimpleOlog, Type } from "catcolab-logics/simple-olog";
+import { describe, expect, test } from "vitest";
+
+// RFC-0006 "Diagram notebooks": diagrams are another type of notebook with a
+// very similar editing interface.
+import { createBinder, RichText } from "catcolab-documents";
+
+async function ologModel() {
+    const binder = createBinder();
+    const model = await binder.createNotebook(SimpleOlog, { title: "An Olog" });
+
+    const A = model.add(Type, { label: "A" });
+    const B = model.add(Type, { label: "B" });
+    const has = model.add(Aspect, { label: "has", from: A, to: B });
+
+    return { binder, model, A, B, has };
+}
+
+describe.skip("diagram notebooks", () => {
+    test("a diagram notebook is created in a model", async () => {
+        const { binder, model } = await ologModel();
+
+        const diagram = await binder.createNotebook(SimpleOlog.Diagram, {
+            title: "Olog diagram",
+            in: model,
+        });
+
+        expect(diagram.title).toBe("Olog diagram");
+        expect(diagram.theory).toBe("simple-olog");
+    });
+
+    test("cells are added over the model", async () => {
+        const { binder, model, A, B, has } = await ologModel();
+
+        const diagram = await binder.createNotebook(SimpleOlog.Diagram, {
+            title: "Olog diagram",
+            in: model,
+        });
+
+        diagram.add(RichText, { content: "We picture two instances of the olog." });
+
+        const x = diagram.add(SimpleOlog.Diagram.Individual, { label: "x", over: A });
+        const y = diagram.add(SimpleOlog.Diagram.Individual, { label: "y", over: B });
+
+        expect(x.over?.label).toBe("A");
+        expect(x.type.obType.content).toBe("Object");
+
+        const f = diagram.add(SimpleOlog.Diagram.Aspect, { from: x, to: y, over: has });
+
+        expect(f.over?.label).toBe("has");
+        expect(f.from?.label).toBe("x");
+        expect(f.to?.label).toBe("y");
+    });
+});

--- a/packages/documents/test/helpers/fake_backend.ts
+++ b/packages/documents/test/helpers/fake_backend.ts
@@ -1,0 +1,62 @@
+// A stand-in for the CatColab backend, modelled on its real RPC surface.
+//
+// The production backend is reached through a Qubit RPC client (see
+// packages/frontend/src/api/rpc.ts and the generated `QubitServer` type in
+// packages/backend/pkg/src/index.ts). Every method returns an `RpcResult<T>`,
+// a tagged `Ok`/`Err` union, and document reads come back as a `RefDoc`, a
+// tagged `Live`/`Readonly` union. We reproduce those shapes here so a store
+// backed by this backend has to unwrap them exactly like
+// `Api.createDoc`/`Api.fetchDocCacheEntry` do.
+//
+// The two methods a store uses:
+//
+//   * `new_ref(content)`: create a document from `content` under a fresh ref id,
+//     returning the ref id (the `_id` of a `StableRef`). Analog of
+//     `rpc.new_ref.mutate`, called by `Api.createDoc`.
+//   * `get_doc(refId)`: resolve a ref id to the Automerge document behind it.
+//     Analog of `rpc.get_doc.query`, whose `docId` the frontend then `find`s.
+//
+// The backend holds its own networked `Repo` in production; here the store and
+// backend share one in-memory `Repo`, and every document is served as `Live`
+// (the store `find`s it by `docId`).
+import { type DocumentId, Repo } from "@automerge/automerge-repo";
+import { v7 } from "uuid";
+
+import type { Document } from "catcolab-document-types";
+
+export type RpcResult<T> =
+    | { tag: "Ok"; content: T }
+    | { tag: "Err"; code: number; message: string };
+
+export type RefDoc = { tag: "Live"; docId: string; isDeleted: boolean };
+
+export class FakeBackend {
+    readonly serverHost = "test.catcolab.org";
+
+    /** The Automerge repo the backend serves documents out of. */
+    readonly repo = new Repo();
+
+    /** ref id -> Automerge document id, the mapping `get_doc` serves. */
+    private readonly refs = new Map<string, DocumentId>();
+
+    /**
+     * Analog of `rpc.new_ref.mutate`: take document *content*, create the repo
+     * document backend-side, and return a fresh ref id. This is what
+     * `Api.createDoc` calls, and what a store's `createHandle` calls.
+     */
+    async new_ref(content: Document): Promise<RpcResult<string>> {
+        const handle = this.repo.create<Document>(content as Document);
+        const refId = v7();
+        this.refs.set(refId, handle.documentId);
+        return { tag: "Ok", content: refId };
+    }
+
+    /** Analog of `rpc.get_doc.query`: ref id -> `RefDoc` (always `Live` here). */
+    async get_doc(refId: string): Promise<RpcResult<RefDoc>> {
+        const docId = this.refs.get(refId);
+        if (!docId) {
+            return { tag: "Err", code: 404, message: `Unknown document ${refId}` };
+        }
+        return { tag: "Ok", content: { tag: "Live", docId, isDeleted: false } };
+    }
+}

--- a/packages/documents/test/helpers/self_resolving.ts
+++ b/packages/documents/test/helpers/self_resolving.ts
@@ -1,0 +1,47 @@
+import { v7 } from "uuid";
+
+import type { DocumentStore } from "catcolab-documents";
+
+/**
+ * Build the `getDocumentRef`/`getHandle` pair a single-document store needs to
+ * resolve its *own* notebooks — the contract {@link DocumentStore} now requires,
+ * since `validate` resolves a notebook's own model by taking a reference to its
+ * handle. Each handle is assigned a stable id and registered so the shared
+ * recursive elaborator can fetch it back (via `getHandle`, then view its
+ * document with the store's own `getDocumentView`) and elaborate it against the
+ * host notebook's core theory (supplied by `validate`).
+ *
+ * Used by the test fixtures' stores so a no-instantiation notebook validates
+ * (the store can resolve its own handle) without each fixture reimplementing the
+ * recursive elaborator.
+ */
+export function selfResolving<Handle extends WeakKey>(): Pick<
+    DocumentStore<Handle>,
+    "getDocumentRef" | "getHandle"
+> {
+    const ids = new WeakMap<Handle, string>();
+    const byId = new Map<string, Handle>();
+
+    const idFor = (handle: Handle): string => {
+        let id = ids.get(handle);
+        if (!id) {
+            id = v7();
+            ids.set(handle, id);
+            byId.set(id, handle);
+        }
+        return id;
+    };
+
+    return {
+        getDocumentRef: (handle) => ({ id: idFor(handle), version: null, server: "" }),
+        getHandle: async (ref) => {
+            const handle = byId.get(ref.id);
+            return handle
+                ? { tag: "Ok", content: handle }
+                : {
+                      tag: "Err",
+                      content: [{ message: `Cannot resolve reference "${ref.id}".`, path: ["id"] }],
+                  };
+        },
+    };
+}

--- a/packages/documents/test/instances.test.ts
+++ b/packages/documents/test/instances.test.ts
@@ -1,0 +1,69 @@
+import { Attr, AttrType, Entity, Mapping, SimpleSchema } from "catcolab-logics/simple-schema";
+import { describe, expect, test } from "vitest";
+
+// RFC-0006 "Tabular instances": an instance API that mirrors the notebook API,
+// with `add` keyed by schema entities and a `rowsOf` that mirrors `cellsOf`.
+// Unlike cells, rows keep a separate `values` field to keep them in their own
+// namespace.
+import { createBinder } from "catcolab-documents";
+
+describe.skip("tabular instances", () => {
+    test("an instance of a schema has a similar add method and rowsOf", async () => {
+        const binder = createBinder();
+
+        const schema = await binder.createNotebook(SimpleSchema, { title: "Company schema" });
+        const person = schema.add(Entity, { label: "Person" });
+        const company = schema.add(Entity, { label: "Company" });
+        const str = schema.add(AttrType, { label: "String" });
+
+        schema.add(Mapping, { label: "employer", from: person, to: company });
+        schema.add(Attr, { label: "name", from: person, to: str });
+
+        const instance = await binder.createInstance(schema, { title: "Company instance" });
+        const acme = instance.add(company, {});
+        instance.add(person, { name: "Alice", employer: acme });
+        instance.add(person, { name: "Bob", employer: acme });
+
+        const names: unknown[] = [];
+        for (const row of instance.rowsOf(person)) {
+            names.push(row.values["name"]);
+        }
+        expect(names).toEqual(["Alice", "Bob"]);
+    });
+
+    test("logic shapes can be defined as notebooks of SimpleSchema", async () => {
+        const binder = createBinder();
+
+        const CausalLoop = await binder.createNotebook(SimpleSchema, { title: "Causal loop" });
+
+        const String = CausalLoop.add(AttrType, { label: "String" });
+
+        const Variable = CausalLoop.add(Entity, { label: "Variable" });
+        CausalLoop.add(Attr, { label: "name", from: Variable, to: String });
+
+        const PositiveLink = CausalLoop.add(Entity, { label: "PositiveLink" });
+        CausalLoop.add(Mapping, { label: "from", from: PositiveLink, to: Variable });
+        CausalLoop.add(Mapping, { label: "to", from: PositiveLink, to: Variable });
+
+        const NegativeLink = CausalLoop.add(Entity, { label: "NegativeLink" });
+        CausalLoop.add(Mapping, { label: "from", from: NegativeLink, to: Variable });
+        CausalLoop.add(Mapping, { label: "to", from: NegativeLink, to: Variable });
+
+        // Instances of `CausalLoop` are akin to notebooks of the actual
+        // `CausalLoop` logic.
+        const predatorPrey = await binder.createInstance(CausalLoop, { title: "Predator-prey" });
+
+        const foxes = predatorPrey.add(Variable, { name: "Foxes" });
+        const rabbits = predatorPrey.add(Variable, { name: "Rabbits" });
+
+        predatorPrey.add(PositiveLink, { from: rabbits, to: foxes });
+        predatorPrey.add(NegativeLink, { from: foxes, to: rabbits });
+
+        expect(predatorPrey.rowsOf(Variable).map((row) => row.values["name"])).toEqual([
+            "Foxes",
+            "Rabbits",
+        ]);
+        expect(predatorPrey.rowsOf(PositiveLink).length).toBe(1);
+        expect(predatorPrey.rowsOf(NegativeLink).length).toBe(1);
+    });
+});

--- a/packages/documents/test/instantiation.test.ts
+++ b/packages/documents/test/instantiation.test.ts
@@ -1,0 +1,35 @@
+import { SimpleOlog, Type } from "catcolab-logics/simple-olog";
+import { describe, expect, test } from "vitest";
+
+// RFC-0006 "Instantiation".
+//
+// Instantiation is just another cell type provided by `catcolab-documents`. The
+// initial implementation only supports instantiation of notebooks already
+// defined in the local binder.
+import { createBinder, Instantiation } from "catcolab-documents";
+
+describe.skip("instantiation", () => {
+    test("a notebook from the same binder can be instantiated with specializations", async () => {
+        const binder = createBinder();
+        const notebook = await binder.createNotebook(SimpleOlog, { title: "An Olog" });
+        const target = notebook.add(Type, { label: "B" });
+
+        const anotherOlog = await binder.createNotebook(SimpleOlog, { title: "Another Olog" });
+        const thing = anotherOlog.add(Type, { label: "Thing" });
+
+        const instantiation = notebook.add(Instantiation, {
+            label: "ImportedOlog",
+            model: anotherOlog,
+            // maps ImportedOlog.Thing <- B
+            specializations: [{ object: thing, as: target }],
+        });
+
+        expect(instantiation.label).toBe("ImportedOlog");
+        expect(notebook.cellsOf(Instantiation).length).toBe(1);
+        expect(notebook.cellsOf(Instantiation)[0]?.id).toBe(instantiation.id);
+
+        // Instantiating a valid notebook keeps this notebook valid.
+        const result = await notebook.validate();
+        expect(result.tag).toBe("Ok");
+    });
+});

--- a/packages/documents/test/migration.test.ts
+++ b/packages/documents/test/migration.test.ts
@@ -1,0 +1,42 @@
+import { Aspect, SimpleOlog, Type } from "catcolab-logics/simple-olog";
+import { Entity, Mapping, SimpleSchema } from "catcolab-logics/simple-schema";
+import { describe, expect, test } from "vitest";
+
+// RFC-0006 "Migrating between logics": `migrateTo` rewrites the document in
+// place and returns a `Result` carrying a notebook of the target shape.
+import { createBinder } from "catcolab-documents";
+
+describe.skip("migrating between logics", () => {
+    test("migrateTo rewrites an olog into a schema in place", async () => {
+        const binder = createBinder();
+        const olog = await binder.createNotebook(SimpleOlog, { title: "An Olog" });
+
+        const a = olog.add(Type, { label: "A" });
+        const b = olog.add(Type, { label: "B" });
+        olog.add(Aspect, { label: "has", from: a, to: b });
+
+        const migration = await olog.migrateTo(SimpleSchema);
+        expect(migration.tag).toBe("Ok");
+        if (migration.tag !== "Ok") {
+            return;
+        }
+        const schema = migration.content;
+
+        // The original document was rewritten in place, not copied.
+        expect(schema.document === olog.document).toBe(true);
+        expect(schema.document.theory).toBe("simple-schema");
+        expect(
+            schema
+                .cellsOf(Entity)
+                .map((cell) => cell.label)
+                .join(", "),
+        ).toBe("A, B");
+        expect(
+            schema
+                .cellsOf(Mapping)
+                .map((cell) => cell.label)
+                .join(", "),
+        ).toBe("has");
+        expect((await schema.validate()).tag).toBe("Ok");
+    });
+});

--- a/packages/documents/test/path-equations.test.ts
+++ b/packages/documents/test/path-equations.test.ts
@@ -1,0 +1,37 @@
+import { Entity, Mapping, SimpleSchema } from "catcolab-logics/simple-schema";
+import { describe, expect, test } from "vitest";
+
+// RFC-0006 "Path equations": `PathEquation` is another cell type, with a
+// `CellKind.PathEquation` discriminant, that a shape opts into via
+// `supportsEquations: true`.
+import { createBinder, PathEquation } from "catcolab-documents";
+
+describe.skip("path equations", () => {
+    test("a path equation cell relates two paths of morphisms", async () => {
+        const binder = createBinder();
+        const notebook = await binder.createNotebook(SimpleSchema, { title: "Example schema" });
+
+        const person = notebook.add(Entity, { label: "Person" });
+        const department = notebook.add(Entity, { label: "Department" });
+        const company = notebook.add(Entity, { label: "Company" });
+
+        const worksIn = notebook.add(Mapping, { label: "works in", from: person, to: department });
+        const partOf = notebook.add(Mapping, { label: "part of", from: department, to: company });
+        const employer = notebook.add(Mapping, { label: "employer", from: person, to: company });
+
+        // An employee's employer is the company their department is part of.
+        const equation = notebook.add(PathEquation, {
+            label: "employment",
+            lhs: [worksIn, partOf],
+            rhs: [employer],
+        });
+
+        expect(equation.label).toBe("employment");
+        expect(equation.lhs.map((step) => step.label).join(" ; ")).toBe("works in ; part of");
+        expect(equation.rhs.map((step) => step.label).join(" ; ")).toBe("employer");
+        expect(notebook.cellsOf(PathEquation).length).toBe(1);
+
+        const result = await notebook.validate();
+        expect(result.tag).toBe("Ok");
+    });
+});

--- a/packages/documents/test/richtext-prosemirror.test.tsx
+++ b/packages/documents/test/richtext-prosemirror.test.tsx
@@ -1,0 +1,183 @@
+// RFC-0006 "Rich text handling".
+//
+// Rich text is special: editor components bypass the notebook interface to
+// work with ProseMirror and the Automerge plugin for ProseMirror. A store
+// defines `getRichTextRef`, which adds an `editorRef` field to `RichText`
+// cells that the editor component makes use of.
+import * as Automerge from "@automerge/automerge";
+import { type Doc, getBackend, getObjectId, type Patch } from "@automerge/automerge";
+import {
+    type DocHandle,
+    type DocHandleChangePayload,
+    type Prop,
+    Repo,
+} from "@automerge/automerge-repo";
+import { makeDocumentProjection } from "@automerge/automerge-repo-solid-primitives";
+import { basicSchemaAdapter, init } from "@automerge/prosemirror";
+import { SimpleOlog } from "catcolab-logics/simple-olog";
+import { EditorState } from "prosemirror-state";
+import { EditorView } from "prosemirror-view";
+import { createEffect, createSignal, For, onCleanup } from "solid-js";
+import { render } from "solid-js/web";
+import { describe, expect, test } from "vitest";
+
+import type { Document } from "catcolab-document-types";
+import {
+    createBinder,
+    defineShape,
+    type DocumentStore,
+    RichText,
+    type RichTextCell,
+} from "catcolab-documents";
+
+type StoreHandle = {
+    readonly docHandle: DocHandle<Document>;
+    readonly docView: Document;
+};
+
+function makeAutomergeRichTextStore(): DocumentStore<StoreHandle> {
+    const repo = new Repo();
+    return {
+        createHandle: async (initialDoc) => {
+            const docHandle = repo.create<Document>(initialDoc as Document);
+            return { docHandle, docView: makeDocumentProjection(docHandle) };
+        },
+        getDocumentView: (handle) => handle.docView,
+        changeDocument: (handle, fn) => handle.docHandle.change(fn),
+        subscribe: (handle, callback) => {
+            handle.docHandle.on("change", callback);
+            return () => handle.docHandle.off("change", callback);
+        },
+        copyValue: (handle, value) => {
+            const objId = getObjectId(value as object);
+            if (objId === null) {
+                throw new Error("value is not part of the document");
+            }
+            return getBackend(handle.docHandle.doc()).materialize(objId) as typeof value;
+        },
+        getDocumentRef: (handle) => ({
+            id: handle.docHandle.documentId,
+            version: null,
+            server: "",
+        }),
+        getHandle: async () => ({
+            tag: "Err",
+            content: [{ message: "This store cannot resolve references." }],
+        }),
+        // This is needed for the RichTextCellEditor to bypass the notebook interface.
+        getRichTextRef: (handle, cellId) => ({
+            docHandle: handle.docHandle,
+            path: ["notebook", "cellContents", cellId, "content"],
+        }),
+    };
+}
+
+function isPathPrefixOf(candidate: Prop[], target: readonly Prop[]) {
+    return (
+        candidate.length <= target.length &&
+        candidate.every((part, index) => part === target[index])
+    );
+}
+
+function hasStructuralReplacement(patches: Patch[], textPath: readonly Prop[]) {
+    return patches.some(
+        (patch) =>
+            (patch.action === "put" || patch.action === "del") &&
+            isPathPrefixOf(patch.path, textPath),
+    );
+}
+
+function RichTextCellEditor(props: { cell: RichTextCell; onView: (view: EditorView) => void }) {
+    let editorRoot!: HTMLDivElement;
+    const [reinitTrigger, setReinitTrigger] = createSignal(0);
+
+    createEffect(() => {
+        void reinitTrigger();
+
+        // The editorRef is exposed on the cell.
+        const ref = props.cell.editorRef;
+        if (!ref) {
+            throw new Error("RichTextCellEditor: cell has no editorRef");
+        }
+
+        const docHandle = ref.docHandle as DocHandle<unknown>;
+        const path = [...ref.path];
+        const { schema, pmDoc, plugin } = init(docHandle, path, {
+            schemaAdapter: basicSchemaAdapter,
+        });
+        const state = EditorState.create({ schema, plugins: [plugin], doc: pmDoc });
+        const view: EditorView = new EditorView(editorRoot, {
+            state,
+            dispatchTransaction: (tx) => {
+                if (!view.isDestroyed) {
+                    view.updateState(view.state.apply(tx));
+                }
+            },
+        });
+
+        const onRemoteChange = (payload: DocHandleChangePayload<unknown>) => {
+            if (hasStructuralReplacement(payload.patches, path)) {
+                setReinitTrigger((n) => n + 1);
+            }
+        };
+
+        docHandle.on("change", onRemoteChange);
+        props.onView(view);
+        onCleanup(() => {
+            docHandle.off("change", onRemoteChange);
+            view.destroy();
+        });
+    });
+
+    return <div class="rich-text-cell" ref={editorRoot} />;
+}
+
+describe.skip("rich text handling", () => {
+    test("editorRef lets ProseMirror edit rich text cells through Automerge", async () => {
+        const InformalShape = defineShape({ informal: [RichText] });
+
+        const store = makeAutomergeRichTextStore();
+        const frontendBinder = createBinder(store);
+        const notebook = await frontendBinder.createNotebook(SimpleOlog, { title: "Notes" });
+        const note = notebook.add(RichText, { content: "" });
+
+        let view: EditorView | undefined;
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+        const dispose = render(
+            () => (
+                <For each={notebook.cellsOf(InformalShape)}>
+                    {(cell) => (
+                        <RichTextCellEditor cell={cell} onView={(nextView) => (view = nextView)} />
+                    )}
+                </For>
+            ),
+            container,
+        );
+
+        if (!view) {
+            throw new Error("Expected the editor view to be created.");
+        }
+        view.dispatch(view.state.tr.insertText("Hello from ProseMirror"));
+        expect(note.content).toBe("Hello from ProseMirror");
+
+        const ref = note.editorRef;
+        if (!ref) {
+            throw new Error("Expected the note to expose an editorRef.");
+        }
+        const docHandle = ref.docHandle as DocHandle<Document>;
+        docHandle.change((doc) => {
+            Automerge.splice(doc as Doc<unknown>, [...ref.path], 0, 5, "Howdy");
+        });
+        expect(view.state.doc.textContent).toBe("Howdy from ProseMirror");
+
+        const staleView = view;
+        note.update({ content: "Replaced programmatically" });
+        expect(view).not.toBe(staleView);
+        expect(staleView?.isDestroyed).toBe(true);
+        expect(view.state.doc.textContent).toBe("Replaced programmatically");
+
+        dispose();
+        container.remove();
+    });
+});

--- a/packages/documents/test/runtime-errors.test.ts
+++ b/packages/documents/test/runtime-errors.test.ts
@@ -1,0 +1,90 @@
+import { PetriNet, Place, Transition } from "catcolab-logics/petri-net";
+import { Aspect, SimpleOlog, Type } from "catcolab-logics/simple-olog";
+import { AttrType, Mapping, SimpleSchema } from "catcolab-logics/simple-schema";
+import { describe, expect, test } from "vitest";
+
+// RFC-0006 "Runtime errors" and "Further runtime errors".
+//
+// Since the API can also be used from JavaScript directly without type
+// checking, the same invalid inputs that TypeScript catches are also rejected
+// at runtime. Each one throws an error carrying a Standard Schema compatible
+// `issues` array. (The `as never` casts bypass the static checks that
+// type-errors.test-d.ts covers.)
+import { createBinder } from "catcolab-documents";
+
+/** Run `fn`, expecting it to throw an error with a Standard Schema compatible
+ * `issues` array; returns the joined issue messages. */
+function issuesOf(fn: () => unknown): string {
+    try {
+        fn();
+    } catch (error) {
+        const issues = (error as { issues?: { message: string }[] }).issues;
+        if (!issues) {
+            throw new Error("Expected the thrown error to carry an `issues` array.", {
+                cause: error,
+            });
+        }
+        return issues.map((issue) => issue.message).join("; ");
+    }
+    throw new Error("Expected the call to throw.");
+}
+
+describe.skip("runtime errors", () => {
+    test("invalid shapes throw with a Standard Schema compatible issues array", async () => {
+        const binder = createBinder();
+        const notebook = await binder.createNotebook(SimpleOlog, { title: "An Olog" });
+
+        const source = notebook.add(Type, { label: "A" });
+        const target = notebook.add(Type, { label: "B" });
+        const arrow = notebook.add(Aspect, { label: "has", from: source, to: target });
+
+        // Arrays are not valid endpoints in a simple olog.
+        expect(issuesOf(() => arrow.update({ from: [source] } as never))).toBe(
+            "`from` must be an object cell or null (was an array)",
+        );
+
+        // Arrays are not valid endpoints in a simple olog.
+        expect(
+            issuesOf(() =>
+                notebook.add(Aspect, { label: "bad", from: [source, target], to: target } as never),
+            ),
+        ).toBe("`from` must be an object cell or null (was an array)");
+
+        // Missing required fields.
+        expect(issuesOf(() => notebook.add(Aspect, {} as never))).toBe(
+            "`from` must be an object cell or null (was missing); " +
+                "`label` must be a string or null (was missing); " +
+                "`to` must be an object cell or null (was missing)",
+        );
+
+        // null fields are allowed.
+        expect(() => notebook.add(Aspect, { label: null, from: null, to: null })).not.toThrow();
+    });
+
+    test("a mapping's endpoints must be entities, not attribute types", async () => {
+        const binder = createBinder();
+        const schema = await binder.createNotebook(SimpleSchema, { title: "Example schema" });
+
+        const str = schema.add(AttrType, { label: "String" });
+
+        expect(
+            issuesOf(() => schema.add(Mapping, { label: "bad", from: str, to: str } as never)),
+        ).toBe(
+            "`from` must be an object cell of type Entity (was an object cell of type AttrType); " +
+                "`to` must be an object cell of type Entity (was an object cell of type AttrType)",
+        );
+    });
+
+    test("validation adapts to the underlying logic", async () => {
+        const binder = createBinder();
+        const notebook = await binder.createNotebook(PetriNet, { title: "Example Petri-net" });
+
+        const a = notebook.add(Place, { label: "A" });
+        const c = notebook.add(Place, { label: "C" });
+
+        // Petri net transitions require arrays of places.
+        expect(
+            issuesOf(() => notebook.add(Transition, { label: "bad", from: a, to: [c] } as never)),
+        ).toBe("`from` must be an array or null (was an object cell of type Object)");
+    });
+});

--- a/packages/documents/test/serialization.test.ts
+++ b/packages/documents/test/serialization.test.ts
@@ -1,0 +1,50 @@
+import { PetriNet } from "catcolab-logics/petri-net";
+import { SimpleOlog } from "catcolab-logics/simple-olog";
+import { describe, expect, test } from "vitest";
+
+// RFC-0006 "Serialization": dumping a notebook, loading it back, shape
+// mismatches, and loading from a `DocumentRef`.
+import { createBinder } from "catcolab-documents";
+
+describe.skip("serialization", () => {
+    test("a dumped notebook can be loaded", async () => {
+        const binder = createBinder();
+        const notebook = await binder.createNotebook(PetriNet, { title: "Example Petri-net" });
+
+        const petriNetData = notebook.dump();
+
+        const loaded = await binder.loadNotebook(PetriNet, petriNetData);
+        expect(loaded.tag).toBe("Ok");
+        if (loaded.tag !== "Ok") {
+            return;
+        }
+        expect(loaded.content.title).toBe("Example Petri-net");
+    });
+
+    test("loading a document with the wrong shape yields an Err describing the mismatch", async () => {
+        const binder = createBinder();
+        const notebook = await binder.createNotebook(PetriNet, { title: "Example Petri-net" });
+
+        const petriNetData = notebook.dump();
+
+        const wrong = await binder.loadNotebook(SimpleOlog, petriNetData);
+        expect(wrong.tag).toBe("Err");
+        if (wrong.tag !== "Err") {
+            return;
+        }
+        expect(wrong.content.map((issue) => issue.message).join("; ")).toBe(
+            'Cannot load document with theory "petri-net" using a shape with theory "simple-olog".',
+        );
+    });
+
+    test("loadNotebookFromRef returns an Err when the store cannot resolve the reference", async () => {
+        const binder = createBinder();
+
+        const loaded = await binder.loadNotebookFromRef(PetriNet, {
+            id: "some-document-id",
+            version: null,
+        });
+
+        expect(loaded.tag).toBe("Err");
+    });
+});

--- a/packages/documents/test/shapes.test-d.ts
+++ b/packages/documents/test/shapes.test-d.ts
@@ -1,0 +1,345 @@
+import { SimpleOlog } from "catcolab-logics/simple-olog";
+import { SimpleSchema } from "catcolab-logics/simple-schema";
+import { describe, test } from "vitest";
+
+// RFC-0006 "Generic shapes of notebooks" (type-level behaviour).
+//
+// With a union of shapes passed to `Notebook`, adding cells requires narrowing
+// with `supports`; structurally incompatible notebooks are rejected by the
+// compiler. These cases are checked by the compiler only (vitest typecheck
+// mode); nothing here executes. The runtime counterparts live in
+// shapes.test.ts.
+import {
+    createBinder,
+    defineMorphism,
+    defineObject,
+    defineShape,
+    type Notebook,
+} from "catcolab-documents";
+
+const BasicObj = defineObject({ tag: "Basic", content: "Object" });
+
+const OnlyBasicObj = defineShape({
+    objects: [BasicObj],
+});
+
+const EntityObj = defineObject({ tag: "Basic", content: "Entity" });
+const OnlyEntityObj = defineShape({
+    objects: [EntityObj],
+});
+
+const Morphism = defineMorphism({
+    tag: "Hom",
+    content: EntityObj.obType,
+});
+const EntityWithMor = defineShape({
+    objects: [EntityObj],
+    morphisms: [Morphism],
+});
+
+const tensor = { tag: "Basic", content: "tensor" } as const;
+
+const ListMor = defineMorphism(
+    { tag: "Hom", content: BasicObj.obType },
+    {
+        domain: { apply: tensor, modality: "List" },
+        codomain: { apply: tensor, modality: "List" },
+    },
+);
+const ListShape = defineShape({
+    objects: [BasicObj],
+    morphisms: [ListMor],
+});
+
+const SymmetricListMor = defineMorphism(
+    { tag: "Hom", content: BasicObj.obType },
+    {
+        domain: { apply: tensor, modality: "SymmetricList" },
+        codomain: { apply: tensor, modality: "SymmetricList" },
+    },
+);
+const SymmetricListShape = defineShape({
+    objects: [BasicObj],
+    morphisms: [SymmetricListMor],
+});
+
+const CocartesianListMor = defineMorphism(
+    { tag: "Hom", content: BasicObj.obType },
+    {
+        domain: { apply: tensor, modality: "CocartesianList" },
+        codomain: { apply: tensor, modality: "CocartesianList" },
+    },
+);
+const CocartesianListShape = defineShape({
+    objects: [BasicObj],
+    morphisms: [CocartesianListMor],
+});
+
+const CartesianListMor = defineMorphism(
+    { tag: "Hom", content: BasicObj.obType },
+    {
+        domain: { apply: tensor, modality: "CartesianList" },
+        codomain: { apply: tensor, modality: "CartesianList" },
+    },
+);
+const CartesianListShape = defineShape({
+    objects: [BasicObj],
+    morphisms: [CartesianListMor],
+});
+
+const AdditiveListMor = defineMorphism(
+    { tag: "Hom", content: BasicObj.obType },
+    {
+        domain: { apply: tensor, modality: "AdditiveList" },
+        codomain: { apply: tensor, modality: "AdditiveList" },
+    },
+);
+const AdditiveListShape = defineShape({
+    objects: [BasicObj],
+    morphisms: [AdditiveListMor],
+});
+
+type NotebookOfLists = Notebook<
+    | typeof ListShape
+    | typeof SymmetricListShape
+    | typeof CocartesianListShape
+    | typeof CartesianListShape
+    | typeof AdditiveListShape
+>;
+
+/** A stand-in value for the compiler; this file is typechecked, never run. */
+function typeOnly<T>(): T {
+    throw new Error("type-level only");
+}
+
+describe.skip("generic shapes (type level)", () => {
+    test("a notebook lacking a shape's objects is rejected", async () => {
+        const binder = createBinder();
+
+        function addObjects(notebook: Notebook<typeof OnlyBasicObj>) {
+            notebook.add(BasicObj, { label: "A" });
+            notebook.add(BasicObj, { label: "B" });
+        }
+
+        const olog = await binder.createNotebook(SimpleOlog, { title: "olog" });
+        addObjects(olog);
+
+        // A schema notebook has no basic `Object` so we get a type error.
+        const schema = await binder.createNotebook(SimpleSchema, { title: "schema" });
+
+        // @ts-expect-error A SimpleSchema notebook lacks the basic `Object` that OnlyBasicObj requires.
+        addObjects(schema);
+    });
+
+    test("a union of shapes requires narrowing with supports before adding", () => {
+        function addBasicAndEntityObjects(
+            notebook: Notebook<typeof OnlyBasicObj | typeof OnlyEntityObj>,
+        ) {
+            // @ts-expect-error We can't add a BasicObj without narrowing the notebook
+            // type because OnlyEntityObj does not support BasicObj.
+            notebook.add(BasicObj, { label: "A" });
+
+            // This is ok because we narrowed the notebook type.
+            if (notebook.supports(BasicObj)) {
+                notebook.add(BasicObj, { label: "B" });
+            }
+
+            // @ts-expect-error We can't add an EntityObj without narrowing the notebook
+            // type because OnlyBasicObj does not support EntityObj.
+            notebook.add(EntityObj, { label: "C" });
+
+            // This is ok because we narrowed the notebook type.
+            if (notebook.supports(EntityObj)) {
+                notebook.add(EntityObj, { label: "D" });
+            }
+        }
+
+        const notebook = typeOnly<Notebook<typeof OnlyBasicObj | typeof OnlyEntityObj>>();
+        addBasicAndEntityObjects(notebook);
+    });
+
+    test("supports can also take a shape as an argument", () => {
+        function addBasicEntityAndMor(
+            notebook: Notebook<typeof OnlyBasicObj | typeof EntityWithMor>,
+        ) {
+            // @ts-expect-error We can't add a BasicObj without narrowing the notebook
+            // type because EntityWithMor does not support BasicObj.
+            notebook.add(BasicObj, { label: "A" });
+
+            // This is ok because we narrowed the notebook type.
+            if (notebook.supports(OnlyBasicObj)) {
+                notebook.add(BasicObj, { label: "B" });
+            }
+
+            // @ts-expect-error We can't add an EntityObj without narrowing the notebook
+            // type because OnlyBasicObj does not support EntityObj.
+            notebook.add(EntityObj, { label: "C" });
+
+            // This is ok because we narrowed the notebook type to supporting both
+            // `EntityObj` and `Morphism`.
+            if (notebook.supports(EntityWithMor)) {
+                const d = notebook.add(EntityObj, { label: "D" });
+                notebook.add(Morphism, { label: "f", from: d, to: d });
+            }
+        }
+
+        const notebook = typeOnly<Notebook<typeof OnlyBasicObj | typeof EntityWithMor>>();
+        addBasicEntityAndMor(notebook);
+    });
+
+    test("adding a list morphism to a union of list shapes requires narrowing", () => {
+        function badAddListMorphism(notebook: NotebookOfLists) {
+            const a = notebook.add(BasicObj, { label: "A" });
+            const b = notebook.add(BasicObj, { label: "B" });
+            const c = notebook.add(BasicObj, { label: "C" });
+
+            // @ts-expect-error Not all variants support adding a `ListMor`. You need to narrow the type using the `supports` method.
+            notebook.add(ListMor, { label: "L", from: [a, b], to: [c] });
+        }
+
+        const notebook = typeOnly<NotebookOfLists>();
+        badAddListMorphism(notebook);
+    });
+
+    test("structurally incompatible notebooks are rejected", async () => {
+        const binder = createBinder();
+
+        const addListMorphism = typeOnly<(notebook: NotebookOfLists) => void>();
+
+        const simpleOlog = await binder.createNotebook(SimpleOlog, { title: "example" });
+
+        // @ts-expect-error A SimpleOlog notebook lacks the list-valued morphisms ListShape requires.
+        addListMorphism(simpleOlog);
+
+        const JustObjectShape = defineShape({
+            theory: "just-objects",
+            objects: [BasicObj],
+        });
+
+        const justObjects = await binder.createNotebook(JustObjectShape, { title: "example" });
+
+        // @ts-expect-error We have no morphisms in `JustObjectShape`.
+        addListMorphism(justObjects);
+
+        const JustMorphismShape = defineShape({
+            theory: "just-morphisms",
+            morphisms: [ListMor],
+        });
+
+        const justMorphisms = await binder.createNotebook(JustMorphismShape, {
+            title: "example",
+        });
+
+        // @ts-expect-error We have no objects in `JustMorphismShape`.
+        addListMorphism(justMorphisms);
+    });
+
+    test("morphisms only accept endpoints of their own object type", () => {
+        const EntityListMor = defineMorphism(
+            { tag: "Hom", content: EntityObj.obType },
+            {
+                domain: { apply: tensor, modality: "List" },
+                codomain: { apply: tensor, modality: "List" },
+            },
+        );
+
+        const MultiObjectListShape = defineShape({
+            objects: [BasicObj, EntityObj],
+            morphisms: [ListMor, EntityListMor],
+        });
+
+        function badAddListMorphism2(notebook: Notebook<typeof MultiObjectListShape>) {
+            const a = notebook.add(BasicObj, { label: "A" });
+            const b = notebook.add(BasicObj, { label: "B" });
+            const e = notebook.add(EntityObj, { label: "E" });
+
+            notebook.add(ListMor, { label: "L1", from: [a, b], to: [b] });
+            // @ts-expect-error We can't use an EntityObj with a ListMor
+            notebook.add(ListMor, { label: "L2", from: [a, b], to: [e] });
+        }
+
+        const notebook = typeOnly<Notebook<typeof MultiObjectListShape>>();
+        badAddListMorphism2(notebook);
+    });
+
+    test("narrowing objects across unions of shapes", () => {
+        const EntityListMor = defineMorphism(
+            { tag: "Hom", content: EntityObj.obType },
+            {
+                domain: { apply: tensor, modality: "List" },
+                codomain: { apply: tensor, modality: "List" },
+            },
+        );
+
+        const EntityObjectListShape = defineShape({
+            objects: [EntityObj],
+            morphisms: [EntityListMor],
+        });
+
+        type NotebookOfListsWithEntity = Notebook<
+            | typeof ListShape
+            | typeof SymmetricListShape
+            | typeof CocartesianListShape
+            | typeof CartesianListShape
+            | typeof AdditiveListShape
+            | typeof EntityObjectListShape
+        >;
+
+        function goodAddObject(notebook: NotebookOfListsWithEntity) {
+            if (notebook.supports(BasicObj)) {
+                notebook.add(BasicObj, { label: "A" });
+            }
+
+            if (notebook.supports(EntityObj)) {
+                notebook.add(EntityObj, { label: "E" });
+            }
+        }
+
+        const BothObjectsShape = defineShape({
+            objects: [BasicObj, EntityObj],
+        });
+
+        function goodAddObject2(notebook: NotebookOfListsWithEntity) {
+            if (notebook.supports(BothObjectsShape)) {
+                notebook.add(BasicObj, { label: "A" });
+                notebook.add(EntityObj, { label: "E" });
+            }
+        }
+
+        type JustEntityObjectListShape = Notebook<typeof EntityObjectListShape>;
+
+        function goodAddObject3(notebook: JustEntityObjectListShape) {
+            notebook.add(EntityObj, { label: "E" });
+        }
+
+        function badAddObject(notebook: NotebookOfListsWithEntity) {
+            // @ts-expect-error We can't add a BasicObj without narrowing the notebook type because EntityObjectListShape does not support BasicObj.
+            notebook.add(BasicObj, { label: "A" });
+
+            // @ts-expect-error We can't add an EntityObj without narrowing the notebook type because not all notebooks support EntityObj.
+            notebook.add(EntityObj, { label: "E" });
+        }
+
+        function badAddObject2(notebook: Notebook<typeof BothObjectsShape>) {
+            const a = notebook.add(BasicObj, { label: "A" });
+            const b = notebook.add(BasicObj, { label: "B" });
+
+            // @ts-expect-error BothObjectsShape can never support CocartesianListMor.
+            if (notebook.supports(CocartesianListMor)) {
+                // @ts-expect-error BothObjectsShape does not support CocartesianListMor.
+                notebook.add(CocartesianListMor, { label: "L", from: [a, b], to: [b] });
+            }
+        }
+
+        const notebookOfLists = typeOnly<NotebookOfListsWithEntity>();
+        goodAddObject(notebookOfLists);
+        goodAddObject2(notebookOfLists);
+        badAddObject(notebookOfLists);
+
+        const entityNotebook = typeOnly<JustEntityObjectListShape>();
+        goodAddObject3(entityNotebook);
+
+        const bothNotebook = typeOnly<Notebook<typeof BothObjectsShape>>();
+        badAddObject2(bothNotebook);
+    });
+});

--- a/packages/documents/test/shapes.test.ts
+++ b/packages/documents/test/shapes.test.ts
@@ -1,0 +1,219 @@
+import { PetriNet } from "catcolab-logics/petri-net";
+import { SimpleOlog } from "catcolab-logics/simple-olog";
+import { Attr, AttrType, Entity, Mapping, SimpleSchema } from "catcolab-logics/simple-schema";
+import { describe, expect, test } from "vitest";
+
+// RFC-0006 "Generic shapes of notebooks" (runtime behaviour).
+//
+// Using `defineShape` we don't have to define a complete notebook: shapes can
+// be subsets of a notebook and/or span across different notebooks. Generic
+// consumers narrow what a notebook actually supports with `supports`, and
+// `cellsOf` also accepts a `Shape` to filter by. The type-level counterparts
+// live in shapes.test-d.ts.
+import {
+    createBinder,
+    defineMorphism,
+    defineObject,
+    defineShape,
+    type Notebook,
+} from "catcolab-documents";
+
+const BasicObj = defineObject({ tag: "Basic", content: "Object" });
+
+const OnlyBasicObj = defineShape({
+    objects: [BasicObj],
+});
+
+const tensor = { tag: "Basic", content: "tensor" } as const;
+
+const ListMor = defineMorphism(
+    { tag: "Hom", content: BasicObj.obType },
+    {
+        domain: { apply: tensor, modality: "List" },
+        codomain: { apply: tensor, modality: "List" },
+    },
+);
+
+const ListShape = defineShape({
+    objects: [BasicObj],
+    morphisms: [ListMor],
+});
+
+const SymmetricListMor = defineMorphism(
+    { tag: "Hom", content: BasicObj.obType },
+    {
+        domain: { apply: tensor, modality: "SymmetricList" },
+        codomain: { apply: tensor, modality: "SymmetricList" },
+    },
+);
+
+const SymmetricListShape = defineShape({
+    objects: [BasicObj],
+    morphisms: [SymmetricListMor],
+});
+
+const CocartesianListMor = defineMorphism(
+    { tag: "Hom", content: BasicObj.obType },
+    {
+        domain: { apply: tensor, modality: "CocartesianList" },
+        codomain: { apply: tensor, modality: "CocartesianList" },
+    },
+);
+
+const CocartesianListShape = defineShape({
+    objects: [BasicObj],
+    morphisms: [CocartesianListMor],
+});
+
+const CartesianListMor = defineMorphism(
+    { tag: "Hom", content: BasicObj.obType },
+    {
+        domain: { apply: tensor, modality: "CartesianList" },
+        codomain: { apply: tensor, modality: "CartesianList" },
+    },
+);
+
+const CartesianListShape = defineShape({
+    objects: [BasicObj],
+    morphisms: [CartesianListMor],
+});
+
+const AdditiveListMor = defineMorphism(
+    { tag: "Hom", content: BasicObj.obType },
+    {
+        domain: { apply: tensor, modality: "AdditiveList" },
+        codomain: { apply: tensor, modality: "AdditiveList" },
+    },
+);
+
+const AdditiveListShape = defineShape({
+    objects: [BasicObj],
+    morphisms: [AdditiveListMor],
+});
+
+type NotebookOfLists = Notebook<
+    | typeof ListShape
+    | typeof SymmetricListShape
+    | typeof CocartesianListShape
+    | typeof CartesianListShape
+    | typeof AdditiveListShape
+>;
+
+/**
+ * Works on any notebook that supports any of the morphisms our list shapes
+ * support; returns which list morphism variant was added.
+ */
+function addListMorphism(notebook: NotebookOfLists): string {
+    const a = notebook.add(BasicObj, { label: "A" });
+    const b = notebook.add(BasicObj, { label: "B" });
+    const c = notebook.add(BasicObj, { label: "C" });
+
+    if (notebook.supports(ListMor)) {
+        notebook.add(ListMor, { label: "L", from: [a, b], to: [c] });
+        return "ListMor";
+    } else if (notebook.supports(SymmetricListMor)) {
+        notebook.add(SymmetricListMor, { label: "L", from: [a, b], to: [c] });
+        return "SymmetricListMor";
+    } else if (notebook.supports(CocartesianListMor)) {
+        notebook.add(CocartesianListMor, { label: "L", from: [a, b], to: [c] });
+        return "CocartesianListMor";
+    } else if (notebook.supports(CartesianListMor)) {
+        notebook.add(CartesianListMor, { label: "L", from: [a, b], to: [c] });
+        return "CartesianListMor";
+    } else if (notebook.supports(AdditiveListMor)) {
+        notebook.add(AdditiveListMor, { label: "L", from: [a, b], to: [c] });
+        return "AdditiveListMor";
+    }
+    // If the code type checked this should be unreachable.
+    throw new Error("Did not find any supported List morphism in the notebook.");
+}
+
+describe.skip("generic shapes of notebooks", () => {
+    test("a generic function against a subset shape works with notebooks from either logic", async () => {
+        const binder = createBinder();
+
+        function addObjects(notebook: Notebook<typeof OnlyBasicObj>) {
+            notebook.add(BasicObj, { label: "A" });
+            notebook.add(BasicObj, { label: "B" });
+        }
+
+        // Both an olog and a petri-net notebook support `BasicObj` (they share
+        // the basic `Object`).
+        const olog = await binder.createNotebook(SimpleOlog, { title: "olog" });
+        const petriNet = await binder.createNotebook(PetriNet, { title: "petri-net" });
+
+        addObjects(olog);
+        addObjects(petriNet);
+
+        expect(olog.cellsOf(BasicObj).map((cell) => cell.label)).toEqual(["A", "B"]);
+        expect(petriNet.cellsOf(BasicObj).map((cell) => cell.label)).toEqual(["A", "B"]);
+    });
+
+    test("supports narrows what a notebook accepts at runtime", async () => {
+        const binder = createBinder();
+
+        const EntityObj = defineObject({ tag: "Basic", content: "Entity" });
+        const OnlyEntityObj = defineShape({
+            objects: [EntityObj],
+        });
+
+        // On a union of shapes, `supports` reports what the notebook actually
+        // accepts; it can take a cell definition or a shape as an argument.
+        function probe(notebook: Notebook<typeof OnlyBasicObj | typeof OnlyEntityObj>) {
+            return {
+                basic: notebook.supports(BasicObj),
+                entity: notebook.supports(EntityObj),
+                basicShape: notebook.supports(OnlyBasicObj),
+            };
+        }
+
+        const olog = await binder.createNotebook(SimpleOlog, { title: "olog" });
+        const schema = await binder.createNotebook(SimpleSchema, { title: "schema" });
+
+        expect(probe(olog)).toEqual({ basic: true, entity: false, basicShape: true });
+        // A schema notebook has no basic `Object`.
+        expect(probe(schema)).toEqual({ basic: false, entity: true, basicShape: false });
+    });
+
+    test("cellsOf also accepts a shape to filter by", async () => {
+        const binder = createBinder();
+
+        const EntityShape = defineShape({
+            objects: [Entity],
+            morphisms: [Mapping],
+        });
+
+        const schema = await binder.createNotebook(SimpleSchema, { title: "Example" });
+
+        const a = schema.add(Entity, { label: "A" });
+        const b = schema.add(AttrType, { label: "B" });
+        const c = schema.add(Entity, { label: "C" });
+        schema.add(Attr, { label: "f", from: a, to: b });
+        schema.add(Mapping, { label: "g", from: a, to: c });
+
+        const labels: (string | null | undefined)[] = [];
+        for (const cell of schema.cellsOf(EntityShape)) {
+            labels.push(cell.label);
+        }
+        expect(labels).toEqual(["A", "C", "g"]);
+    });
+
+    test("a structurally compatible notebook is accepted and the appropriate morphism is added", async () => {
+        const binder = createBinder();
+
+        const petriNet = await binder.createNotebook(PetriNet, { title: "example" });
+        expect(addListMorphism(petriNet)).toBe("SymmetricListMor");
+
+        const entityObType = defineObject({ tag: "Basic", content: "Entity" });
+        const EntityObjectShape = defineShape({
+            theory: "entity-objects",
+            objects: [entityObType, BasicObj],
+            morphisms: [ListMor],
+        });
+
+        const entityObjects = await binder.createNotebook(EntityObjectShape, {
+            title: "example",
+        });
+        expect(addListMorphism(entityObjects)).toBe("ListMor");
+    });
+});

--- a/packages/documents/test/solid-completions.test.tsx
+++ b/packages/documents/test/solid-completions.test.tsx
@@ -1,0 +1,282 @@
+import { Attr, AttrType, Entity, SimpleSchema } from "catcolab-logics/simple-schema";
+import {
+    type Accessor,
+    createContext,
+    createSignal,
+    For,
+    onCleanup,
+    Show,
+    useContext,
+} from "solid-js";
+import { createStore, reconcile, type SetStoreFunction, unwrap } from "solid-js/store";
+import { render } from "solid-js/web";
+import { describe, expect, test } from "vitest";
+
+import type { Document } from "catcolab-document-types";
+// RFC-0006 "SolidJS example with validation & completions".
+//
+// `onValidate` feeds a signal with validation results; the validated model is
+// wired through the components to offer completions for a mapping's codomain.
+import {
+    CellKind,
+    createBinder,
+    defineMorphism,
+    defineObject,
+    defineShape,
+    type DocumentStore,
+    type ModelValidationResult,
+    type Notebook,
+    type NotebookCell,
+    RichText,
+    type ValidatableNotebook,
+} from "catcolab-documents";
+import type { DblModel, ObType, QualifiedName } from "catlog-wasm";
+import { selfResolving } from "./helpers/self_resolving";
+
+type SolidStoreHandle = {
+    draftDoc: Document;
+    docView: Document;
+    setDocView: SetStoreFunction<Document>;
+    listeners: Set<() => void>;
+};
+
+const solidStore: DocumentStore<SolidStoreHandle> = {
+    async createHandle(initialDoc) {
+        const draftDoc = structuredClone(initialDoc as Document);
+        const [docView, setDocView] = createStore<Document>(initialDoc as Document);
+        return { draftDoc, docView, setDocView, listeners: new Set() };
+    },
+    getDocumentView: (handle) => handle.docView,
+    changeDocument: (handle, fn) => {
+        fn(handle.draftDoc);
+        handle.setDocView(reconcile(structuredClone(handle.draftDoc), { key: "id" }));
+        for (const listener of Array.from(handle.listeners)) {
+            listener();
+        }
+    },
+    subscribe: (handle, callback) => {
+        handle.listeners.add(callback);
+        return () => {
+            handle.listeners.delete(callback);
+        };
+    },
+    copyValue: (_handle, value) => structuredClone(unwrap(value)),
+    ...selfResolving<SolidStoreHandle>(),
+};
+
+const solidBinder = createBinder(solidStore);
+
+const MyEntity = defineObject({ tag: "Basic", content: "Entity" });
+const MyAttrType = defineObject({ tag: "Basic", content: "AttrType" });
+const MyAttr = defineMorphism(
+    { tag: "Basic", content: "Attr" },
+    { domain: MyEntity.obType, codomain: MyAttrType.obType },
+);
+
+const MyShape = defineShape({
+    objects: [MyEntity, MyAttrType],
+    morphisms: [MyAttr],
+    informal: [RichText],
+});
+
+type MyNotebook = Notebook<typeof MyShape>;
+
+function label(model: DblModel, id: QualifiedName): string {
+    return model.obGeneratorLabel(id)?.join(".") ?? "?";
+}
+
+function filteredCompletions(model: DblModel, obType: ObType, text: string): QualifiedName[] {
+    const needle = text.toLowerCase();
+    return model
+        .obGeneratorsWithType(obType)
+        .filter((id) => label(model, id).toLowerCase().includes(needle));
+}
+
+function codomainLabel(model: DblModel | undefined, morphism: NotebookCell<typeof MyAttr>): string {
+    if (!model) {
+        return "?";
+    }
+    const cod = model?.morPresentation(morphism.id)?.cod;
+    return cod?.tag === "Basic" ? label(model, cod.content) : "?";
+}
+
+type MyContextValue = {
+    notebook: MyNotebook;
+    model: Accessor<DblModel>;
+};
+
+const MyContext = createContext<MyContextValue>();
+
+function useMyContext() {
+    const context = useContext(MyContext);
+    if (!context) {
+        throw new Error("Schema editor context is missing.");
+    }
+    return context;
+}
+
+function selectCodomain(
+    notebook: MyNotebook,
+    attrCell: NotebookCell<typeof MyAttr>,
+    id: QualifiedName,
+) {
+    const result = notebook.get(MyAttrType, id);
+    if (result.tag === "Ok") {
+        attrCell.update({ to: result.content });
+    }
+}
+
+function CompletionPicker(props: {
+    obType: ObType;
+    selected: string;
+    text: Accessor<string>;
+    onSelect: (id: QualifiedName) => void;
+}) {
+    const context = useMyContext();
+    return (
+        <span class="picker">
+            <span class="selected">{props.selected}</span>
+            <ul class="completion-list">
+                <For each={filteredCompletions(context.model(), props.obType, props.text())}>
+                    {(id) => (
+                        <li onClick={() => props.onSelect(id)}>{label(context.model(), id)}</li>
+                    )}
+                </For>
+            </ul>
+        </span>
+    );
+}
+
+function MyAttrCellEditor(props: {
+    attrCell: NotebookCell<typeof MyAttr>;
+    text: Accessor<string>;
+}) {
+    const context = useMyContext();
+    return (
+        <li>
+            Attr: {props.attrCell.label}: {props.attrCell.from?.label} -&gt;{" "}
+            <CompletionPicker
+                obType={MyAttrType.obType}
+                selected={codomainLabel(context.model(), props.attrCell)}
+                text={props.text}
+                onSelect={(id) => selectCodomain(context.notebook, props.attrCell, id)}
+            />
+        </li>
+    );
+}
+
+function MyCellEditor(props: { cell: NotebookCell<typeof MyShape>; text: Accessor<string> }) {
+    if (props.cell.kind === CellKind.Morphism) {
+        return <MyAttrCellEditor attrCell={props.cell} text={props.text} />;
+    }
+    if (props.cell.kind === CellKind.Object) {
+        const kind = props.cell.type === MyAttrType ? "MyAttrType" : "MyEntity";
+        return (
+            <li>
+                {kind}: {props.cell.label}
+            </li>
+        );
+    }
+    if (props.cell.kind === CellKind.RichText) {
+        return <li>Text: {props.cell.content}</li>;
+    }
+    return null;
+}
+
+// Globals for testing
+let testCurrentModel!: () => DblModel | undefined;
+
+function MyNotebookEditor(props: {
+    notebook: MyNotebook & ValidatableNotebook;
+    text: Accessor<string>;
+}) {
+    // `onValidate` delivers an initial result and then re-validates whenever
+    // anything the validation depends on changes, notifying only when the
+    // result actually changed.
+    const [validation, setValidation] = createSignal<ModelValidationResult>();
+    const unsubscribe = props.notebook.onValidate(setValidation);
+    onCleanup(unsubscribe);
+
+    const model = () => {
+        const result = validation();
+        return result?.tag === "Ok" ? result.content : undefined;
+    };
+
+    testCurrentModel = model;
+
+    return (
+        <section>
+            <h1>{props.notebook.title}</h1>
+            <Show when={model()} fallback={<p>Validating...</p>}>
+                {(m) => (
+                    <MyContext.Provider value={{ notebook: props.notebook, model: m }}>
+                        <ul>
+                            <For each={props.notebook.cellsOf(MyShape)}>
+                                {(cell) => <MyCellEditor cell={cell} text={props.text} />}
+                            </For>
+                        </ul>
+                    </MyContext.Provider>
+                )}
+            </Show>
+        </section>
+    );
+}
+
+async function until(predicate: () => boolean) {
+    while (!predicate()) {
+        await new Promise((resolve) => setTimeout(resolve));
+    }
+}
+
+describe.skip("SolidJS validation & completions", () => {
+    test("the validated model feeds completions and codomain selection", async () => {
+        const notebook = await solidBinder.createNotebook(SimpleSchema, {
+            title: "Company schema",
+        });
+        const person = notebook.add(Entity, { label: "Person" });
+        const string = notebook.add(AttrType, { label: "String" });
+        notebook.add(AttrType, { label: "Integer" });
+        notebook.add(AttrType, { label: "Boolean" });
+        const name = notebook.add(Attr, { label: "name", from: person, to: string });
+
+        const [text, setText] = createSignal("");
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+        const dispose = render(
+            () => <MyNotebookEditor notebook={notebook} text={text} />,
+            container,
+        );
+
+        await until(() => testCurrentModel() !== undefined);
+        expect(
+            [...container.querySelectorAll(".completion-list li")]
+                .map((li) => li.textContent)
+                .join(", "),
+        ).toBe("String, Integer, Boolean");
+        expect(codomainLabel(testCurrentModel(), name)).toBe("String");
+
+        setText("in");
+        expect(
+            [...container.querySelectorAll(".completion-list li")]
+                .map((li) => li.textContent)
+                .join(", "),
+        ).toBe("String, Integer");
+
+        const model = testCurrentModel();
+        if (!model) {
+            throw new Error("Expected a valid model.");
+        }
+        const integer = filteredCompletions(model, MyAttrType.obType, "in").find(
+            (id) => label(model, id) === "Integer",
+        );
+        if (!integer) {
+            throw new Error("Expected an Integer completion.");
+        }
+        selectCodomain(notebook, name, integer);
+        await until(() => codomainLabel(testCurrentModel(), name) === "Integer");
+        expect(codomainLabel(testCurrentModel(), name)).toBe("Integer");
+
+        dispose();
+        container.remove();
+    });
+});

--- a/packages/documents/test/solid-shape-consumer.test.tsx
+++ b/packages/documents/test/solid-shape-consumer.test.tsx
@@ -1,0 +1,204 @@
+import { PetriNet, Place, Transition } from "catcolab-logics/petri-net";
+import { For } from "solid-js";
+import { createStore, reconcile, type SetStoreFunction, unwrap } from "solid-js/store";
+import { render } from "solid-js/web";
+import { describe, expect, test } from "vitest";
+
+import type { Document } from "catcolab-document-types";
+// RFC-0006 "Use with SolidJS — Shape consumer".
+//
+// Components consume the shape they need: a generic shape over the basic
+// object, a symmetric-list morphism and rich text works for any structurally
+// compatible notebook, here a Petri net.
+import {
+    CellKind,
+    createBinder,
+    defineMorphism,
+    defineObject,
+    defineShape,
+    type DocumentStore,
+    type Notebook,
+    type NotebookCell,
+    RichText,
+} from "catcolab-documents";
+
+type SolidStoreHandle = {
+    draftDoc: Document;
+    docView: Document;
+    setDocView: SetStoreFunction<Document>;
+    listeners: Set<() => void>;
+};
+
+const solidStoreIds = new WeakMap<SolidStoreHandle, string>();
+const solidStoreIdFor = (handle: SolidStoreHandle): string => {
+    let id = solidStoreIds.get(handle);
+    if (!id) {
+        id = crypto.randomUUID();
+        solidStoreIds.set(handle, id);
+    }
+    return id;
+};
+
+const solidStore: DocumentStore<SolidStoreHandle> = {
+    async createHandle(initialDoc) {
+        const draftDoc = structuredClone(initialDoc as Document);
+        const [docView, setDocView] = createStore<Document>(initialDoc as Document);
+        return { draftDoc, docView, setDocView, listeners: new Set() };
+    },
+    getDocumentView: (handle) => handle.docView,
+    changeDocument: (handle, fn) => {
+        fn(handle.draftDoc);
+        handle.setDocView(reconcile(structuredClone(handle.draftDoc), { key: "id" }));
+        for (const listener of Array.from(handle.listeners)) {
+            listener();
+        }
+    },
+    subscribe: (handle, callback) => {
+        handle.listeners.add(callback);
+        return () => {
+            handle.listeners.delete(callback);
+        };
+    },
+    copyValue: (_handle, value) => structuredClone(unwrap(value)),
+    getDocumentRef: (handle) => ({ id: solidStoreIdFor(handle), version: null, server: "" }),
+    // Link resolution omitted for brevity.
+    getHandle: async () => ({
+        tag: "Err",
+        content: [{ message: "This store cannot resolve references." }],
+    }),
+};
+
+const basicObject = defineObject({ tag: "Basic", content: "Object" });
+const symmetricListMorphism = defineMorphism(
+    { tag: "Hom", content: basicObject.obType },
+    {
+        domain: { apply: { tag: "Basic", content: "tensor" }, modality: "SymmetricList" },
+        codomain: { apply: { tag: "Basic", content: "tensor" }, modality: "SymmetricList" },
+    },
+);
+
+type BasicObCell = NotebookCell<typeof basicObject>;
+type SymmetricListCell = NotebookCell<typeof symmetricListMorphism>;
+
+const GenericShape = defineShape({
+    objects: [basicObject],
+    morphisms: [symmetricListMorphism],
+    informal: [RichText],
+});
+
+function ObListEditor(props: { objects: BasicObCell[] }) {
+    return <span>[{props.objects.map((place) => place.label).join(", ")}]</span>;
+}
+
+function MorphismCellEditor(props: {
+    notebook: Notebook<typeof GenericShape>;
+    morphism: SymmetricListCell;
+}) {
+    // Contrived test example: adding an arbitrary but valid input place
+    const runTestMutation = () => {
+        const referenced = new Set(
+            [...props.morphism.from, ...props.morphism.to].map((ob) => ob.id),
+        );
+        const input = props.notebook.cellsOf(basicObject).find((ob) => !referenced.has(ob.id));
+        if (input) {
+            props.morphism.update({ from: [...props.morphism.from, input] });
+        }
+    };
+    return (
+        <li>
+            <span class="cell-label">
+                Transition: <ObListEditor objects={props.morphism.from} />
+                <span> -&gt; </span>
+                <ObListEditor objects={props.morphism.to} />
+                <span>{props.morphism.label}</span>
+            </span>
+            <button aria-label="run test mutation" onClick={runTestMutation} />
+        </li>
+    );
+}
+
+function ModelCellEditor(props: {
+    notebook: Notebook<typeof GenericShape>;
+    cell: NotebookCell<typeof GenericShape>;
+}) {
+    const cell = props.cell;
+    if (cell.kind === CellKind.Morphism) {
+        return <MorphismCellEditor notebook={props.notebook} morphism={cell} />;
+    }
+    if (cell.kind === CellKind.Object) {
+        return (
+            <li>
+                <span class="cell-label">Place: {cell.label}</span>
+            </li>
+        );
+    }
+    if (cell.kind === CellKind.RichText) {
+        return (
+            <li>
+                <span class="cell-label">Text: {cell.content}</span>
+            </li>
+        );
+    }
+    return null;
+}
+
+function ModelNotebookEditor(props: { notebook: Notebook<typeof GenericShape> }) {
+    return (
+        <section>
+            <h1>{props.notebook.title}</h1>
+            <ul>
+                <For each={props.notebook.cellsOf(GenericShape)}>
+                    {(cell) => <ModelCellEditor notebook={props.notebook} cell={cell} />}
+                </For>
+            </ul>
+        </section>
+    );
+}
+
+describe.skip("SolidJS shape consumer", () => {
+    test("a generic editor renders a Petri net notebook and mutates it reactively", async () => {
+        const solidBinder = createBinder(solidStore);
+
+        const notebook = await solidBinder.createNotebook(PetriNet, { title: "Petri net" });
+        const a = notebook.add(Place, { label: "A" });
+        notebook.add(Place, { label: "B" });
+        const c = notebook.add(Place, { label: "C" });
+        notebook.add(Transition, { label: "fires", from: [a], to: [c] });
+
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+
+        const dispose = render(() => <ModelNotebookEditor notebook={notebook} />, container);
+
+        expect(container.innerHTML).toBe(
+            "<section><h1>Petri net</h1><ul>" +
+                '<li><span class="cell-label">Place: A</span></li>' +
+                '<li><span class="cell-label">Place: B</span></li>' +
+                '<li><span class="cell-label">Place: C</span></li>' +
+                '<li><span class="cell-label">Transition: <span>[A<!---->]</span>' +
+                "<span> -&gt; </span><span>[C<!---->]</span><span>fires</span></span>" +
+                '<button aria-label="run test mutation"></button></li>' +
+                "</ul></section>",
+        );
+
+        const appendButton = container.querySelector<HTMLButtonElement>(
+            '[aria-label="run test mutation"]',
+        );
+        expect(appendButton).not.toBeNull();
+        appendButton?.click();
+
+        expect(container.innerHTML).toBe(
+            "<section><h1>Petri net</h1><ul>" +
+                '<li><span class="cell-label">Place: A</span></li>' +
+                '<li><span class="cell-label">Place: B</span></li>' +
+                '<li><span class="cell-label">Place: C</span></li>' +
+                '<li><span class="cell-label">Transition: <span>[A, B<!---->]</span>' +
+                "<span> -&gt; </span><span>[C<!---->]</span><span>fires</span></span>" +
+                '<button aria-label="run test mutation"></button></li>' +
+                "</ul></section>",
+        );
+
+        dispose();
+        container.remove();
+    });
+});

--- a/packages/documents/test/stores/automerge-store.test.ts
+++ b/packages/documents/test/stores/automerge-store.test.ts
@@ -1,0 +1,68 @@
+// RFC-0006 "Use with SolidJS and Automerge" — the Automerge binder.
+//
+// A simple Automerge store: handles are `DocHandle`s in a `Repo`, changes go
+// through `DocHandle.change`, and copied values are materialized off the
+// Automerge backend.
+import { getBackend, getObjectId } from "@automerge/automerge";
+import { type DocHandle, Repo } from "@automerge/automerge-repo";
+import { SimpleOlog, Type } from "catcolab-logics/simple-olog";
+import { describe, expect, test } from "vitest";
+
+import type { Document } from "catcolab-document-types";
+import { createBinder, type DocumentStore } from "catcolab-documents";
+
+const repo = new Repo();
+
+const automergeStore: DocumentStore<DocHandle<Document>> = {
+    createHandle: async (initialDoc) => {
+        return repo.create<Document>(initialDoc as Document);
+    },
+    changeDocument: (handle, fn) => handle.change(fn),
+    subscribe: (handle, callback) => {
+        const onChange = () => callback();
+        handle.on("change", onChange);
+        return () => handle.off("change", onChange);
+    },
+    copyValue: (handle, value) => {
+        const doc = handle.doc();
+        const objId = getObjectId(value as object);
+        if (objId === null) {
+            throw new Error("value is not part of the document");
+        }
+        return getBackend(doc).materialize(objId) as typeof value;
+    },
+    getDocumentView: (handle) => handle.doc(),
+    getDocumentRef: (handle) => ({ id: handle.documentId, version: null, server: "" }),
+    // Link resolution omitted for brevity.
+    getHandle: async () => ({
+        tag: "Err",
+        content: [{ message: "This store cannot resolve references." }],
+    }),
+};
+
+describe.skip("Automerge binder", () => {
+    test("a binder over an Automerge store is used just as the default binder", async () => {
+        const automergeBinder = createBinder(automergeStore);
+
+        const notebook = await automergeBinder.createNotebook(SimpleOlog, { title: "An Olog" });
+        expect(notebook.title).toBe("An Olog");
+    });
+
+    test("edits are persisted in the Automerge document", async () => {
+        // This minimal store snapshots its view per handle, so it demonstrates
+        // creation and persistence; a store with *live* reads projects its
+        // handle instead (see backend-store.test.ts).
+        const automergeBinder = createBinder(automergeStore);
+
+        const notebook = await automergeBinder.createNotebook(SimpleOlog, { title: "An Olog" });
+        notebook.add(Type, { label: "A" });
+        notebook.add(Type, { label: "B" });
+
+        const reloaded = await automergeBinder.loadNotebook(SimpleOlog, notebook.dump());
+        expect(reloaded.tag).toBe("Ok");
+        if (reloaded.tag !== "Ok") {
+            return;
+        }
+        expect(reloaded.content.cellsOf(Type).map((cell) => cell.label)).toEqual(["A", "B"]);
+    });
+});

--- a/packages/documents/test/stores/backend-store.test.ts
+++ b/packages/documents/test/stores/backend-store.test.ts
@@ -1,0 +1,111 @@
+// RFC-0006 "An Automerge and SolidJS binder for our backend".
+//
+// An approximation of a binder working with the CatColab backend and frontend
+// using Automerge, SolidJS and the RPC client (mocked as `FakeBackend`):
+// `createHandle` registers new documents with the backend, and `getHandle`
+// resolves `DocumentRef`s back through it, so instantiations across notebooks
+// validate.
+import { getBackend, getObjectId } from "@automerge/automerge";
+import type { DocHandle, DocumentId } from "@automerge/automerge-repo";
+import { makeDocumentProjection } from "@automerge/automerge-repo-solid-primitives";
+import { SimpleOlog, Type } from "catcolab-logics/simple-olog";
+import { describe, expect, test } from "vitest";
+
+import type { Document } from "catcolab-document-types";
+import { createBinder, type DocumentStore, Instantiation } from "catcolab-documents";
+import { FakeBackend } from "../helpers/fake_backend";
+
+const backend = new FakeBackend();
+const repo = backend.repo;
+
+type StoreHandle = {
+    docHandle: DocHandle<Document>;
+    docView: Document;
+};
+
+const makeHandle = (docHandle: DocHandle<Document>): StoreHandle => ({
+    docHandle,
+    docView: makeDocumentProjection(docHandle),
+});
+
+const refByDocId = new Map<DocumentId, string>();
+const handleByRefId = new Map<string, StoreHandle>();
+
+const backendStore: DocumentStore<StoreHandle> = {
+    createHandle: async (initialDoc: Document) => {
+        const created = await backend.new_ref(initialDoc);
+        if (created.tag !== "Ok") {
+            throw new Error(created.message);
+        }
+        const refId = created.content;
+
+        const fetched = await backend.get_doc(refId);
+        if (fetched.tag !== "Ok") {
+            throw new Error(fetched.message);
+        }
+        const docHandle = await repo.find<Document>(fetched.content.docId as DocumentId);
+        const handle = makeHandle(docHandle);
+
+        refByDocId.set(docHandle.documentId, refId);
+        handleByRefId.set(refId, handle);
+        return handle;
+    },
+    getDocumentView: (handle) => handle.docView,
+    changeDocument: (handle, fn) => handle.docHandle.change(fn),
+    subscribe: (handle, callback) => {
+        handle.docHandle.on("change", callback);
+        return () => handle.docHandle.off("change", callback);
+    },
+    copyValue: (handle, value) => {
+        const doc = handle.docHandle.doc();
+        const objId = getObjectId(value as object);
+        if (objId === null) {
+            throw new Error("value is not part of the document");
+        }
+        return getBackend(doc).materialize(objId) as typeof value;
+    },
+    getDocumentRef: (handle) => {
+        const refId = refByDocId.get(handle.docHandle.documentId);
+        if (!refId) {
+            throw new Error("handle is not registered with this store");
+        }
+        return { id: refId, version: null, server: backend.serverHost };
+    },
+    getHandle: async (ref) => {
+        const refId = ref.id;
+        const cached = handleByRefId.get(refId);
+        if (cached) {
+            return { tag: "Ok", content: cached };
+        }
+
+        const result = await backend.get_doc(refId);
+        if (result.tag !== "Ok") {
+            return {
+                tag: "Err",
+                content: [{ message: `Cannot resolve reference "${refId}".`, path: ["id"] }],
+            };
+        }
+
+        const docHandle = await repo.find<Document>(result.content.docId as DocumentId);
+        const handle = makeHandle(docHandle);
+        handleByRefId.set(refId, handle);
+        refByDocId.set(docHandle.documentId, refId);
+        return { tag: "Ok", content: handle };
+    },
+};
+
+describe.skip("backend binder", () => {
+    test("notebooks with instantiations resolve through the backend and validate", async () => {
+        const backendBinder = createBinder(backendStore);
+
+        const imported = await backendBinder.createNotebook(SimpleOlog, { title: "Imported" });
+        imported.add(Type, { label: "Thing" });
+
+        const notebook = await backendBinder.createNotebook(SimpleOlog, { title: "Main" });
+        notebook.add(Type, { label: "A" });
+        notebook.add(Instantiation, { label: "ImportedOlog", model: imported });
+
+        const result = await notebook.validate();
+        expect(result.tag).toBe("Ok");
+    });
+});

--- a/packages/documents/test/stores/solid-store.test.ts
+++ b/packages/documents/test/stores/solid-store.test.ts
@@ -1,0 +1,92 @@
+import { SimpleOlog, Type } from "catcolab-logics/simple-olog";
+import { createStore, reconcile, type SetStoreFunction, unwrap } from "solid-js/store";
+import { describe, expect, test } from "vitest";
+
+import type { Document } from "catcolab-document-types";
+// RFC-0006 "Use with SolidJS and Automerge" — the SolidJS binder.
+//
+// The `Binder` abstraction keeps the API consistent while plugging in custom
+// backends through `createBinder` and the `DocumentStore` type. A simple
+// SolidJS store keeps a draft document plus a Solid store view reconciled on
+// every change.
+import { createBinder, type DocumentStore } from "catcolab-documents";
+
+type SolidStoreHandle = {
+    draftDoc: Document;
+    docView: Document;
+    setDocView: SetStoreFunction<Document>;
+    listeners: Set<() => void>;
+};
+
+// Every store mints a stable reference for its handles; this one assigns an id
+// on demand and keeps it in a WeakMap.
+const solidStoreIds = new WeakMap<SolidStoreHandle, string>();
+const solidStoreIdFor = (handle: SolidStoreHandle): string => {
+    let id = solidStoreIds.get(handle);
+    if (!id) {
+        id = crypto.randomUUID();
+        solidStoreIds.set(handle, id);
+    }
+    return id;
+};
+
+const solidStore: DocumentStore<SolidStoreHandle> = {
+    async createHandle(initialDoc) {
+        const draftDoc = structuredClone(initialDoc as Document);
+        const [docView, setDocView] = createStore<Document>(initialDoc as Document);
+        return { draftDoc, docView, setDocView, listeners: new Set() };
+    },
+    changeDocument: (handle, fn) => {
+        fn(handle.draftDoc);
+        handle.setDocView(reconcile(structuredClone(handle.draftDoc), { key: "id" }));
+        for (const listener of Array.from(handle.listeners)) {
+            listener();
+        }
+    },
+    subscribe: (handle, callback) => {
+        handle.listeners.add(callback);
+        return () => {
+            handle.listeners.delete(callback);
+        };
+    },
+    copyValue: (_handle, value) => structuredClone(unwrap(value)),
+    getDocumentView: (handle) => handle.docView,
+    getDocumentRef: (handle) => ({ id: solidStoreIdFor(handle), version: null, server: "" }),
+    // Link resolution omitted for brevity.
+    getHandle: async () => ({
+        tag: "Err",
+        content: [{ message: "This store cannot resolve references." }],
+    }),
+};
+
+describe.skip("SolidJS binder", () => {
+    test("a binder over a Solid store is used just as the default binder", async () => {
+        const solidBinder = createBinder(solidStore);
+
+        const notebook = await solidBinder.createNotebook(SimpleOlog, { title: "An Olog" });
+        expect(notebook.title).toBe("An Olog");
+
+        const a = notebook.add(Type, { label: "A" });
+        notebook.add(Type, { label: "B" });
+
+        expect(notebook.cellsOf(Type).map((cell) => cell.label)).toEqual(["A", "B"]);
+
+        a.update({ label: "A2" });
+        expect(a.label).toBe("A2");
+    });
+
+    test("changes notify subscribers through the store", async () => {
+        const solidBinder = createBinder(solidStore);
+        const notebook = await solidBinder.createNotebook(SimpleOlog, { title: "An Olog" });
+
+        let changes = 0;
+        const unsubscribe = notebook.onChange(() => {
+            changes += 1;
+        });
+
+        notebook.add(Type, { label: "A" });
+        expect(changes).toBeGreaterThan(0);
+
+        unsubscribe();
+    });
+});

--- a/packages/documents/test/transactions.test.ts
+++ b/packages/documents/test/transactions.test.ts
@@ -1,0 +1,32 @@
+import { Entity, SimpleSchema } from "catcolab-logics/simple-schema";
+import { describe, expect, test } from "vitest";
+
+// RFC-0006 "Transactions": a set of changes staged on a draft, invisible on the
+// source notebook until committed, and revertible as a whole via the returned
+// commit.
+import { createBinder } from "catcolab-documents";
+
+describe.skip("transactions", () => {
+    test("changes stage on the transaction, apply on commit and revert as a batch", async () => {
+        const binder = createBinder();
+        const schema = await binder.createNotebook(SimpleSchema, { title: "Example schema" });
+
+        const tx = schema.beginTransaction();
+        tx.add(Entity, { label: "Person" });
+        tx.add(Entity, { label: "Company" });
+
+        expect(schema.cellsOf(Entity).length).toBe(0);
+        expect(tx.cellsOf(Entity).length).toBe(2);
+
+        const commit = tx.commit();
+        expect(
+            schema
+                .cellsOf(Entity)
+                .map((cell) => cell.label)
+                .join(", "),
+        ).toBe("Person, Company");
+
+        schema.revertCommit(commit);
+        expect(schema.cellsOf(Entity).length).toBe(0);
+    });
+});

--- a/packages/documents/test/type-errors.test-d.ts
+++ b/packages/documents/test/type-errors.test-d.ts
@@ -1,0 +1,69 @@
+import { PetriNet, Place, Transition } from "catcolab-logics/petri-net";
+import { Aspect, SimpleOlog, Type } from "catcolab-logics/simple-olog";
+import { AttrType, Mapping, SimpleSchema } from "catcolab-logics/simple-schema";
+import { describe, test } from "vitest";
+
+// RFC-0006 "Type errors" and "Further type errors".
+//
+// TypeScript type checking gives confidence that use of the notebook API makes
+// sense and is free of misspellings or other issues that would throw errors at
+// runtime. These cases are checked by the compiler only (vitest typecheck
+// mode); nothing here executes.
+import { createBinder } from "catcolab-documents";
+
+describe.skip("type errors", () => {
+    test("invalid shapes are type errors in a simple olog", async () => {
+        const binder = createBinder();
+        const notebook = await binder.createNotebook(SimpleOlog, { title: "An Olog" });
+
+        const source = notebook.add(Type, { label: "A" });
+        const target = notebook.add(Type, { label: "B" });
+        const arrow = notebook.add(Aspect, { label: "has", from: source, to: target });
+
+        // @ts-expect-error Arrays are not valid endpoints in a simple olog.
+        arrow.update({ from: [source] });
+
+        // @ts-expect-error Arrays are not valid endpoints in a simple olog.
+        notebook.add(Aspect, { label: "bad", from: [source, target], to: target });
+        // @ts-expect-error Missing required fields.
+        notebook.add(Aspect, {});
+        // null fields are allowed.
+        notebook.add(Aspect, { label: null, from: null, to: null });
+    });
+
+    test("a mapping's endpoints must be entities, not attribute types", async () => {
+        const binder = createBinder();
+        const schema = await binder.createNotebook(SimpleSchema, { title: "Example schema" });
+
+        const str = schema.add(AttrType, { label: "String" });
+
+        // @ts-expect-error A mapping's endpoints must be entities, not attribute types.
+        schema.add(Mapping, {
+            label: "bad",
+            from: str,
+            to: str,
+        });
+    });
+
+    test("endpoint shapes adapt to the underlying logic", async () => {
+        const binder = createBinder();
+        const notebook = await binder.createNotebook(PetriNet, { title: "Example Petri-net" });
+
+        const a = notebook.add(Place, { label: "A" });
+        const b = notebook.add(Place, { label: "B" });
+        const c = notebook.add(Place, { label: "C" });
+
+        notebook.add(Transition, {
+            label: "t1",
+            from: [a, b],
+            to: [c],
+        });
+
+        // @ts-expect-error Petri net transitions require arrays of places.
+        notebook.add(Transition, {
+            label: "bad",
+            from: a,
+            to: [c],
+        });
+    });
+});

--- a/packages/documents/test/validation.test.ts
+++ b/packages/documents/test/validation.test.ts
@@ -1,0 +1,110 @@
+import { Aspect, SimpleOlog, Type } from "catcolab-logics/simple-olog";
+import { describe, expect, test } from "vitest";
+
+// RFC-0006 "Model validation": the asynchronous `validate` method, subscribing
+// to validation changes with `onValidate`, and validation failures.
+import { createBinder, Instantiation, type Result } from "catcolab-documents";
+import type { DblModel } from "catlog-wasm";
+
+async function wellFormedOlog() {
+    const binder = createBinder();
+    const notebook = await binder.createNotebook(SimpleOlog, { title: "An Olog" });
+
+    const source = notebook.add(Type, { label: "A" });
+    const target = notebook.add(Type, { label: "B" });
+    notebook.add(Aspect, { label: "has", from: source, to: target });
+
+    return notebook;
+}
+
+describe.skip("validate", () => {
+    test("a well-formed notebook validates to an Ok carrying the model", async () => {
+        const notebook = await wellFormedOlog();
+
+        const result: Result<DblModel> = await notebook.validate();
+        expect(result.tag).toBe("Ok");
+    });
+
+    test("the validated model is available on the result and can be queried", async () => {
+        const notebook = await wellFormedOlog();
+
+        const result = await notebook.validate();
+        expect(result.tag).toBe("Ok");
+        if (result.tag !== "Ok") {
+            return;
+        }
+        expect(result.content.obGenerators().length).toBe(2);
+        expect(result.content.morGenerators().length).toBe(1);
+    });
+});
+
+describe.skip("onValidate", () => {
+    test("always calls the callback at least once with the current validation", async () => {
+        const notebook = await wellFormedOlog();
+
+        const first = await new Promise<Result<DblModel>>((resolve) => {
+            const unsubscribe = notebook.onValidate((result: Result<DblModel>) => {
+                resolve(result);
+                unsubscribe();
+            });
+        });
+
+        expect(first.tag).toBe("Ok");
+    });
+
+    test("notifies when changes to the formal content affect the validation result", async () => {
+        const notebook = await wellFormedOlog();
+
+        const results: Result<DblModel>[] = [];
+        const unsubscribe = notebook.onValidate((result: Result<DblModel>) => {
+            results.push(result);
+        });
+
+        // Wait for the initial validation.
+        while (results.length === 0) {
+            await new Promise((resolve) => setTimeout(resolve));
+        }
+        const initialCount = results.length;
+
+        notebook.add(Type, { label: "C" });
+        while (results.length === initialCount) {
+            await new Promise((resolve) => setTimeout(resolve));
+        }
+
+        unsubscribe();
+
+        const latest = results[results.length - 1];
+        expect(latest?.tag).toBe("Ok");
+        if (latest?.tag !== "Ok") {
+            return;
+        }
+        expect(latest.content.obGenerators().length).toBe(3);
+    });
+});
+
+describe.skip("validation result", () => {
+    test("an ill-formed notebook results in an Err carrying issues", async () => {
+        const binder = createBinder();
+
+        const first = await binder.createNotebook(SimpleOlog, { title: "First" });
+        const second = await binder.createNotebook(SimpleOlog, { title: "Second" });
+
+        first.add(Type, { label: "A" });
+        second.add(Type, { label: "B" });
+
+        // A cycle: `first` instantiates `second`, which instantiates `first`.
+        first.add(Instantiation, { label: "ImportedSecond", model: second });
+        second.add(Instantiation, { label: "ImportedFirst", model: first });
+
+        const result = await first.validate();
+        expect(result.tag).toBe("Err");
+        if (result.tag !== "Err") {
+            return;
+        }
+        expect(result.content.map((issue) => issue.message).join("; ")).toBe(
+            'Instantiation cycle detected: "First" → "Second" → "First". ' +
+                "A notebook cannot instantiate itself, directly or indirectly. " +
+                "To fix, remove one of the instantiations in this chain.",
+        );
+    });
+});

--- a/packages/documents/tsconfig.json
+++ b/packages/documents/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "module": "ESNext",
+        "lib": ["ES2023"],
+        "skipLibCheck": true,
+
+        "moduleResolution": "bundler",
+        "isolatedModules": true,
+        "noEmit": true,
+
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noFallthroughCasesInSwitch": true
+    },
+    // The implementation does not exist yet (TDD): this package is currently a
+    // test suite for the future `catcolab-documents` source in `src/`.
+    "files": []
+}

--- a/packages/documents/tsconfig.test.json
+++ b/packages/documents/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    "extends": ["./tsconfig.json", "@tsconfig/strictest/tsconfig.json"],
+    "compilerOptions": {
+        "noEmit": true,
+        "types": ["node"],
+        "jsx": "preserve",
+        "jsxImportSource": "solid-js",
+        "lib": ["ES2023", "DOM", "DOM.Iterable"]
+    },
+    "include": ["vite.config.ts", "test/**/*.ts", "test/**/*.tsx"]
+}

--- a/packages/documents/vite.config.ts
+++ b/packages/documents/vite.config.ts
@@ -1,0 +1,15 @@
+import { monorepoDedupe } from "@catcolab-dev-tools/vite-plugin-monorepo-dedupe";
+import solid from "vite-plugin-solid";
+import wasm from "vite-plugin-wasm";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    plugins: [monorepoDedupe(), wasm(), solid()],
+    test: {
+        environment: "happy-dom",
+        typecheck: {
+            enabled: true,
+            tsconfig: "./tsconfig.test.json",
+        },
+    },
+});

--- a/packages/logics/package.json
+++ b/packages/logics/package.json
@@ -1,0 +1,33 @@
+{
+    "name": "catcolab-logics",
+    "version": "0.1.0",
+    "private": true,
+    "license": "MIT",
+    "type": "module",
+    "exports": {
+        "./*": "./src/*.ts"
+    },
+    "scripts": {
+        "format": "oxfmt .",
+        "lint": "oxlint --fix && oxfmt .",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "check": "tsc -p tsconfig.test.json && pnpm run lint",
+        "ci": "oxlint --deny-warnings && oxfmt --check ."
+    },
+    "dependencies": {
+        "catcolab-documents": "link:../documents",
+        "catlog-wasm": "link:../catlog-wasm/dist/pkg-browser"
+    },
+    "devDependencies": {
+        "@catcolab-dev-tools/vite-plugin-monorepo-dedupe": "link:../../tools/vite-plugin-monorepo-dedupe",
+        "@tsconfig/strictest": "^2.0.8",
+        "@types/node": "^24.0.0",
+        "catcolab-document-types": "link:../document-types/pkg",
+        "happy-dom": "^20.0.0",
+        "typescript": "^6.0.3",
+        "vite": "^7.2.2",
+        "vite-plugin-wasm": "^3.5.0",
+        "vitest": "^4.0.8"
+    }
+}

--- a/packages/logics/pnpm-lock.yaml
+++ b/packages/logics/pnpm-lock.yaml
@@ -1,0 +1,1039 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      catcolab-documents:
+        specifier: link:../documents
+        version: link:../documents
+      catlog-wasm:
+        specifier: link:../catlog-wasm/dist/pkg-browser
+        version: link:../catlog-wasm/dist/pkg-browser
+    devDependencies:
+      '@catcolab-dev-tools/vite-plugin-monorepo-dedupe':
+        specifier: link:../../tools/vite-plugin-monorepo-dedupe
+        version: link:../../tools/vite-plugin-monorepo-dedupe
+      '@tsconfig/strictest':
+        specifier: ^2.0.8
+        version: 2.0.8
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.13.3
+      catcolab-document-types:
+        specifier: link:../document-types/pkg
+        version: link:../document-types/pkg
+      happy-dom:
+        specifier: ^20.0.0
+        version: 20.10.6
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^7.2.2
+        version: 7.3.6(@types/node@24.13.3)
+      vite-plugin-wasm:
+        specifier: ^3.5.0
+        version: 3.6.0(vite@7.3.6(@types/node@24.13.3))
+      vitest:
+        specifier: ^4.0.8
+        version: 4.1.10(@types/node@24.13.3)(happy-dom@20.10.6)(vite@7.3.6(@types/node@24.13.3))
+
+packages:
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tsconfig/strictest@2.0.8':
+    resolution: {integrity: sha512-XnQ7vNz5HRN0r88GYf1J9JJjqtZPiHt2woGJOo2dYqyHGGcd6OLGqSlBB6p1j9mpzja6Oe5BoPqWmeDx6X9rLw==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  happy-dom@20.10.6:
+    resolution: {integrity: sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==}
+    engines: {node: '>=20.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  vite-plugin-wasm@3.6.0:
+    resolution: {integrity: sha512-mL/QPziiIA4RAA6DkaZZzOstdwbW5jO4Vz7Zenj0wieKWBlNvIvX5L5ljum9lcUX0ShNfBgCNLKTjNkRVVqcsw==}
+    peerDependencies:
+      vite: ^2 || ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tsconfig/strictest@2.0.8': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@24.13.3':
+    dependencies:
+      undici-types: 7.18.2
+
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 24.13.3
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@24.13.3))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@24.13.3)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  assertion-error@2.0.1: {}
+
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 24.13.3
+
+  chai@6.2.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  entities@7.0.1: {}
+
+  es-module-lexer@2.3.0: {}
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fsevents@2.3.3:
+    optional: true
+
+  happy-dom@20.10.6:
+    dependencies:
+      '@types/node': 24.13.3
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  nanoid@3.3.15: {}
+
+  obug@2.1.3: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  postcss@8.5.16:
+    dependencies:
+      nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rollup@4.62.2:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
+      fsevents: 2.3.3
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
+
+  typescript@6.0.3: {}
+
+  undici-types@7.18.2: {}
+
+  vite-plugin-wasm@3.6.0(vite@7.3.6(@types/node@24.13.3)):
+    dependencies:
+      vite: 7.3.6(@types/node@24.13.3)
+
+  vite@7.3.6(@types/node@24.13.3):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rollup: 4.62.2
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.3
+      fsevents: 2.3.3
+
+  vitest@4.1.10(@types/node@24.13.3)(happy-dom@20.10.6)(vite@7.3.6(@types/node@24.13.3)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@24.13.3))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.6(@types/node@24.13.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.3
+      happy-dom: 20.10.6
+    transitivePeerDependencies:
+      - msw
+
+  whatwg-mimetype@3.0.0: {}
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  ws@8.21.0: {}

--- a/packages/logics/test/simple-olog.test.ts
+++ b/packages/logics/test/simple-olog.test.ts
@@ -1,0 +1,102 @@
+import { Aspect, SimpleOlog, Type } from "catcolab-logics/simple-olog";
+import { SimpleSchema } from "catcolab-logics/simple-schema";
+import { describe, expect, test } from "vitest";
+
+// The `simple-olog` logic (RFC-0006 "Defining notebook shapes").
+//
+// `catcolab-logics/simple-olog` binds the theory of categories to the frontend
+// as a shape: a basic `Type` object, a `Hom` `Aspect` morphism, rich text,
+// equations, instances (diagrams) and a migration to `simple-schema`.
+import { createBinder, PathEquation, RichText } from "catcolab-documents";
+
+describe.skip("the simple-olog logic", () => {
+    test("Type is the basic Object and Aspect is a Hom over it", async () => {
+        const binder = createBinder();
+        const notebook = await binder.createNotebook(SimpleOlog, { title: "An Olog" });
+
+        expect(notebook.document.theory).toBe("simple-olog");
+
+        const a = notebook.add(Type, { label: "A" });
+        const b = notebook.add(Type, { label: "B" });
+        const has = notebook.add(Aspect, { label: "has", from: a, to: b });
+
+        expect(Type.obType).toEqual({ tag: "Basic", content: "Object" });
+        expect(a.type.obType.content).toBe("Object");
+        expect(has.type.morType.tag).toBe("Hom");
+    });
+
+    test("notebooks validate against the core theory of categories", async () => {
+        const binder = createBinder();
+        const notebook = await binder.createNotebook(SimpleOlog, { title: "An Olog" });
+
+        const a = notebook.add(Type, { label: "A" });
+        const b = notebook.add(Type, { label: "B" });
+        notebook.add(Aspect, { label: "has", from: a, to: b });
+
+        const result = await notebook.validate();
+        expect(result.tag).toBe("Ok");
+        if (result.tag !== "Ok") {
+            return;
+        }
+        expect(result.content.obGenerators().length).toBe(2);
+        expect(result.content.morGenerators().length).toBe(1);
+    });
+
+    test("the shape supports rich text and path equations", async () => {
+        const binder = createBinder();
+        const notebook = await binder.createNotebook(SimpleOlog, { title: "An Olog" });
+
+        const note = notebook.add(RichText, { content: "A note." });
+        expect(note.content).toBe("A note.");
+
+        const a = notebook.add(Type, { label: "A" });
+        const f = notebook.add(Aspect, { label: "f", from: a, to: a });
+        const g = notebook.add(Aspect, { label: "g", from: a, to: a });
+
+        const equation = notebook.add(PathEquation, {
+            label: "idempotent",
+            lhs: [f, f],
+            rhs: [g],
+        });
+        expect(equation.lhs.map((step) => step.label)).toEqual(["f", "f"]);
+        expect(notebook.cellsOf(PathEquation).length).toBe(1);
+    });
+
+    test("supportsInstances generates the .Diagram shape", async () => {
+        const binder = createBinder();
+        const model = await binder.createNotebook(SimpleOlog, { title: "An Olog" });
+
+        const A = model.add(Type, { label: "A" });
+        const B = model.add(Type, { label: "B" });
+        const has = model.add(Aspect, { label: "has", from: A, to: B });
+
+        const diagram = await binder.createNotebook(SimpleOlog.Diagram, {
+            title: "Olog diagram",
+            in: model,
+        });
+
+        const x = diagram.add(SimpleOlog.Diagram.Individual, { label: "x", over: A });
+        const y = diagram.add(SimpleOlog.Diagram.Individual, { label: "y", over: B });
+        const f = diagram.add(SimpleOlog.Diagram.Aspect, { from: x, to: y, over: has });
+
+        expect(x.over?.label).toBe("A");
+        expect(f.over?.label).toBe("has");
+    });
+
+    test("ologs migrate to simple-schema", async () => {
+        const binder = createBinder();
+        const olog = await binder.createNotebook(SimpleOlog, { title: "An Olog" });
+
+        const a = olog.add(Type, { label: "A" });
+        const b = olog.add(Type, { label: "B" });
+        olog.add(Aspect, { label: "has", from: a, to: b });
+
+        const migration = await olog.migrateTo(SimpleSchema);
+        expect(migration.tag).toBe("Ok");
+        if (migration.tag !== "Ok") {
+            return;
+        }
+        expect(migration.content.document.theory).toBe("simple-schema");
+        expect((await migration.content.validate()).tag).toBe("Ok");
+    });
+});

--- a/packages/logics/test/simple-schema.test.ts
+++ b/packages/logics/test/simple-schema.test.ts
@@ -1,0 +1,93 @@
+import { SimpleOlog } from "catcolab-logics/simple-olog";
+import { Attr, AttrType, Entity, Mapping, SimpleSchema } from "catcolab-logics/simple-schema";
+import { describe, expect, test } from "vitest";
+
+// The `simple-schema` logic (RFC-0006 "Defining notebook shapes").
+//
+// `catcolab-logics/simple-schema` binds the theory of schemas to the frontend
+// as a shape: basic `Entity` and `AttrType` objects, a `Hom` `Mapping` between
+// entities, a basic `Attr` from entities to attribute types, rich text,
+// equations, instances and a migration to `simple-olog`.
+import { createBinder, RichText } from "catcolab-documents";
+
+describe.skip("the simple-schema logic", () => {
+    test("Entity and AttrType are basic objects; Mapping and Attr relate them", async () => {
+        const binder = createBinder();
+        const notebook = await binder.createNotebook(SimpleSchema, { title: "Example schema" });
+
+        expect(notebook.document.theory).toBe("simple-schema");
+        expect(Entity.obType).toEqual({ tag: "Basic", content: "Entity" });
+        expect(AttrType.obType).toEqual({ tag: "Basic", content: "AttrType" });
+
+        const person = notebook.add(Entity, { label: "Person" });
+        const company = notebook.add(Entity, { label: "Company" });
+        const str = notebook.add(AttrType, { label: "String" });
+
+        const employer = notebook.add(Mapping, { label: "employer", from: person, to: company });
+        const name = notebook.add(Attr, { label: "name", from: person, to: str });
+
+        expect(person.type.obType.content).toBe("Entity");
+        expect(str.type.obType.content).toBe("AttrType");
+        expect(employer.type.morType.tag).toBe("Hom");
+        expect(name.type.morType).toEqual({ tag: "Basic", content: "Attr" });
+    });
+
+    test("notebooks validate against the core theory of schemas", async () => {
+        const binder = createBinder();
+        const notebook = await binder.createNotebook(SimpleSchema, { title: "Example schema" });
+
+        const person = notebook.add(Entity, { label: "Person" });
+        const company = notebook.add(Entity, { label: "Company" });
+        const str = notebook.add(AttrType, { label: "String" });
+        notebook.add(Mapping, { label: "employer", from: person, to: company });
+        notebook.add(Attr, { label: "name", from: person, to: str });
+
+        const result = await notebook.validate();
+        expect(result.tag).toBe("Ok");
+        if (result.tag !== "Ok") {
+            return;
+        }
+        expect(result.content.obGenerators().length).toBe(3);
+        expect(result.content.morGenerators().length).toBe(2);
+    });
+
+    test("the shape supports rich text", async () => {
+        const binder = createBinder();
+        const notebook = await binder.createNotebook(SimpleSchema, { title: "Example schema" });
+
+        const note = notebook.add(RichText, { content: "A note." });
+        expect(note.content).toBe("A note.");
+    });
+
+    test("supportsInstances generates the .Diagram shape", async () => {
+        const binder = createBinder();
+        const model = await binder.createNotebook(SimpleSchema, { title: "Example schema" });
+
+        const person = model.add(Entity, { label: "Person" });
+
+        const diagram = await binder.createNotebook(SimpleSchema.Diagram, {
+            title: "Schema diagram",
+            in: model,
+        });
+
+        const x = diagram.add(SimpleSchema.Diagram.Individual, { label: "x", over: person });
+        expect(x.over?.label).toBe("Person");
+    });
+
+    test("schemas migrate to simple-olog", async () => {
+        const binder = createBinder();
+        const schema = await binder.createNotebook(SimpleSchema, { title: "Example schema" });
+
+        const person = schema.add(Entity, { label: "Person" });
+        const company = schema.add(Entity, { label: "Company" });
+        schema.add(Mapping, { label: "employer", from: person, to: company });
+
+        const migration = await schema.migrateTo(SimpleOlog);
+        expect(migration.tag).toBe("Ok");
+        if (migration.tag !== "Ok") {
+            return;
+        }
+        expect(migration.content.document.theory).toBe("simple-olog");
+        expect((await migration.content.validate()).tag).toBe("Ok");
+    });
+});

--- a/packages/logics/tsconfig.json
+++ b/packages/logics/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "module": "ESNext",
+        "lib": ["ES2023"],
+        "skipLibCheck": true,
+
+        "moduleResolution": "bundler",
+        "isolatedModules": true,
+        "noEmit": true,
+
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noFallthroughCasesInSwitch": true
+    },
+    // The logics do not exist yet (TDD): this package is currently a test
+    // suite for the future `catcolab-logics` source in `src/`.
+    "files": []
+}

--- a/packages/logics/tsconfig.test.json
+++ b/packages/logics/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+    "extends": ["./tsconfig.json", "@tsconfig/strictest/tsconfig.json"],
+    "compilerOptions": {
+        "noEmit": true,
+        "types": ["node"],
+        "lib": ["ES2023", "DOM", "DOM.Iterable"]
+    },
+    "include": ["vite.config.ts", "test/**/*.ts"]
+}

--- a/packages/logics/vite.config.ts
+++ b/packages/logics/vite.config.ts
@@ -1,0 +1,10 @@
+import { monorepoDedupe } from "@catcolab-dev-tools/vite-plugin-monorepo-dedupe";
+import wasm from "vite-plugin-wasm";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    plugins: [monorepoDedupe(), wasm()],
+    test: {
+        environment: "happy-dom",
+    },
+});

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,8 @@ packages:
   - "packages/backend/pkg"
   - "packages/frontend"
   - "packages/document-methods"
+  - "packages/documents"
+  - "packages/logics"
   - "packages/ui-components"
   - "packages/gaios"
   - "tools/oxlint-plugin-catcolab"


### PR DESCRIPTION
These are machine ported from RFC-0006 covering the documents package and the `SimpleOlog` and `SimpleSchema` logics. I included `PetriNet` because I had a lot of `PetriNet` examples in the RFC. No other logics or analyses notebooks expected to be implemented for these to pass. I expect we may want to tweak these here and there as we implement. 

I did confirm these _can_ pass, by letting them run against my very rough initial implementation that is not included here, but they are not only not run but also marked as skipped. Once we have some basic implementation going we can actually run them and unskip feature by feature.

The main thing to review here is probably the folder structure and naming for the new packages and just to glance over the tests to see if anything jumps out. I don't expect anyone to read all the tests but they should all look familiar from the RFC. 