### PR TITLE
OBEE-17 Action API: Property based tests for model notebooks

### DIFF
--- a/infrastructure/scripts/dump-model-fixtures
+++ b/infrastructure/scripts/dump-model-fixtures
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Dump all active model documents from a CatColab deployment.
+#
+# Usage: dump-model-fixtures <ssh-target> <document-server> <output-file>
+# Example: dump-model-fixtures catcolab@backend-next.catcolab.org next.catcolab.org dumps/next-model-fixtures.json
+
+set -euo pipefail
+umask 077
+
+ssh_target="${1:?Usage: dump-model-fixtures <ssh-target> <document-server> <output-file>}"
+document_server="${2:?Usage: dump-model-fixtures <ssh-target> <document-server> <output-file>}"
+output_file="${3:?Usage: dump-model-fixtures <ssh-target> <document-server> <output-file>}"
+models_file=$(mktemp)
+output_dir=$(dirname "$output_file")
+if [[ ! -d "$output_dir" ]]; then
+  echo "Error: output directory does not exist: $output_dir" >&2
+  exit 1
+fi
+output_tmp=$(mktemp "$output_dir/.model-fixtures.XXXXXX")
+trap 'rm -f "$models_file" "$output_tmp"' EXIT
+
+echo "Dumping active model documents from $ssh_target..." >&2
+echo "Warning: the output contains private user-authored notebook content." >&2
+
+ssh "$ssh_target" bash -s > "$models_file" <<'REMOTE_SCRIPT'
+set -euo pipefail
+
+if [[ ! -f /run/agenix/catcolabSecrets ]]; then
+  echo "Error: /run/agenix/catcolabSecrets not found" >&2
+  exit 1
+fi
+
+db_url=$(grep '^DATABASE_URL=' /run/agenix/catcolabSecrets | cut -d= -f2-)
+if [[ -z "$db_url" ]]; then
+  echo "Error: DATABASE_URL not found in /run/agenix/catcolabSecrets" >&2
+  exit 1
+fi
+
+psql "$db_url" -t -A -c "
+  SELECT COALESCE(
+    json_agg(
+      json_build_object(
+        'refId', r.id::text,
+        'document', s.content
+      )
+      ORDER BY r.id
+    ),
+    '[]'::json
+  )
+  FROM refs r
+  JOIN snapshots s
+    ON s.id = r.current_snapshot
+   AND s.for_ref = r.id
+  WHERE r.deleted_at IS NULL
+    AND s.content->>'type' = 'model';
+"
+REMOTE_SCRIPT
+
+jq --arg server "$document_server" '{formatVersion: 1, server: $server, models: .}' \
+  "$models_file" > "$output_tmp"
+jq empty "$output_tmp"
+mv "$output_tmp" "$output_file"
+
+model_count=$(jq '.models | length' "$output_file")
+echo "Dumped $model_count active model documents to $output_file" >&2

--- a/packages/documents/package.json
+++ b/packages/documents/package.json
@@ -12,6 +12,7 @@
         "format": "oxfmt .",
         "lint": "oxlint --fix && oxfmt .",
         "test": "vitest run",
+        "test:db-dump": "vitest --config vitest.db-dump.config.ts --run",
         "test:watch": "vitest",
         "check": "tsc -p tsconfig.test.json && pnpm run lint",
         "ci": "oxlint --deny-warnings && oxfmt --check ."
@@ -33,6 +34,7 @@
         "@types/uuid": "^10.0.0",
         "catcolab-documents": "workspace:*",
         "catcolab-logics": "workspace:*",
+        "fast-check": "^4.9.0",
         "happy-dom": "^20.0.0",
         "prosemirror-model": "^1.25.9",
         "prosemirror-state": "^1.4.4",

--- a/packages/documents/pnpm-lock.yaml
+++ b/packages/documents/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       catcolab-logics:
         specifier: workspace:*
         version: link:../logics
+      fast-check:
+        specifier: ^4.9.0
+        version: 4.9.0
       happy-dom:
         specifier: ^20.0.0
         version: 20.10.6
@@ -699,6 +702,10 @@ packages:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
+  fast-check@4.9.0:
+    resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
+    engines: {node: '>=12.17.0'}
+
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
@@ -820,6 +827,9 @@ packages:
 
   prosemirror-view@1.42.0:
     resolution: {integrity: sha512-N54DF3OXNWDuP81G1kbfCys8ZzIjuL1VnvJ2mk5STSu/fNxWIcX/EutQLA3s9KR/2wVhgDi4hzBB/1fINVxk0A==}
+
+  pure-rand@8.4.2:
+    resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
 
   rollup@4.62.2:
     resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
@@ -1579,6 +1589,10 @@ snapshots:
 
   expect-type@1.4.0: {}
 
+  fast-check@4.9.0:
+    dependencies:
+      pure-rand: 8.4.2
+
   fast-sha256@1.3.0: {}
 
   fdir@6.5.0(picomatch@4.0.5):
@@ -1698,6 +1712,8 @@ snapshots:
       prosemirror-model: 1.25.10
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
+
+  pure-rand@8.4.2: {}
 
   rollup@4.62.2:
     dependencies:

--- a/packages/documents/test/corpus/model-editing.db-dump-test.ts
+++ b/packages/documents/test/corpus/model-editing.db-dump-test.ts
@@ -1,0 +1,503 @@
+import { readFileSync } from "node:fs";
+import { PetriNet } from "catcolab-logics/petri-net";
+import { SimpleOlog } from "catcolab-logics/simple-olog";
+import { SimpleSchema } from "catcolab-logics/simple-schema";
+import fc from "fast-check";
+import { describe, expect, test } from "vitest";
+
+import { migrateDocument, type Document } from "catcolab-document-types";
+import {
+    createBinder,
+    type DocumentStore,
+    type Notebook,
+    RichText,
+    type ValidatableNotebook,
+} from "catcolab-documents";
+import { assertNotebookStructureIsConsistent } from "../helpers/notebook_invariants";
+
+const shapeByTheory = {
+    "petri-net": PetriNet,
+    "simple-olog": SimpleOlog,
+    "simple-schema": SimpleSchema,
+} as const;
+
+type SupportedShape = (typeof shapeByTheory)[keyof typeof shapeByTheory];
+type CorpusNotebook = Notebook<SupportedShape> & ValidatableNotebook;
+type CorpusTransaction = ReturnType<CorpusNotebook["beginTransaction"]>;
+type ModelDocument = Extract<Document, { type: "model" }>;
+
+type Edit =
+    | { kind: "add-rich-text"; content: string }
+    | { kind: "delete"; target: number }
+    | { kind: "duplicate"; target: number }
+    | { kind: "move-down"; target: number }
+    | { kind: "move-to"; target: number; destination: number }
+    | { kind: "move-up"; target: number };
+
+type SemanticPreservingEdit =
+    | { kind: "add-rich-text"; content: string }
+    | { kind: "move-down"; target: number }
+    | { kind: "move-to"; target: number; destination: number }
+    | { kind: "move-up"; target: number };
+
+const editArbitrary: fc.Arbitrary<Edit> = fc.oneof(
+    fc.record({ kind: fc.constant("add-rich-text"), content: fc.string() }),
+    fc.record({ kind: fc.constant("delete"), target: fc.nat() }),
+    fc.record({ kind: fc.constant("duplicate"), target: fc.nat() }),
+    fc.record({ kind: fc.constant("move-down"), target: fc.nat() }),
+    fc.record({
+        kind: fc.constant("move-to"),
+        target: fc.nat(),
+        destination: fc.integer(),
+    }),
+    fc.record({ kind: fc.constant("move-up"), target: fc.nat() }),
+);
+
+const editProgramArbitrary = fc.array(editArbitrary, { minLength: 1, maxLength: 25 });
+
+const semanticPreservingEditArbitrary: fc.Arbitrary<SemanticPreservingEdit> = fc.oneof(
+    fc.record({ kind: fc.constant("add-rich-text"), content: fc.string() }),
+    fc.record({ kind: fc.constant("move-down"), target: fc.nat() }),
+    fc.record({
+        kind: fc.constant("move-to"),
+        target: fc.nat(),
+        destination: fc.integer(),
+    }),
+    fc.record({ kind: fc.constant("move-up"), target: fc.nat() }),
+);
+
+const semanticPreservingProgramArbitrary = fc.array(semanticPreservingEditArbitrary, {
+    minLength: 1,
+    maxLength: 25,
+});
+
+type FixtureRecord = {
+    readonly refId: string;
+    readonly document: ModelDocument;
+};
+
+type Corpus = {
+    readonly server: string;
+    readonly records: ReadonlyMap<string, FixtureRecord>;
+    readonly candidates: readonly FixtureRecord[];
+    readonly migrationFailures: number;
+    readonly total: number;
+};
+
+type FixtureHandle = {
+    readonly refId: string;
+    readonly listeners: Set<() => void>;
+    document: Document;
+};
+
+function notify(handle: FixtureHandle): void {
+    for (const listener of handle.listeners) {
+        listener();
+    }
+}
+
+describe("editing valid models from a Next database dump", () => {
+    test("arbitrary transactional edits preserve structure and revert exactly", async () => {
+        const fixturePath = process.env["NOTEBOOK_FIXTURES_PATH"];
+        if (!fixturePath) {
+            throw new Error("NOTEBOOK_FIXTURES_PATH must point to a Next model fixture.");
+        }
+
+        const corpus = loadCorpus(fixturePath);
+        const limit = readPositiveInteger("DOCUMENT_CORPUS_LIMIT") ?? corpus.candidates.length;
+        const numRuns = readPositiveInteger("DOCUMENT_CORPUS_RUNS") ?? 3;
+        const candidates = corpus.candidates.slice(0, limit);
+        const candidateTheories = new Set(candidates.map(({ document }) => document.theory));
+        const validByTheory = new Map<string, number>();
+
+        let valid = 0;
+        let loadFailures = 0;
+        let structurallyInvalid = 0;
+        let semanticallyInvalid = 0;
+
+        for (const candidate of candidates) {
+            const opened = await openFixture(corpus, candidate);
+            if (opened.tag === "Err") {
+                loadFailures += 1;
+                continue;
+            }
+
+            try {
+                assertNotebookStructureIsConsistent(opened.notebook);
+            } catch {
+                structurallyInvalid += 1;
+                continue;
+            }
+
+            if ((await opened.notebook.validate()).tag !== "Ok") {
+                semanticallyInvalid += 1;
+                continue;
+            }
+
+            valid += 1;
+            validByTheory.set(
+                candidate.document.theory,
+                (validByTheory.get(candidate.document.theory) ?? 0) + 1,
+            );
+            await checkFixture(corpus, candidate, numRuns);
+        }
+
+        console.info("Next model corpus summary", {
+            candidates: candidates.length,
+            loadFailures,
+            migrationFailures: corpus.migrationFailures,
+            semanticallyInvalid,
+            structurallyInvalid,
+            total: corpus.total,
+            valid,
+        });
+        expect(valid).toBeGreaterThan(0);
+        for (const theory of candidateTheories) {
+            expect(validByTheory.get(theory) ?? 0).toBeGreaterThan(0);
+        }
+    });
+});
+
+async function checkFixture(
+    corpus: Corpus,
+    fixture: FixtureRecord,
+    numRuns: number,
+): Promise<void> {
+    try {
+        await fc.assert(
+            fc.asyncProperty(semanticPreservingProgramArbitrary, async (edits) => {
+                const opened = await openFixture(corpus, fixture);
+                if (opened.tag === "Err") {
+                    throw new Error("A baseline-valid fixture could not be reopened.");
+                }
+
+                for (const edit of edits) {
+                    applySemanticPreservingEdit(opened.notebook, edit);
+                    assertNotebookStructureIsConsistent(opened.notebook);
+                    expect((await opened.notebook.validate()).tag).toBe("Ok");
+                }
+            }),
+            { numRuns, seed: seedFromRef(fixture.refId) },
+        );
+
+        await fc.assert(
+            fc.asyncProperty(editProgramArbitrary, async (edits) => {
+                const opened = await openFixture(corpus, fixture);
+                if (opened.tag === "Err") {
+                    throw new Error("A baseline-valid fixture could not be reopened.");
+                }
+
+                const { notebook, storeHarness } = opened;
+                assertNotebookStructureIsConsistent(notebook);
+                expect((await notebook.validate()).tag).toBe("Ok");
+
+                const baseline = structuredClone(notebook.dump());
+                const dependencies = storeHarness.snapshotLoadedExcept(fixture.refId);
+                const transaction = notebook.beginTransaction();
+
+                for (const edit of edits) {
+                    applyEdit(transaction, edit);
+                    assertNotebookStructureIsConsistent(transaction);
+                }
+
+                const commit = transaction.commit();
+                assertNotebookStructureIsConsistent(notebook);
+                expect(["Err", "Ok"]).toContain((await notebook.validate()).tag);
+
+                notebook.revertCommit(commit);
+                assertNotebookStructureIsConsistent(notebook);
+                expect(notebook.dump()).toEqual(baseline);
+                expect((await notebook.validate()).tag).toBe("Ok");
+                expect(storeHarness.snapshotLoadedExcept(fixture.refId)).toEqual(dependencies);
+            }),
+            { numRuns, seed: seedFromRef(fixture.refId) },
+        );
+    } catch (error) {
+        throw new Error(
+            `Editing property failed for ref ${fixture.refId}, theory ${fixture.document.theory}.`,
+            { cause: error },
+        );
+    }
+}
+
+function applySemanticPreservingEdit(notebook: CorpusNotebook, edit: SemanticPreservingEdit): void {
+    if (edit.kind === "add-rich-text") {
+        notebook.add(RichText, { content: edit.content });
+        return;
+    }
+
+    const cells = notebook.cells();
+    if (cells.length === 0) {
+        return;
+    }
+    const cell = cells[edit.target % cells.length];
+    if (!cell) {
+        return;
+    }
+
+    switch (edit.kind) {
+        case "move-down":
+            cell.moveDown();
+            break;
+        case "move-to":
+            cell.moveTo(edit.destination);
+            break;
+        case "move-up":
+            cell.moveUp();
+            break;
+    }
+}
+
+function applyEdit(notebook: CorpusTransaction, edit: Edit): void {
+    if (edit.kind === "add-rich-text") {
+        notebook.add(RichText, { content: edit.content });
+        return;
+    }
+
+    const cells = notebook.cells();
+    if (cells.length === 0) {
+        return;
+    }
+
+    const cell = cells[edit.target % cells.length];
+    if (!cell) {
+        return;
+    }
+
+    switch (edit.kind) {
+        case "delete":
+            cell.delete();
+            break;
+        case "duplicate":
+            if ("duplicate" in cell && typeof cell.duplicate === "function") {
+                cell.duplicate();
+            }
+            break;
+        case "move-down":
+            cell.moveDown();
+            break;
+        case "move-to":
+            cell.moveTo(edit.destination);
+            break;
+        case "move-up":
+            cell.moveUp();
+            break;
+    }
+}
+
+async function openFixture(
+    corpus: Corpus,
+    fixture: FixtureRecord,
+): Promise<
+    { tag: "Ok"; notebook: CorpusNotebook; storeHarness: FixtureStoreHarness } | { tag: "Err" }
+> {
+    const storeHarness = createFixtureStore(corpus.records, corpus.server);
+    const binder = createBinder(storeHarness.store);
+    const shape = shapeByTheory[fixture.document.theory as keyof typeof shapeByTheory];
+    if (!shape) {
+        return { tag: "Err" };
+    }
+
+    const loaded = await binder.loadNotebookFromRef(shape, {
+        id: fixture.refId,
+        server: corpus.server,
+        version: null,
+    });
+    return loaded.tag === "Ok"
+        ? { tag: "Ok", notebook: loaded.content as CorpusNotebook, storeHarness }
+        : { tag: "Err" };
+}
+
+type FixtureStoreHarness = {
+    readonly store: DocumentStore<FixtureHandle, Document>;
+    snapshotLoadedExcept(refId: string): Map<string, Document>;
+};
+
+function createFixtureStore(
+    records: ReadonlyMap<string, FixtureRecord>,
+    server: string,
+): FixtureStoreHarness {
+    const handles = new Map<string, FixtureHandle>();
+    let createdCount = 0;
+
+    const replaceDocument = (handle: FixtureHandle, document: Document): void => {
+        for (const key of Object.keys(handle.document)) {
+            delete (handle.document as unknown as Record<string, unknown>)[key];
+        }
+        Object.assign(handle.document, structuredClone(document));
+        notify(handle);
+    };
+
+    const getOrCreate = (refId: string): FixtureHandle | undefined => {
+        const existing = handles.get(refId);
+        if (existing) {
+            return existing;
+        }
+        const fixture = records.get(refId);
+        if (!fixture) {
+            return undefined;
+        }
+        const handle = {
+            refId,
+            listeners: new Set<() => void>(),
+            document: structuredClone(fixture.document),
+        };
+        handles.set(refId, handle);
+        return handle;
+    };
+
+    return {
+        store: {
+            createHandle: async (document) => {
+                const refId = `fixture-created-${createdCount++}`;
+                const handle = {
+                    refId,
+                    listeners: new Set<() => void>(),
+                    document: structuredClone(document as Document),
+                };
+                handles.set(refId, handle);
+                return handle;
+            },
+            getDocumentView: (handle) => handle.document,
+            changeDocument: (handle, change) => {
+                change(handle.document);
+                notify(handle);
+            },
+            createDraft: (handle) => {
+                const refId = `fixture-draft-${createdCount++}`;
+                const draft = {
+                    refId,
+                    listeners: new Set<() => void>(),
+                    document: structuredClone(handle.document),
+                };
+                handles.set(refId, draft);
+                return draft;
+            },
+            commitDraft: (handle, draft) => {
+                const before = structuredClone(handle.document);
+                replaceDocument(handle, draft.document);
+                return { before, after: structuredClone(handle.document) };
+            },
+            revertCommit: (handle, commit) => replaceDocument(handle, commit.before),
+            subscribe: (handle, callback) => {
+                handle.listeners.add(callback);
+                return () => {
+                    handle.listeners.delete(callback);
+                };
+            },
+            copyValue: (_handle, value) => structuredClone(value),
+            getDocumentRef: (handle) => ({ id: handle.refId, server, version: null }),
+            getHandle: async (ref) => {
+                if ((ref.server && ref.server !== server) || ref.version !== null) {
+                    return {
+                        tag: "Err",
+                        content: [
+                            {
+                                message: `Unsupported fixture reference ${ref.id}.`,
+                                path: ["id"],
+                            },
+                        ],
+                    };
+                }
+                const handle = getOrCreate(ref.id);
+                return handle
+                    ? { tag: "Ok", content: handle }
+                    : {
+                          tag: "Err",
+                          content: [
+                              {
+                                  message: `Cannot resolve fixture reference ${ref.id}.`,
+                                  path: ["id"],
+                              },
+                          ],
+                      };
+            },
+        },
+        snapshotLoadedExcept: (refId) =>
+            new Map(
+                [...handles]
+                    .filter(([loadedRefId]) => loadedRefId !== refId && records.has(loadedRefId))
+                    .map(([loadedRefId, handle]) => [
+                        loadedRefId,
+                        structuredClone(handle.document),
+                    ]),
+            ),
+    };
+}
+
+function loadCorpus(path: string): Corpus {
+    const value: unknown = JSON.parse(readFileSync(path, "utf8"));
+    if (!isRecord(value) || value["formatVersion"] !== 1 || typeof value["server"] !== "string") {
+        throw new Error("Invalid model fixture header.");
+    }
+    if (!Array.isArray(value["models"])) {
+        throw new Error("Model fixture must contain a models array.");
+    }
+
+    const records = new Map<string, FixtureRecord>();
+    const seenRefs = new Set<string>();
+    let migrationFailures = 0;
+    for (const entry of value["models"]) {
+        if (
+            !isRecord(entry) ||
+            typeof entry["refId"] !== "string" ||
+            !isRecord(entry["document"])
+        ) {
+            throw new Error("Invalid model fixture entry.");
+        }
+        const refId = entry["refId"];
+        if (seenRefs.has(refId)) {
+            throw new Error(`Duplicate fixture reference ${refId}.`);
+        }
+        seenRefs.add(refId);
+
+        let document: Document;
+        try {
+            document = migrateDocument(structuredClone(entry["document"])) as Document;
+        } catch {
+            migrationFailures += 1;
+            continue;
+        }
+        if (document.type !== "model") {
+            migrationFailures += 1;
+            continue;
+        }
+        records.set(refId, { refId, document });
+    }
+
+    const candidates = [...records.values()].filter(
+        ({ document }) => document.theory in shapeByTheory,
+    );
+    return {
+        server: value["server"],
+        records,
+        candidates,
+        migrationFailures,
+        total: value["models"].length,
+    };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readPositiveInteger(name: string): number | undefined {
+    const value = process.env[name];
+    if (value === undefined) {
+        return undefined;
+    }
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+        throw new Error(`${name} must be a positive integer.`);
+    }
+    return parsed;
+}
+
+function seedFromRef(refId: string): number {
+    let hash = 0x811c9dc5;
+    for (const char of refId) {
+        hash ^= char.codePointAt(0) ?? 0;
+        hash = Math.imul(hash, 0x01000193);
+    }
+    return hash & 0x7fffffff;
+}

--- a/packages/documents/test/helpers/notebook_invariants.ts
+++ b/packages/documents/test/helpers/notebook_invariants.ts
@@ -1,0 +1,40 @@
+import { expect } from "vitest";
+
+import type { Document } from "catcolab-document-types";
+
+export type NotebookWithDocument = {
+    readonly document: Document;
+    cells(): readonly { id: string }[];
+    dump(): unknown;
+};
+
+/** Assert that the persisted notebook index and the public cell view agree. */
+export function assertNotebookStructureIsConsistent(notebook: NotebookWithDocument): void {
+    const document = notebook.document;
+    if (document.type !== "model") {
+        throw new Error(`Expected a model document, got ${document.type}.`);
+    }
+
+    const { cellContents, cellOrder } = document.notebook;
+    const contentIds = Object.keys(cellContents);
+
+    expect(new Set(cellOrder).size).toBe(cellOrder.length);
+    expect(cellOrder.toSorted()).toEqual(contentIds.toSorted());
+
+    const formalIds: string[] = [];
+    for (const id of cellOrder) {
+        const cell = cellContents[id];
+        expect(cell).toBeDefined();
+        expect(cell?.id).toBe(id);
+        if (cell?.tag === "formal") {
+            formalIds.push(cell.content.id);
+        }
+    }
+
+    expect(new Set(formalIds).size).toBe(formalIds.length);
+    expect(notebook.cells().map((cell) => cell.id)).toEqual(cellOrder);
+
+    const dump = notebook.dump();
+    expect(() => structuredClone(dump)).not.toThrow();
+    expect(() => JSON.parse(JSON.stringify(dump))).not.toThrow();
+}

--- a/packages/documents/tsconfig.test.json
+++ b/packages/documents/tsconfig.test.json
@@ -7,5 +7,5 @@
         "jsxImportSource": "solid-js",
         "lib": ["ES2023", "DOM", "DOM.Iterable"]
     },
-    "include": ["vite.config.ts", "test/**/*.ts", "test/**/*.tsx"]
+    "include": ["vite.config.ts", "vitest.db-dump.config.ts", "test/**/*.ts", "test/**/*.tsx"]
 }

--- a/packages/documents/vitest.db-dump.config.ts
+++ b/packages/documents/vitest.db-dump.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+
+import baseConfig from "./vite.config";
+
+export default mergeConfig(
+    baseConfig,
+    defineConfig({
+        test: {
+            include: ["test/corpus/**/*.db-dump-test.ts"],
+            testTimeout: 600_000,
+        },
+    }),
+);


### PR DESCRIPTION
Based on #1346 

This implements property based tests, generating "arbitrary" edits that are executed on existing notebooks retrieved via a DB dump from next. 

"arbitrary" in quotation marks because we categorise them into edits that should preserve the validity of the models and ones that are destructive. 