### PR TITLE
OBEE-24 LLMConversation document connected to inference in FE

### DIFF
--- a/packages/backend/src/user_state.rs
+++ b/packages/backend/src/user_state.rs
@@ -505,6 +505,7 @@ pub mod arbitrary {
             DocumentType::Model,
             DocumentType::Diagram,
             DocumentType::Analysis,
+            DocumentType::LLMConversation,
         ])
         .boxed()
     }

--- a/packages/backend/tests/llm_conversation_tests.rs
+++ b/packages/backend/tests/llm_conversation_tests.rs
@@ -1,0 +1,70 @@
+//! Integration tests for LLM conversation backend behavior.
+
+#[cfg(feature = "integration-tests")]
+mod common;
+
+#[cfg(feature = "integration-tests")]
+mod integration_tests {
+    use crate::common::test_utils::{
+        create_test_app_state, create_test_document_content, create_test_firebase_user,
+        ensure_user_exists, run_migrations,
+    };
+    use backend::app::AppCtx;
+    use backend::document;
+    use backend::user_state::read_user_state_from_db;
+    use serde_json::json;
+    use sqlx::PgPool;
+    use uuid::Uuid;
+
+    fn create_llm_conversation_content(name: &str, parent_ref_id: Uuid) -> serde_json::Value {
+        json!({
+            "version": "2",
+            "type": "llmconversation",
+            "name": name,
+            "llmConversationOf": {
+                "_id": parent_ref_id.to_string(),
+                "_version": null,
+                "_server": "test",
+                "type": "llmconversation-of"
+            },
+            "llmModel": "openai/gpt-oss-20b:free",
+            "interactions": []
+        })
+    }
+
+    /// A conversation should be indexed as depending on its parent model.
+    #[sqlx::test]
+    async fn conversation_relation_is_indexed(pool: PgPool) -> sqlx::Result<()> {
+        run_migrations(&pool).await?;
+        let state = create_test_app_state(pool.clone()).await;
+
+        let user_id = format!("test_user_{}", Uuid::now_v7());
+        ensure_user_exists(&pool, &user_id).await.expect("Failed to create user");
+
+        let ctx = AppCtx {
+            state,
+            user: Some(create_test_firebase_user(&user_id)),
+        };
+        let parent_id =
+            document::new_ref(ctx.clone(), create_test_document_content("Parent Model"))
+                .await
+                .unwrap();
+        let conversation_id =
+            document::new_ref(ctx, create_llm_conversation_content("Conversation", parent_id))
+                .await
+                .unwrap();
+
+        let user_state = read_user_state_from_db(user_id, &pool).await.unwrap();
+        let parent = &user_state.documents[&parent_id.to_string()];
+        let conversation = &user_state.documents[&conversation_id.to_string()];
+
+        assert_eq!(conversation.depends_on.len(), 1);
+        assert_eq!(conversation.depends_on[0].ref_id, parent_id);
+        assert_eq!(conversation.depends_on[0].relation_type, "llmconversation-of");
+        assert_eq!(parent.used_by.len(), 1);
+        assert_eq!(parent.used_by[0].ref_id, conversation_id);
+        assert_eq!(parent.used_by[0].relation_type, "llmconversation-of");
+
+        Ok(())
+    }
+}

--- a/packages/document-methods/src/index.ts
+++ b/packages/document-methods/src/index.ts
@@ -1,7 +1,9 @@
 export type { DiagramDocument } from "./diagram";
+export type { LLMConversationDocument } from "./llm_conversation";
 export type { ModelDocument } from "./model";
 export type { FormalCell, RichTextCell } from "./notebook";
 
 export * as Diagram from "./diagram";
+export * as LLMConversation from "./llm_conversation";
 export * as Model from "./model";
 export * as Nb from "./notebook";

--- a/packages/document-methods/src/llm_conversation.ts
+++ b/packages/document-methods/src/llm_conversation.ts
@@ -14,15 +14,15 @@ import { currentVersion } from "catcolab-document-types";
 /** A document containing an LLM conversation attached to a model. */
 export type LLMConversationDocument = Document & { type: "llmconversation" };
 
-/** Create an empty LLM conversation for a model. */
+/** Create an empty LLM conversation for a document. */
 export const newLLMConversationDocument = (
-    modelRef: StableRef,
+    documentRef: StableRef,
     llmModel: string,
 ): LLMConversationDocument => ({
     name: "",
     type: "llmconversation",
     llmConversationOf: {
-        ...modelRef,
+        ...documentRef,
         type: "llmconversation-of",
     },
     llmModel,

--- a/packages/document-methods/src/llm_conversation.ts
+++ b/packages/document-methods/src/llm_conversation.ts
@@ -1,0 +1,98 @@
+import { v7 } from "uuid";
+
+import type {
+    EvalResult,
+    FeedbackResolution,
+    InlineFile,
+    Document,
+    LLMInteraction,
+    StableRef,
+    Uuid,
+} from "catcolab-document-types";
+import { currentVersion } from "catcolab-document-types";
+
+/** A document containing an LLM conversation attached to a model. */
+export type LLMConversationDocument = Document & { type: "llmconversation" };
+
+/** Create an empty LLM conversation for a model. */
+export const newLLMConversationDocument = (
+    modelRef: StableRef,
+    llmModel: string,
+): LLMConversationDocument => ({
+    name: "",
+    type: "llmconversation",
+    llmConversationOf: {
+        ...modelRef,
+        type: "llmconversation-of",
+    },
+    llmModel,
+    interactions: [],
+    version: currentVersion(),
+});
+
+/** Create an interaction containing a user message. */
+export function newUserMessage(
+    content: string,
+    files: InlineFile[],
+): Extract<LLMInteraction, { tag: "user-message" }> {
+    return {
+        tag: "user-message",
+        id: v7(),
+        timestamp: new Date().toISOString(),
+        content,
+        files,
+    };
+}
+
+/** Create an interaction containing a completed LLM message. */
+export function newLLMMessage(content: string): Extract<LLMInteraction, { tag: "llm-message" }> {
+    return {
+        tag: "llm-message",
+        id: v7(),
+        timestamp: new Date().toISOString(),
+        content,
+    };
+}
+
+/** Create an interaction containing one completed `contextExec` call. */
+export function newLLMCodeExecution(
+    toolCallId: string,
+    code: string,
+    result: EvalResult,
+    transaction?: unknown,
+): Extract<LLMInteraction, { tag: "llm-code-execution" }> {
+    return {
+        tag: "llm-code-execution",
+        id: v7(),
+        timestamp: new Date().toISOString(),
+        toolCallId,
+        code,
+        result,
+        ...(transaction === undefined ? {} : { transaction }),
+    };
+}
+
+/** Append an interaction to a conversation's ordered history. */
+export function appendLLMInteraction(
+    conversation: LLMConversationDocument,
+    interaction: LLMInteraction,
+) {
+    conversation.interactions.push(interaction);
+}
+
+/** Resolve a pending feedback request by its stable interaction ID. */
+export function resolveUserFeedbackRequest(
+    conversation: LLMConversationDocument,
+    requestId: Uuid,
+    resolution: Exclude<FeedbackResolution, "unresolved">,
+) {
+    const request = conversation.interactions.find(
+        (interaction): interaction is Extract<LLMInteraction, { tag: "user-feedback-request" }> =>
+            interaction.tag === "user-feedback-request" && interaction.id === requestId,
+    );
+    if (!request || request.resolution !== "unresolved") {
+        return false;
+    }
+    request.resolution = resolution;
+    return true;
+}

--- a/packages/document-types/src/v0/api.rs
+++ b/packages/document-types/src/v0/api.rs
@@ -57,6 +57,9 @@ pub enum LinkType {
     #[serde(rename = "diagram-in")]
     DiagramIn,
 
+    #[serde(rename = "llmconversation-of")]
+    ConversationOf,
+
     #[serde(rename = "instantiation")]
     Instantiation,
 }
@@ -75,6 +78,7 @@ pub(crate) mod arbitrary {
             proptest::sample::select(&[
                 LinkType::AnalysisOf,
                 LinkType::DiagramIn,
+                LinkType::ConversationOf,
                 LinkType::Instantiation,
             ])
             .boxed()

--- a/packages/document-types/src/v0/document.rs
+++ b/packages/document-types/src/v0/document.rs
@@ -64,6 +64,8 @@ pub enum DocumentType {
     Diagram,
     #[cfg_attr(feature = "backend", autosurgeon(rename = "analysis"))]
     Analysis,
+    #[cfg_attr(feature = "backend", autosurgeon(rename = "llmconversation"))]
+    LLMConversation,
 }
 
 impl FromStr for DocumentType {
@@ -74,6 +76,7 @@ impl FromStr for DocumentType {
             "model" => Ok(DocumentType::Model),
             "diagram" => Ok(DocumentType::Diagram),
             "analysis" => Ok(DocumentType::Analysis),
+            "llmconversation" => Ok(DocumentType::LLMConversation),
             other => Err(format!("unknown document type: {other}")),
         }
     }

--- a/packages/document-types/src/v2/document.rs
+++ b/packages/document-types/src/v2/document.rs
@@ -4,6 +4,7 @@ pub use crate::v1::DocumentType;
 
 use super::analysis::Analysis;
 use super::api::Link;
+use super::llm_conversation::LLMConversationDocumentContent;
 use super::notebook::Notebook;
 
 use serde::{Deserialize, Serialize};
@@ -58,6 +59,8 @@ pub enum Document {
     Diagram(DiagramDocumentContent),
     #[serde(rename = "analysis")]
     Analysis(AnalysisDocumentContent),
+    #[serde(rename = "llmconversation")]
+    LLMConversation(LLMConversationDocumentContent),
 }
 
 impl Document {

--- a/packages/document-types/src/v2/llm_conversation.rs
+++ b/packages/document-types/src/v2/llm_conversation.rs
@@ -5,20 +5,13 @@ use serde_json::Value;
 use tsify::Tsify;
 use uuid::Uuid;
 
-/// A supported inline file type.
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
-pub enum FileType {
-    CSV,
-}
-
 /// A file stored inline with a user message.
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub struct InlineFile {
     pub filename: String,
-    #[serde(rename = "fileType")]
-    pub file_type: FileType,
+    #[serde(rename = "mediaType")]
+    pub media_type: String,
     pub content: Vec<u8>,
 }
 
@@ -101,7 +94,7 @@ pub enum LLMInteraction {
     UserFeedbackRequest(UserFeedbackRequest),
 }
 
-/// A sequential conversation attached to a CatColab model.
+/// A sequential conversation attached to a CatColab document.
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub struct LLMConversationDocumentContent {

--- a/packages/document-types/src/v2/llm_conversation.rs
+++ b/packages/document-types/src/v2/llm_conversation.rs
@@ -1,0 +1,115 @@
+use super::api::Link;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tsify::Tsify;
+use uuid::Uuid;
+
+/// A supported inline file type.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub enum FileType {
+    CSV,
+}
+
+/// A file stored inline with a user message.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct InlineFile {
+    pub filename: String,
+    #[serde(rename = "fileType")]
+    pub file_type: FileType,
+    pub content: Vec<u8>,
+}
+
+/// The result of executing code requested by the LLM.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
+#[serde(tag = "tag")]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub enum EvalResult {
+    Ok { value: String },
+    Err { error: String },
+}
+
+/// A message submitted by the user.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct UserMessage {
+    pub timestamp: String,
+    pub id: Uuid,
+    pub content: String,
+    pub files: Vec<InlineFile>,
+}
+
+/// A completed textual response from the LLM.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct LLMMessage {
+    pub timestamp: String,
+    pub id: Uuid,
+    pub content: String,
+}
+
+/// A `contextExec` call and its completed result.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct LLMCodeExecution {
+    pub timestamp: String,
+    pub id: Uuid,
+    #[serde(rename = "toolCallId")]
+    pub tool_call_id: String,
+    pub code: String,
+    pub result: EvalResult,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transaction: Option<Value>,
+}
+
+/// The user's resolution of a feedback request.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
+#[serde(rename_all = "lowercase")]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub enum FeedbackResolution {
+    Unresolved,
+    Approved,
+    Rejected,
+}
+
+/// A request for the user to approve or reject a proposed transaction.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct UserFeedbackRequest {
+    pub timestamp: String,
+    pub id: Uuid,
+    #[serde(rename = "codeExecution")]
+    pub code_execution: Uuid,
+    pub content: String,
+    pub resolution: FeedbackResolution,
+}
+
+/// An interaction in an LLM conversation.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
+#[serde(tag = "tag")]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub enum LLMInteraction {
+    #[serde(rename = "user-message")]
+    UserMessage(UserMessage),
+    #[serde(rename = "llm-message")]
+    LLMMessage(LLMMessage),
+    #[serde(rename = "llm-code-execution")]
+    LLMCodeExecution(LLMCodeExecution),
+    #[serde(rename = "user-feedback-request")]
+    UserFeedbackRequest(UserFeedbackRequest),
+}
+
+/// A sequential conversation attached to a CatColab model.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct LLMConversationDocumentContent {
+    pub name: String,
+    #[serde(rename = "llmConversationOf")]
+    pub conversation_of: Link,
+    #[serde(rename = "llmModel")]
+    pub llm_model: String,
+    pub interactions: Vec<LLMInteraction>,
+    pub version: String,
+}

--- a/packages/document-types/src/v2/mod.rs
+++ b/packages/document-types/src/v2/mod.rs
@@ -4,6 +4,7 @@ pub use v1::{analysis, api, diagram_judgment, model, model_judgment, path, theor
 
 pub mod cell;
 pub mod document;
+pub mod llm_conversation;
 pub mod notebook;
 
 pub use analysis::*;
@@ -11,6 +12,7 @@ pub use api::*;
 pub use cell::*;
 pub use diagram_judgment::*;
 pub use document::*;
+pub use llm_conversation::*;
 pub use model::*;
 pub use model_judgment::*;
 pub use notebook::*;

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -62,6 +62,7 @@
         "js-file-download": "^0.4.12",
         "katex": "^0.16.22",
         "lucide-solid": "^0.471.0",
+        "openai": "^6.45.0",
         "prosemirror-commands": "^1.7.1",
         "prosemirror-inputrules": "^1.5.0",
         "prosemirror-keymap": "^1.2.3",

--- a/packages/frontend/pnpm-lock.yaml
+++ b/packages/frontend/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       lucide-solid:
         specifier: ^0.471.0
         version: 0.471.0(solid-js@1.9.10)
+      openai:
+        specifier: ^6.45.0
+        version: 6.45.0(ws@8.18.3)
       prosemirror-commands:
         specifier: ^1.7.1
         version: 1.7.1
@@ -2368,6 +2371,26 @@ packages:
 
   oniguruma-to-js@0.4.3:
     resolution: {integrity: sha512-X0jWUcAlxORhOqqBREgPMgnshB7ZGYszBNspP+tS9hPD3l13CdaXcHbgImoHUHlrvGx/7AvFEkTRhAGYh+jzjQ==}
+
+  openai@6.45.0:
+    resolution: {integrity: sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==}
+    peerDependencies:
+      '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
+      '@smithy/hash-node': '>=4.3.0 <5'
+      '@smithy/signature-v4': '>=5.4.0 <6'
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-node':
+        optional: true
+      '@smithy/hash-node':
+        optional: true
+      '@smithy/signature-v4':
+        optional: true
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -5957,6 +5980,10 @@ snapshots:
   oniguruma-to-js@0.4.3:
     dependencies:
       regex: 4.3.2
+
+  openai@6.45.0(ws@8.18.3):
+    optionalDependencies:
+      ws: 8.18.3
 
   optionator@0.9.4:
     dependencies:

--- a/packages/frontend/src/api/inference_rpc.test.ts
+++ b/packages/frontend/src/api/inference_rpc.test.ts
@@ -1,17 +1,14 @@
 import { type FirebaseOptions, initializeApp } from "firebase/app";
 import { deleteUser, getAuth, signInWithEmailAndPassword, signOut } from "firebase/auth";
 import invariant from "tiny-invariant";
-import { afterAll, assert, describe, test } from "vitest";
+import { afterAll, assert, beforeAll, describe, test } from "vitest";
 
 import { initTestUserAuth } from "../util/test_util.ts";
 import { createFetchWithAuth, createRpcClient, unwrap, unwrapErr } from "./rpc.ts";
 
 // These tests exercise the live `get_inference_key` RPC, which creates
-// OpenRouter child keys when a provisioning key is configured. They are skipped
-// unless `VITE_RUN_INFERENCE_TESTS=1` is set, so they run locally but not in
-// CI. To run them, ensure you have a backend running; they work both with and
-// without `OPENROUTER_PROVISIONING_KEY` set.
-const enabled = import.meta.env.VITE_RUN_INFERENCE_TESTS === "1";
+// OpenRouter child keys when a provisioning key is configured. They work both
+// with and without `OPENROUTER_PROVISIONING_KEY` set.
 
 const serverUrl = import.meta.env.VITE_SERVER_URL;
 const firebaseOptions = JSON.parse(import.meta.env.VITE_FIREBASE_OPTIONS) as FirebaseOptions;
@@ -19,45 +16,49 @@ const firebaseOptions = JSON.parse(import.meta.env.VITE_FIREBASE_OPTIONS) as Fir
 const firebaseApp = initializeApp(firebaseOptions);
 const rpc = createRpcClient(serverUrl, createFetchWithAuth(firebaseApp));
 
-(enabled ? describe : describe.skip)("RPC for inference keys", async () => {
+describe("RPC for inference keys", () => {
     const auth = getAuth(firebaseApp);
     const email = "test-inference-key@catcolab.org";
     const password = "foobar";
-    await initTestUserAuth(auth, email, password);
 
-    const user = auth.currentUser;
-    invariant(user);
-    afterAll(async () => user && (await deleteUser(user)));
+    beforeAll(async () => {
+        await initTestUserAuth(auth, email, password);
+        invariant(auth.currentUser);
+        unwrap(await rpc.sign_up_or_sign_in.mutate());
+    });
 
-    unwrap(await rpc.sign_up_or_sign_in.mutate());
+    afterAll(async () => {
+        if (auth.currentUser) {
+            await deleteUser(auth.currentUser);
+        }
+    });
 
-    const authResult = await rpc.get_inference_key.query();
-    test.sequential("should return a key, or report inference unavailable", () => {
-        if (authResult.tag === "Ok") {
-            assert.ok(authResult.content.length > 0, "key should be a non-empty string");
+    test.sequential("should return a stable key, or report inference unavailable", async () => {
+        const firstResult = await rpc.get_inference_key.query();
+        if (firstResult.tag === "Ok") {
+            assert.ok(firstResult.content.length > 0, "key should be a non-empty string");
         } else {
             assert.strictEqual(
-                authResult.code,
+                firstResult.code,
                 503,
                 "only expected authenticated error is inference unavailable (503)",
             );
         }
-    });
 
-    const secondResult = await rpc.get_inference_key.query();
-    test.sequential("should return the same value on a second call", () => {
-        assert.strictEqual(secondResult.tag, authResult.tag);
-        if (authResult.tag === "Ok" && secondResult.tag === "Ok") {
-            assert.strictEqual(secondResult.content, authResult.content);
+        const secondResult = await rpc.get_inference_key.query();
+        assert.strictEqual(secondResult.tag, firstResult.tag);
+        if (firstResult.tag === "Ok" && secondResult.tag === "Ok") {
+            assert.strictEqual(secondResult.content, firstResult.content);
         }
     });
 
-    await signOut(auth);
-
-    const unauthResult = await rpc.get_inference_key.query();
-    test.sequential("should prohibit key retrieval when unauthenticated", () => {
-        assert.strictEqual(unwrapErr(unauthResult).code, 401);
+    test.sequential("should prohibit key retrieval when unauthenticated", async () => {
+        await signOut(auth);
+        try {
+            const result = await rpc.get_inference_key.query();
+            assert.strictEqual(unwrapErr(result).code, 401);
+        } finally {
+            await signInWithEmailAndPassword(auth, email, password);
+        }
     });
-
-    await signInWithEmailAndPassword(auth, email, password);
 });

--- a/packages/frontend/src/inference/chat.test.ts
+++ b/packages/frontend/src/inference/chat.test.ts
@@ -1,0 +1,109 @@
+import { type FirebaseOptions, initializeApp } from "firebase/app";
+import { deleteUser, getAuth } from "firebase/auth";
+import invariant from "tiny-invariant";
+import { afterAll, assert, beforeAll, describe, test } from "vitest";
+
+import { createFetchWithAuth, createRpcClient } from "../api/rpc.ts";
+import { initTestUserAuth } from "../util/test_util.ts";
+import { createInferenceClient, runOpenAIChatTurn, type OpenAITranscript } from "./chat.ts";
+
+// When inference is configured, these tests exercise a live `runOpenAIChatTurn`
+// against OpenRouter, using a free model. A backend without
+// `OPENROUTER_PROVISIONING_KEY` is expected to report inference as unavailable,
+// in which case the OpenRouter assertions have nothing to exercise.
+
+const serverUrl = import.meta.env.VITE_SERVER_URL;
+const firebaseOptions = JSON.parse(import.meta.env.VITE_FIREBASE_OPTIONS) as FirebaseOptions;
+
+const firebaseApp = initializeApp(firebaseOptions);
+const rpc = createRpcClient(serverUrl, createFetchWithAuth(firebaseApp));
+
+const testModel = "openai/gpt-oss-20b:free";
+
+describe("chat turn over OpenRouter", () => {
+    const auth = getAuth(firebaseApp);
+    let client: ReturnType<typeof createInferenceClient> | undefined;
+
+    beforeAll(async () => {
+        await initTestUserAuth(auth, "test-inference-chat@catcolab.org", "foobar");
+        invariant(auth.currentUser);
+
+        await rpc.sign_up_or_sign_in.mutate();
+        const keyResult = await rpc.get_inference_key.query();
+        if (keyResult.tag === "Err") {
+            assert.strictEqual(
+                keyResult.code,
+                503,
+                "only expected authenticated error is inference unavailable (503)",
+            );
+            return;
+        }
+        client = createInferenceClient(keyResult.content);
+    });
+
+    afterAll(async () => {
+        if (auth.currentUser) {
+            await deleteUser(auth.currentUser);
+        }
+    });
+
+    test(
+        "streams a final assistant string for a trivial prompt",
+        { timeout: 120000 },
+        async ({ skip }) => {
+            if (!client) {
+                skip("inference is unavailable (503)");
+                return;
+            }
+
+            const transcript: OpenAITranscript = [
+                { role: "user", content: "Reply with exactly the word: pong" },
+            ];
+            const result = await runOpenAIChatTurn(client, transcript, {}, undefined, testModel);
+
+            assert.ok(result.content.length > 0, "final content should be a non-empty string");
+            assert.strictEqual(transcript[0]?.role, "user");
+            assert.strictEqual(result.generatedMessageDelta.at(-1)?.role, "assistant");
+        },
+    );
+
+    test(
+        "records the contextExec call and result as OpenAI messages",
+        { timeout: 120000 },
+        async ({ skip }) => {
+            if (!client) {
+                skip("inference is unavailable (503)");
+                return;
+            }
+
+            const transcript: OpenAITranscript = [
+                {
+                    role: "user",
+                    content: "Use contextExec to evaluate 6 * 7, then tell me the result.",
+                },
+            ];
+            const result = await runOpenAIChatTurn(client, transcript, {}, undefined, testModel);
+
+            const assistant = result.generatedMessageDelta.find(
+                (message) =>
+                    message.role === "assistant" &&
+                    message.tool_calls?.some(
+                        (call) => call.type === "function" && call.function.name === "contextExec",
+                    ),
+            );
+            invariant(assistant?.role === "assistant");
+
+            const toolCall = assistant.tool_calls?.find(
+                (call) => call.type === "function" && call.function.name === "contextExec",
+            );
+            invariant(toolCall);
+
+            const toolResult = result.generatedMessageDelta.find(
+                (message) => message.role === "tool" && message.tool_call_id === toolCall.id,
+            );
+            invariant(toolResult?.role === "tool");
+            invariant(typeof toolResult.content === "string");
+            assert.deepStrictEqual(JSON.parse(toolResult.content), { tag: "Ok", value: "42" });
+        },
+    );
+});

--- a/packages/frontend/src/inference/chat.ts
+++ b/packages/frontend/src/inference/chat.ts
@@ -1,0 +1,136 @@
+import OpenAI from "openai";
+import type {
+    ChatCompletionAssistantMessageParam,
+    ChatCompletionMessageParam,
+    ChatCompletionSystemMessageParam,
+    ChatCompletionToolMessageParam,
+    ChatCompletionUserMessageParam,
+} from "openai/resources/chat/completions";
+
+import { type ContextExecScope, type EvalResult, contextExec } from "./context_exec";
+
+const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+const MODEL = "z-ai/glm-5.2";
+
+/** Maximum model completions, including tool-use continuations, in one user turn. */
+export const MAX_CHAT_COMPLETIONS_PER_TURN = 10;
+
+const EMPTY_FILES = Object.freeze(Object.create(null)) as Readonly<Record<string, string>>;
+
+const SYSTEM_PROMPT =
+    "You are an assistant embedded in CatColab. Use `contextExec` when you need to inspect, compute with, or act on the current CatColab context. It executes JavaScript with the available context values as local bindings. The read-only `files` binding maps available filenames to their UTF-8 content; use `Object.keys(files)` to inspect its keys. Use `return` when you need to observe a value; `await` can be used directly. Only use bindings and APIs explicitly described as available. Answer the user's request clearly and concisely, using tool results when relevant.";
+
+/** Message in the OpenAI-compatible transcript sent for an inference request. */
+export type OpenAITranscriptMessage =
+    | ChatCompletionSystemMessageParam
+    | ChatCompletionUserMessageParam
+    | ChatCompletionAssistantMessageParam
+    | ChatCompletionToolMessageParam;
+
+/** Ephemeral OpenAI-compatible transcript sent for an inference request. */
+export type OpenAITranscript = OpenAITranscriptMessage[];
+
+/** Assistant or tool message newly generated during one OpenAI inference request. */
+export type GeneratedOpenAIMessage =
+    | ChatCompletionAssistantMessageParam
+    | ChatCompletionToolMessageParam;
+
+/** Completed OpenAI inference output, not including the request transcript. */
+export type OpenAIChatTurnResult = {
+    content: string;
+    generatedMessageDelta: GeneratedOpenAIMessage[];
+};
+
+/** Create an OpenAI client configured for OpenRouter. */
+export function createInferenceClient(apiKey: string): OpenAI {
+    return new OpenAI({
+        baseURL: OPENROUTER_BASE_URL,
+        apiKey,
+        dangerouslyAllowBrowser: true,
+    });
+}
+
+/** Run one OpenAI inference turn against a complete, ephemeral request transcript. */
+export async function runOpenAIChatTurn(
+    client: OpenAI,
+    openAITranscript: readonly OpenAITranscriptMessage[],
+    scope: ContextExecScope,
+    onContent?: (delta: string, snapshot: string) => void,
+    model = MODEL,
+): Promise<OpenAIChatTurnResult> {
+    const contextScope: ContextExecScope = { files: EMPTY_FILES, ...scope };
+
+    const messages: ChatCompletionMessageParam[] = [
+        { role: "system", content: SYSTEM_PROMPT },
+        ...openAITranscript,
+    ];
+
+    const runner = client.chat.completions.runTools(
+        {
+            model,
+            messages,
+            stream: true,
+            parallel_tool_calls: false,
+            tools: [
+                {
+                    type: "function",
+                    function: {
+                        name: "contextExec",
+                        description:
+                            "Execute JavaScript with the available CatColab context values as local bindings.",
+                        parameters: {
+                            type: "object",
+                            properties: {
+                                code: {
+                                    type: "string",
+                                    description:
+                                        "JavaScript to execute. Use return to provide a result; await can be used directly.",
+                                },
+                            },
+                            required: ["code"],
+                            additionalProperties: false,
+                        },
+                        function: async (rawArgs: string): Promise<EvalResult> => {
+                            const args = parseContextExecArguments(rawArgs);
+                            if (!args) {
+                                return { tag: "Err", error: "Invalid contextExec arguments" };
+                            }
+                            return await contextExec(args.code, contextScope);
+                        },
+                    },
+                },
+            ],
+        },
+        { maxChatCompletions: MAX_CHAT_COMPLETIONS_PER_TURN },
+    );
+
+    if (onContent) {
+        runner.on("content", onContent);
+    }
+
+    const content = (await runner.finalContent()) ?? "";
+    const generatedMessageDelta: GeneratedOpenAIMessage[] = [];
+    for (const message of runner.messages.slice(messages.length)) {
+        if (message.role !== "assistant" && message.role !== "tool") {
+            throw new Error(`Unexpected generated message role: ${message.role}`);
+        }
+        generatedMessageDelta.push(message);
+    }
+
+    return { content, generatedMessageDelta };
+}
+
+/** Parse the arguments of an OpenAI `contextExec` function call. */
+export function parseContextExecArguments(rawArgs: string): { code: string } | undefined {
+    try {
+        const value = JSON.parse(rawArgs) as { code?: unknown } | null;
+        return typeof value?.code === "string" ? { code: value.code } : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+/** Parse the SDK-generated result of a `contextExec` tool call. */
+export function parseContextExecResult(content: string): EvalResult {
+    return JSON.parse(content) as EvalResult;
+}

--- a/packages/frontend/src/inference/context_exec.test.ts
+++ b/packages/frontend/src/inference/context_exec.test.ts
@@ -1,0 +1,41 @@
+import { assert, describe, test } from "vitest";
+
+import { MAX_CONTEXT_EXEC_RESULT_BYTES, contextExec } from "./context_exec";
+
+describe("contextExec", () => {
+    test("returns the stringified value of a return statement", async () => {
+        const result = await contextExec("return 1 + 2", {});
+        assert.deepStrictEqual(result, { tag: "Ok", value: "3" });
+    });
+
+    test("captures runtime and syntax errors", async () => {
+        const runtimeError = await contextExec("throw new Error('boom')", {});
+        assert.strictEqual(runtimeError.tag, "Err");
+        if (runtimeError.tag === "Err") {
+            assert.match(runtimeError.error, /boom/);
+        }
+
+        const syntaxError = await contextExec("return (", {});
+        assert.strictEqual(syntaxError.tag, "Err");
+    });
+
+    test("always returns a string for successful execution", async () => {
+        const result = await contextExec("return undefined", {});
+        assert.deepStrictEqual(result, { tag: "Ok", value: "undefined" });
+    });
+
+    test("truncates oversized results with an indication", async () => {
+        const result = await contextExec(
+            `return "x".repeat(${MAX_CONTEXT_EXEC_RESULT_BYTES + 1})`,
+            {},
+        );
+        assert.strictEqual(result.tag, "Ok");
+        if (result.tag === "Ok") {
+            assert.isAtMost(
+                new TextEncoder().encode(result.value).length,
+                MAX_CONTEXT_EXEC_RESULT_BYTES,
+            );
+            assert.match(result.value, /Output truncated: 4097 UTF-8 bytes total/);
+        }
+    });
+});

--- a/packages/frontend/src/inference/context_exec.ts
+++ b/packages/frontend/src/inference/context_exec.ts
@@ -1,0 +1,70 @@
+import type { EvalResult } from "catcolab-document-types";
+
+export type { EvalResult } from "catcolab-document-types";
+
+/** Local bindings available to code executed by `contextExec`. */
+export type ContextExecScope = Readonly<Record<string, unknown>>;
+
+/** Maximum UTF-8 byte length of a value returned to the LLM. */
+export const MAX_CONTEXT_EXEC_RESULT_BYTES = 4 * 1024;
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+const textEncoder = new TextEncoder();
+const strictTextDecoder = new TextDecoder("utf-8", { fatal: true });
+
+/** Execute JavaScript with the given local bindings.
+
+The generated function does not close over the caller's lexical scope. As with
+any function created using `Function`, JavaScript globals remain available; this
+is not a sandbox.
+ */
+export async function contextExec(code: string, scope: ContextExecScope): Promise<EvalResult> {
+    const bindings = Object.entries(scope);
+
+    try {
+        // oxlint-disable no-implied-eval -- Executing generated code is the purpose of this module.
+        const fn = new AsyncFunction(
+            ...bindings.map(([name]) => name),
+            `"use strict";\n${code}`,
+        ) as (...args: unknown[]) => Promise<unknown>;
+        // oxlint-enable no-implied-eval
+
+        const value = await fn(...bindings.map(([, value]) => value));
+        return { tag: "Ok", value: truncateResult(stringify(value)) };
+    } catch (err) {
+        const error = err instanceof Error ? err.message : String(err);
+        return { tag: "Err", error: truncateResult(error) };
+    }
+}
+
+function stringify(value: unknown): string {
+    if (typeof value === "string") {
+        return value;
+    }
+    let serialized: string | undefined;
+    try {
+        serialized = JSON.stringify(value);
+    } catch {
+        // Fall back to String below.
+    }
+    return serialized ?? String(value);
+}
+
+function truncateResult(result: string): string {
+    const bytes = textEncoder.encode(result);
+    if (bytes.length <= MAX_CONTEXT_EXEC_RESULT_BYTES) {
+        return result;
+    }
+
+    const suffix = `\n[Output truncated: ${bytes.length} UTF-8 bytes total; return a smaller value.]`;
+    const prefixByteLength = MAX_CONTEXT_EXEC_RESULT_BYTES - textEncoder.encode(suffix).length;
+    for (let end = prefixByteLength; end >= 0; end -= 1) {
+        try {
+            return `${strictTextDecoder.decode(bytes.subarray(0, end))}${suffix}`;
+        } catch {
+            // A UTF-8 character was split at the boundary; try a shorter prefix?
+        }
+    }
+
+    return "<execution result truncation failed>";
+}

--- a/packages/frontend/src/inference/llm_conversation.ts
+++ b/packages/frontend/src/inference/llm_conversation.ts
@@ -1,0 +1,108 @@
+import type { LLMConversationDocument } from "catcolab-document-methods";
+import type { FileType, UserMessage } from "catcolab-document-types";
+import { assertExhaustive } from "../util/assert_exhaustive.ts";
+import type { OpenAITranscript } from "./chat.ts";
+
+/** Files available to `contextExec`, indexed by their filenames. */
+export type ConversationFiles = Readonly<Record<string, string>>;
+
+/** The OpenAI request data derived from a persisted LLM conversation. */
+export type LLMConversationInferenceContext = {
+    transcript: OpenAITranscript;
+    files: ConversationFiles;
+};
+
+/** Derive the OpenAI request data for a persisted LLM conversation. */
+export function prepareLLMConversationInference(
+    conversation: LLMConversationDocument,
+): LLMConversationInferenceContext {
+    const transcript: OpenAITranscript = [];
+    const files: Record<string, string> = Object.create(null) as Record<string, string>;
+
+    for (const interaction of conversation.interactions) {
+        switch (interaction.tag) {
+            case "user-message":
+                transcript.push({ role: "user", content: userMessageToOpenAIContent(interaction) });
+                for (const file of interaction.files) {
+                    files[file.filename] = decodeFile(file.fileType, file.content);
+                }
+                break;
+            case "llm-message":
+                transcript.push({ role: "assistant", content: interaction.content });
+                break;
+            case "llm-code-execution":
+                transcript.push(
+                    {
+                        role: "assistant",
+                        content: null,
+                        tool_calls: [
+                            {
+                                id: interaction.toolCallId,
+                                type: "function",
+                                function: {
+                                    name: "contextExec",
+                                    arguments: JSON.stringify({ code: interaction.code }),
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        role: "tool",
+                        tool_call_id: interaction.toolCallId,
+                        content: JSON.stringify(interaction.result),
+                    },
+                );
+                break;
+            case "user-feedback-request":
+                switch (interaction.resolution) {
+                    case "unresolved":
+                        transcript.push({
+                            role: "system",
+                            content: "The user rejected your proposed changes.",
+                        });
+                        break;
+                    case "approved":
+                        transcript.push({
+                            role: "system",
+                            content: "The user accepted your proposed changes.",
+                        });
+                        break;
+                    case "rejected":
+                        transcript.push({
+                            role: "system",
+                            content: "The user rejected your proposed changes.",
+                        });
+                        break;
+                    default:
+                        assertExhaustive(interaction.resolution);
+                }
+                break;
+            default:
+                assertExhaustive(interaction);
+        }
+    }
+
+    return { transcript, files: Object.freeze(files) };
+}
+
+/** Render a stored user message as the text sent to the LLM. */
+function userMessageToOpenAIContent(message: UserMessage): string {
+    if (message.files.length === 0) {
+        return message.content;
+    }
+
+    const fileNames = [...new Set(message.files.map((file) => JSON.stringify(file.filename)))].join(
+        ", ",
+    );
+    const availability = `The following files are now available in the \`files\` map: ${fileNames}.`;
+    return message.content.length > 0 ? `${message.content}\n\n${availability}` : availability;
+}
+
+function decodeFile(fileType: FileType, content: number[]): string {
+    switch (fileType) {
+        case "CSV":
+            return new TextDecoder("utf-8").decode(Uint8Array.from(content));
+        default:
+            return assertExhaustive(fileType);
+    }
+}

--- a/packages/frontend/src/inference/llm_conversation_adapter.ts
+++ b/packages/frontend/src/inference/llm_conversation_adapter.ts
@@ -1,10 +1,10 @@
 import type { LLMConversationDocument } from "catcolab-document-methods";
-import type { FileType, UserMessage } from "catcolab-document-types";
+import type { UserMessage } from "catcolab-document-types";
 import { assertExhaustive } from "../util/assert_exhaustive.ts";
 import type { OpenAITranscript } from "./chat.ts";
 
 /** Files available to `contextExec`, indexed by their filenames. */
-export type ConversationFiles = Readonly<Record<string, string>>;
+export type ConversationFiles = Readonly<Record<string, string | number[]>>;
 
 /** The OpenAI request data derived from a persisted LLM conversation. */
 export type LLMConversationInferenceContext = {
@@ -17,14 +17,17 @@ export function prepareLLMConversationInference(
     conversation: LLMConversationDocument,
 ): LLMConversationInferenceContext {
     const transcript: OpenAITranscript = [];
-    const files: Record<string, string> = Object.create(null) as Record<string, string>;
+    const files: Record<string, string | number[]> = Object.create(null) as Record<
+        string,
+        string | number[]
+    >;
 
     for (const interaction of conversation.interactions) {
         switch (interaction.tag) {
             case "user-message":
                 transcript.push({ role: "user", content: userMessageToOpenAIContent(interaction) });
                 for (const file of interaction.files) {
-                    files[file.filename] = decodeFile(file.fileType, file.content);
+                    files[file.filename] = decodeFile(file.mediaType, file.content);
                 }
                 break;
             case "llm-message":
@@ -58,7 +61,8 @@ export function prepareLLMConversationInference(
                     case "unresolved":
                         transcript.push({
                             role: "system",
-                            content: "The user rejected your proposed changes.",
+                            content:
+                                "The user has a follow up message and so your proposed changes were not applied.",
                         });
                         break;
                     case "approved":
@@ -98,11 +102,14 @@ function userMessageToOpenAIContent(message: UserMessage): string {
     return message.content.length > 0 ? `${message.content}\n\n${availability}` : availability;
 }
 
-function decodeFile(fileType: FileType, content: number[]): string {
-    switch (fileType) {
-        case "CSV":
-            return new TextDecoder("utf-8").decode(Uint8Array.from(content));
-        default:
-            return assertExhaustive(fileType);
+/** Special logic for doing "reasonable" decoding to files to insert into the
+    execution environment. */
+function decodeFile(_mediaType: string, content: number[]): string | number[] {
+    // For now this is essentially a placeholder until we decide what we want to
+    // do to different media types.
+    try {
+        return new TextDecoder("utf-8", { fatal: true }).decode(Uint8Array.from(content));
+    } catch {
+        return content;
     }
 }

--- a/packages/frontend/src/llm_conversation/document.test.ts
+++ b/packages/frontend/src/llm_conversation/document.test.ts
@@ -56,8 +56,14 @@ function makeLiveConversation(): LiveLLMConversationDoc {
 
 const inputFile: InlineFile = {
     filename: "values.csv",
-    fileType: "CSV",
+    mediaType: "text/csv",
     content: Array.from(new TextEncoder().encode("left,right\n0,1\n")),
+};
+
+const binaryInputFile: InlineFile = {
+    filename: "data.bin",
+    mediaType: "application/octet-stream",
+    content: [0, 255],
 };
 
 const generatedMessageDelta: GeneratedOpenAIMessage[] = [
@@ -96,14 +102,20 @@ describe("LLM conversation turns", () => {
             await runLLMConversationTurn({
                 conversation,
                 inferenceKey: { tag: "Ready", key: "inference-key" },
-                userInput: { content: "Inspect the attached file.", files: [inputFile] },
+                userInput: {
+                    content: "Inspect the attached file.",
+                    files: [inputFile, binaryInputFile],
+                },
                 contextExecScope: {},
             }),
             { tag: "Completed", content: "The values are 0 and 1." },
         );
 
         const scope = inference.runOpenAIChatTurn.mock.calls[0]?.[2] as ContextExecScope;
-        assert.deepStrictEqual(scope.files, { "values.csv": "left,right\n0,1\n" });
+        assert.deepStrictEqual(scope.files, {
+            "values.csv": "left,right\n0,1\n",
+            "data.bin": [0, 255],
+        });
         assert.strictEqual(inference.runOpenAIChatTurn.mock.calls[0]?.[4], "test-model");
 
         const interactions = conversation.liveDoc.docHandle.doc().interactions;

--- a/packages/frontend/src/llm_conversation/document.test.ts
+++ b/packages/frontend/src/llm_conversation/document.test.ts
@@ -1,0 +1,144 @@
+import { Repo } from "@automerge/automerge-repo";
+import { assert, describe, test, vi } from "vitest";
+
+import { LLMConversation, type LLMConversationDocument } from "catcolab-document-methods";
+import type { InlineFile } from "catcolab-document-types";
+import { makeLiveDoc } from "../api";
+import type {
+    GeneratedOpenAIMessage,
+    OpenAIChatTurnResult,
+    OpenAITranscript,
+} from "../inference/chat.ts";
+import type { ContextExecScope } from "../inference/context_exec.ts";
+import { type LiveLLMConversationDoc, runLLMConversationTurn } from "./document.ts";
+
+const inference = vi.hoisted(() => ({
+    createInferenceClient: vi.fn<(apiKey: string) => unknown>(),
+    runOpenAIChatTurn:
+        vi.fn<
+            (
+                client: unknown,
+                transcript: OpenAITranscript,
+                scope: ContextExecScope,
+                onContent?: (delta: string, snapshot: string) => void,
+                model?: string,
+            ) => Promise<OpenAIChatTurnResult>
+        >(),
+}));
+
+vi.mock("../inference/chat.ts", async (importOriginal) => ({
+    ...(await importOriginal()),
+    ...inference,
+}));
+
+const modelRef = {
+    _id: "0198b0e0-2085-1000-8000-000000000001",
+    _version: null,
+    _server: "example.test",
+};
+
+function makeLiveConversation(): LiveLLMConversationDoc {
+    const repo = new Repo();
+    const document = LLMConversation.newLLMConversationDocument(modelRef, "test-model");
+    const liveDoc = makeLiveDoc<LLMConversationDocument>(repo.create(document), "llmconversation");
+
+    return {
+        type: "llmconversation",
+        liveDoc,
+        docRef: {
+            refId: "0198b0e0-2085-1000-8000-000000000010",
+            permissions: { anyone: null, user: "Own", users: null },
+            isDeleted: false,
+        },
+        liveModel: {} as LiveLLMConversationDoc["liveModel"],
+    };
+}
+
+const inputFile: InlineFile = {
+    filename: "values.csv",
+    fileType: "CSV",
+    content: Array.from(new TextEncoder().encode("left,right\n0,1\n")),
+};
+
+const generatedMessageDelta: GeneratedOpenAIMessage[] = [
+    {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+            {
+                id: "call_multiply",
+                type: "function",
+                function: {
+                    name: "contextExec",
+                    arguments: JSON.stringify({ code: "return files['values.csv'];" }),
+                },
+            },
+        ],
+    },
+    {
+        role: "tool",
+        tool_call_id: "call_multiply",
+        content: JSON.stringify({ tag: "Ok", value: "left,right\n0,1\n" }),
+    },
+    { role: "assistant", content: "The values are 0 and 1." },
+];
+
+describe("LLM conversation turns", () => {
+    test("persists a completed user, tool, and assistant turn", async () => {
+        const conversation = makeLiveConversation();
+        inference.createInferenceClient.mockReturnValue({});
+        inference.runOpenAIChatTurn.mockResolvedValue({
+            content: "The values are 0 and 1.",
+            generatedMessageDelta,
+        });
+
+        assert.deepStrictEqual(
+            await runLLMConversationTurn({
+                conversation,
+                inferenceKey: { tag: "Ready", key: "inference-key" },
+                userInput: { content: "Inspect the attached file.", files: [inputFile] },
+                contextExecScope: {},
+            }),
+            { tag: "Completed", content: "The values are 0 and 1." },
+        );
+
+        const scope = inference.runOpenAIChatTurn.mock.calls[0]?.[2] as ContextExecScope;
+        assert.deepStrictEqual(scope.files, { "values.csv": "left,right\n0,1\n" });
+        assert.strictEqual(inference.runOpenAIChatTurn.mock.calls[0]?.[4], "test-model");
+
+        const interactions = conversation.liveDoc.docHandle.doc().interactions;
+        assert.deepStrictEqual(
+            interactions.map((interaction) => interaction.tag),
+            ["user-message", "llm-code-execution", "llm-message"],
+        );
+        const [user, execution, response] = interactions;
+        assert(user?.tag === "user-message");
+        assert(execution?.tag === "llm-code-execution");
+        assert(response?.tag === "llm-message");
+        assert.strictEqual(user.content, "Inspect the attached file.");
+        assert.strictEqual(execution.toolCallId, "call_multiply");
+        assert.strictEqual(response.content, "The values are 0 and 1.");
+    });
+
+    test("retains the user message when inference fails", async () => {
+        const conversation = makeLiveConversation();
+        inference.createInferenceClient.mockReturnValue({});
+        inference.runOpenAIChatTurn.mockRejectedValue(new Error("network failed"));
+
+        assert.deepStrictEqual(
+            await runLLMConversationTurn({
+                conversation,
+                inferenceKey: { tag: "Ready", key: "inference-key" },
+                userInput: { content: "What is the meaning of life?", files: [] },
+                contextExecScope: {},
+            }),
+            { tag: "Failed", message: "network failed" }, // we may never know
+        );
+
+        const interactions = conversation.liveDoc.docHandle.doc().interactions;
+        assert.strictEqual(interactions.length, 1);
+        const user = interactions[0];
+        assert(user?.tag === "user-message");
+        assert.strictEqual(user.content, "What is the meaning of life?");
+    });
+});

--- a/packages/frontend/src/llm_conversation/document.ts
+++ b/packages/frontend/src/llm_conversation/document.ts
@@ -16,7 +16,7 @@ import {
     type GeneratedOpenAIMessage,
 } from "../inference/chat.ts";
 import type { ContextExecScope } from "../inference/context_exec.ts";
-import * as LLMConversationInference from "../inference/llm_conversation.ts";
+import * as LLMConversationAdapter from "../inference/llm_conversation_adapter.ts";
 import type { LiveModelDoc, ModelLibrary } from "../model";
 import type { InferenceKeyResult } from "../user/inference_key_context.tsx";
 
@@ -113,7 +113,7 @@ export async function runLLMConversationTurn(args: {
 
         const persistedConversation = conversation.liveDoc.docHandle.doc();
         const context =
-            LLMConversationInference.prepareLLMConversationInference(persistedConversation);
+            LLMConversationAdapter.prepareLLMConversationInference(persistedConversation);
 
         const result = await runOpenAIChatTurn(
             createInferenceClient(inferenceKey.key),

--- a/packages/frontend/src/llm_conversation/document.ts
+++ b/packages/frontend/src/llm_conversation/document.ts
@@ -1,0 +1,203 @@
+import { LLMConversation, type LLMConversationDocument } from "catcolab-document-methods";
+import type {
+    FeedbackResolution,
+    InlineFile,
+    LLMInteraction,
+    StableRef,
+    Uuid,
+} from "catcolab-document-types";
+import type { JsResult } from "catlog-wasm";
+import type { Api, DocRef, LiveDoc } from "../api";
+import {
+    createInferenceClient,
+    parseContextExecArguments,
+    parseContextExecResult,
+    runOpenAIChatTurn,
+    type GeneratedOpenAIMessage,
+} from "../inference/chat.ts";
+import type { ContextExecScope } from "../inference/context_exec.ts";
+import * as LLMConversationInference from "../inference/llm_conversation.ts";
+import type { LiveModelDoc, ModelLibrary } from "../model";
+import type { InferenceKeyResult } from "../user/inference_key_context.tsx";
+
+/** A live LLM conversation and the model it is attached to. */
+export type LiveLLMConversationDoc = {
+    type: "llmconversation";
+    liveDoc: LiveDoc<LLMConversationDocument>;
+    docRef: DocRef;
+    liveModel: LiveModelDoc;
+};
+
+/** Input for a user message submitted to an LLM conversation. */
+export type LLMConversationUserInput = {
+    content: string;
+    files: InlineFile[];
+};
+
+/** Outcome of attempting one LLM conversation turn. */
+export type LLMConversationTurnResult =
+    | { tag: "Completed"; content: string }
+    | { tag: "Unavailable" }
+    | { tag: "Deleted" }
+    | { tag: "Failed"; message: string };
+
+/** Create a new LLM conversation attached to a model. */
+export function createLLMConversation(
+    api: Api,
+    modelRef: StableRef,
+    llmModel: string,
+): Promise<Uuid> {
+    return api.createDoc(LLMConversation.newLLMConversationDocument(modelRef, llmModel));
+}
+
+/** Retrieve an LLM conversation and its parent model for live editing. */
+export async function getLiveLLMConversation(
+    refId: Uuid,
+    api: Api,
+    models: ModelLibrary<Uuid>,
+): Promise<LiveLLMConversationDoc> {
+    const { liveDoc, docRef } = await api.getLiveDoc<LLMConversationDocument>(
+        refId,
+        "llmconversation",
+    );
+    const liveModel = await models.getLiveModel(liveDoc.doc.llmConversationOf._id);
+
+    return { type: "llmconversation", liveDoc, docRef, liveModel };
+}
+
+/** Resolve a pending feedback request in a live conversation. */
+export function resolveLLMConversationFeedback(
+    conversation: LiveLLMConversationDoc,
+    requestId: Uuid,
+    resolution: Exclude<FeedbackResolution, "unresolved">,
+) {
+    let resolved = false;
+    conversation.liveDoc.changeDoc((doc) => {
+        resolved = LLMConversation.resolveUserFeedbackRequest(doc, requestId, resolution);
+    });
+    return resolved;
+}
+
+/**
+ * Persist a user message, run one OpenAI turn, then persist its completed output.
+ * Streaming assistant text is reported only through `onContent` and is never persisted.
+ */
+export async function runLLMConversationTurn(args: {
+    conversation: LiveLLMConversationDoc;
+    inferenceKey: InferenceKeyResult;
+    userInput: LLMConversationUserInput;
+    contextExecScope: ContextExecScope;
+    onContent?: (delta: string, snapshot: string) => void;
+}): Promise<LLMConversationTurnResult> {
+    const { conversation, inferenceKey, userInput, contextExecScope, onContent } = args;
+    if (conversation.docRef.isDeleted) {
+        return { tag: "Deleted" };
+    }
+    if (inferenceKey.tag !== "Ready") {
+        return { tag: "Unavailable" };
+    }
+
+    try {
+        const userInteraction = LLMConversation.newUserMessage(userInput.content, userInput.files);
+        conversation.liveDoc.changeDoc((doc) => {
+            for (const interaction of doc.interactions) {
+                if (
+                    interaction.tag === "user-feedback-request" &&
+                    interaction.resolution === "unresolved"
+                ) {
+                    interaction.resolution = "rejected";
+                }
+            }
+            LLMConversation.appendLLMInteraction(doc, userInteraction);
+        });
+
+        const persistedConversation = conversation.liveDoc.docHandle.doc();
+        const context =
+            LLMConversationInference.prepareLLMConversationInference(persistedConversation);
+
+        const result = await runOpenAIChatTurn(
+            createInferenceClient(inferenceKey.key),
+            context.transcript,
+            { ...contextExecScope, files: context.files },
+            onContent,
+            persistedConversation.llmModel,
+        );
+        const generated = generatedOpenAIMessageDeltaToLLMInteractions(
+            result.generatedMessageDelta,
+        );
+        if (generated.tag === "Err") {
+            return { tag: "Failed", message: generated.content };
+        }
+
+        conversation.liveDoc.changeDoc((doc) => {
+            for (const interaction of generated.content) {
+                LLMConversation.appendLLMInteraction(doc, interaction);
+            }
+        });
+        return { tag: "Completed", content: result.content };
+    } catch (error) {
+        return { tag: "Failed", message: errorMessage(error) };
+    }
+}
+
+/** Convert generated OpenAI assistant/tool messages to persisted LLM interactions. */
+function generatedOpenAIMessageDeltaToLLMInteractions(
+    messages: readonly GeneratedOpenAIMessage[],
+): JsResult<LLMInteraction[], string> {
+    const interactions: LLMInteraction[] = [];
+
+    for (let index = 0; index < messages.length; index += 1) {
+        const message = messages[index]!;
+        if (message.role !== "assistant") {
+            return { tag: "Err", content: `Expected an assistant message, got ${message.role}` };
+        }
+
+        const toolCalls = message.tool_calls ?? [];
+        if (toolCalls.length === 0) {
+            if (typeof message.content !== "string") {
+                return { tag: "Err", content: "Expected assistant content to be a string" };
+            }
+            interactions.push(LLMConversation.newLLMMessage(message.content));
+            continue;
+        }
+
+        if (toolCalls.length !== 1) {
+            return { tag: "Err", content: "Expected exactly one contextExec tool call" };
+        }
+        if (message.content !== null && message.content !== undefined && message.content !== "") {
+            return {
+                tag: "Err",
+                content: "Cannot store assistant content alongside a contextExec tool call",
+            };
+        }
+
+        const toolCall = toolCalls[0]!;
+        if (toolCall.type !== "function" || toolCall.function.name !== "contextExec") {
+            return { tag: "Err", content: "Expected a contextExec function call" };
+        }
+        const args = parseContextExecArguments(toolCall.function.arguments);
+        if (!args) {
+            return { tag: "Err", content: "Invalid contextExec arguments" };
+        }
+
+        const toolResult = messages[index + 1];
+        if (toolResult?.role !== "tool" || toolResult.tool_call_id !== toolCall.id) {
+            return {
+                tag: "Err",
+                content: "Expected the matching contextExec result immediately after its call",
+            };
+        }
+        if (typeof toolResult.content !== "string") {
+            return { tag: "Err", content: "Expected the contextExec result to be a string" };
+        }
+        const result = parseContextExecResult(toolResult.content);
+        interactions.push(LLMConversation.newLLMCodeExecution(toolCall.id, args.code, result));
+        index += 1;
+    }
+
+    return { tag: "Ok", content: interactions };
+}
+
+function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}

--- a/packages/frontend/src/model/model_library.ts
+++ b/packages/frontend/src/model/model_library.ts
@@ -311,6 +311,9 @@ function elaborateAndValidateModel(
 
 /** Does the patch to the model document affect its formal content? */
 function isPatchToFormalContent(doc: Document, patch: Patch): boolean {
+    if (doc.type !== "model") {
+        return false;
+    }
     const path = patch.path;
     if (!(path[0] === "type" || path[0] === "theory" || path[0] === "notebook")) {
         // Ignore changes to top-level data like document name.

--- a/packages/frontend/src/page/document_breadcrumbs.tsx
+++ b/packages/frontend/src/page/document_breadcrumbs.tsx
@@ -41,6 +41,8 @@ export function getParentRefId(document: Document): string | null {
             return document.diagramIn._id;
         case "analysis":
             return document.analysisOf._id;
+        case "llmconversation":
+            return document.llmConversationOf._id;
         default:
             assertExhaustive(document);
     }

--- a/packages/frontend/src/page/document_menu.tsx
+++ b/packages/frontend/src/page/document_menu.tsx
@@ -60,7 +60,10 @@ export function DocumentMenu(props: {
     const onNewAnalysis = async () => {
         const docRefId = props.docRef.refId;
         const docType = props.liveDoc.doc.type;
-        invariant(docType !== "analysis", "Analysis cannot be created on other analysis");
+        invariant(
+            docType === "model" || docType === "diagram",
+            "Analysis can only be created on a model or diagram",
+        );
 
         const newRef = await createAnalysis(api, docType, api.makeUnversionedRef(docRefId));
         handleDocCreated("analysis", newRef);

--- a/packages/frontend/src/page/document_page.tsx
+++ b/packages/frontend/src/page/document_page.tsx
@@ -571,6 +571,8 @@ async function getLiveDocument(
             const { liveAnalysis, docRef } = await getLiveAnalysis(refId, api, models);
             return { liveDoc: liveAnalysis, docRef };
         }
+        case "llmconversation":
+            throw new Error("LLM conversation pages are not implemented");
         default:
             assertExhaustive(documentType);
     }

--- a/packages/frontend/src/vite-env.d.ts
+++ b/packages/frontend/src/vite-env.d.ts
@@ -6,7 +6,6 @@ interface ImportMetaEnv {
     readonly VITE_AUTOMERGE_REPO_URL: string;
     readonly VITE_FIREBASE_OPTIONS: string;
     readonly VITE_JULIA_URL?: string;
-    readonly VITE_RUN_INFERENCE_TESTS?: string;
 }
 
 interface ImportMeta {

--- a/packages/ui-components/src/document_type_icon.tsx
+++ b/packages/ui-components/src/document_type_icon.tsx
@@ -6,7 +6,7 @@ import { Match, Switch } from "solid-js";
 
 import { ModelFileIcon } from "./model_file_icon";
 
-export type DocumentType = "model" | "diagram" | "analysis";
+export type DocumentType = "model" | "diagram" | "analysis" | "llmconversation";
 
 export function DocumentTypeIcon(props: {
     documentType: DocumentType;


### PR DESCRIPTION
This change depends on #1350 and #1345.

## Context

#1350 introduced the `LLMConversation` document type and its interaction schema. #1345 introduced inference in the front end. This change supplies the frontend machinery that makes that document usable as an inference history. We stop (hopefully) right at the boundary of UI/UX questions for this functionality.

## Design decisions

* The Automerge `LLMConversation` document is the sole source of truth. We do not store an OpenAI transcript alongside it. When a turn runs, the frontend derives a provider transcript and its `files` binding from the current document, combines that with a caller-supplied `contextExec` scope, sends the ephemeral request to OpenRouter, and writes the completed assistant/tool output back to the document. These two directions may be found in:
    + `src/inference/llm_conversation.ts` document -> OpenAI conversion
    + `src/llm_conversation/document.ts` OpenAI -> document conversion

* The upcoming UI has one principal entry point: `runLLMConversationTurn`. It accepts, among other things, an optional streaming callback for UI purposes. A failed inference leaves its submitted user message in the document, allowing a later UI to offer retry.

* Inline files are decoded into a cumulative, read-only `files` map available to the JS tool. This allows the LLMs to perform non-trivial computation and inspection using JS. Questions about file size caps and enforcement are deferred to future UI layers.

* Starting a new user turn automatically records unresolved feedback requests as rejected, and the normal derived transcript informs the model of that rejection before the new message.

* Where possible errors are treated as first-class values, instead of state, so that the UI doesn't have to worry about catching and recovering. In particular unavailable inference, deleted conversations, failed requests, and malformed generated output are returned as values.

## Implementation details

* Add live conversation creation/loading alongside the existing model and diagram document modules.

## Tests

Add turn-level tests using in-memory Automerge and a mocked OpenAI boundary. They verify that a completed user/tool/assistant turn is persisted in the conversation document, and that a failed inference still retains the submitted user message.
