### PR TITLE
OBEE-22 new LLMConversation document type

### DIFF
--- a/packages/backend/src/user_state.rs
+++ b/packages/backend/src/user_state.rs
@@ -505,6 +505,7 @@ pub mod arbitrary {
             DocumentType::Model,
             DocumentType::Diagram,
             DocumentType::Analysis,
+            DocumentType::LLMConversation,
         ])
         .boxed()
     }

--- a/packages/backend/tests/llm_conversation_tests.rs
+++ b/packages/backend/tests/llm_conversation_tests.rs
@@ -1,0 +1,70 @@
+//! Integration tests for LLM conversation backend behavior.
+
+#[cfg(feature = "integration-tests")]
+mod common;
+
+#[cfg(feature = "integration-tests")]
+mod integration_tests {
+    use crate::common::test_utils::{
+        create_test_app_state, create_test_document_content, create_test_firebase_user,
+        ensure_user_exists, run_migrations,
+    };
+    use backend::app::AppCtx;
+    use backend::document;
+    use backend::user_state::read_user_state_from_db;
+    use serde_json::json;
+    use sqlx::PgPool;
+    use uuid::Uuid;
+
+    fn create_llm_conversation_content(name: &str, parent_ref_id: Uuid) -> serde_json::Value {
+        json!({
+            "version": "2",
+            "type": "llmconversation",
+            "name": name,
+            "llmConversationOf": {
+                "_id": parent_ref_id.to_string(),
+                "_version": null,
+                "_server": "test",
+                "type": "llmconversation-of"
+            },
+            "llmModel": "openai/gpt-oss-20b:free",
+            "interactions": []
+        })
+    }
+
+    /// A conversation should be indexed as depending on its parent model.
+    #[sqlx::test]
+    async fn conversation_relation_is_indexed(pool: PgPool) -> sqlx::Result<()> {
+        run_migrations(&pool).await?;
+        let state = create_test_app_state(pool.clone()).await;
+
+        let user_id = format!("test_user_{}", Uuid::now_v7());
+        ensure_user_exists(&pool, &user_id).await.expect("Failed to create user");
+
+        let ctx = AppCtx {
+            state,
+            user: Some(create_test_firebase_user(&user_id)),
+        };
+        let parent_id =
+            document::new_ref(ctx.clone(), create_test_document_content("Parent Model"))
+                .await
+                .unwrap();
+        let conversation_id =
+            document::new_ref(ctx, create_llm_conversation_content("Conversation", parent_id))
+                .await
+                .unwrap();
+
+        let user_state = read_user_state_from_db(user_id, &pool).await.unwrap();
+        let parent = &user_state.documents[&parent_id.to_string()];
+        let conversation = &user_state.documents[&conversation_id.to_string()];
+
+        assert_eq!(conversation.depends_on.len(), 1);
+        assert_eq!(conversation.depends_on[0].ref_id, parent_id);
+        assert_eq!(conversation.depends_on[0].relation_type, "llmconversation-of");
+        assert_eq!(parent.used_by.len(), 1);
+        assert_eq!(parent.used_by[0].ref_id, conversation_id);
+        assert_eq!(parent.used_by[0].relation_type, "llmconversation-of");
+
+        Ok(())
+    }
+}

--- a/packages/document-methods/src/index.ts
+++ b/packages/document-methods/src/index.ts
@@ -1,7 +1,9 @@
 export type { DiagramDocument } from "./diagram";
+export type { LLMConversationDocument } from "./llm_conversation";
 export type { ModelDocument } from "./model";
 export type { FormalCell, RichTextCell } from "./notebook";
 
 export * as Diagram from "./diagram";
+export * as LLMConversation from "./llm_conversation";
 export * as Model from "./model";
 export * as Nb from "./notebook";

--- a/packages/document-methods/src/llm_conversation.ts
+++ b/packages/document-methods/src/llm_conversation.ts
@@ -14,15 +14,15 @@ import { currentVersion } from "catcolab-document-types";
 /** A document containing an LLM conversation attached to a model. */
 export type LLMConversationDocument = Document & { type: "llmconversation" };
 
-/** Create an empty LLM conversation for a model. */
+/** Create an empty LLM conversation for a document. */
 export const newLLMConversationDocument = (
-    modelRef: StableRef,
+    documentRef: StableRef,
     llmModel: string,
 ): LLMConversationDocument => ({
     name: "",
     type: "llmconversation",
     llmConversationOf: {
-        ...modelRef,
+        ...documentRef,
         type: "llmconversation-of",
     },
     llmModel,

--- a/packages/document-methods/src/llm_conversation.ts
+++ b/packages/document-methods/src/llm_conversation.ts
@@ -1,0 +1,98 @@
+import { v7 } from "uuid";
+
+import type {
+    EvalResult,
+    FeedbackResolution,
+    InlineFile,
+    Document,
+    LLMInteraction,
+    StableRef,
+    Uuid,
+} from "catcolab-document-types";
+import { currentVersion } from "catcolab-document-types";
+
+/** A document containing an LLM conversation attached to a model. */
+export type LLMConversationDocument = Document & { type: "llmconversation" };
+
+/** Create an empty LLM conversation for a model. */
+export const newLLMConversationDocument = (
+    modelRef: StableRef,
+    llmModel: string,
+): LLMConversationDocument => ({
+    name: "",
+    type: "llmconversation",
+    llmConversationOf: {
+        ...modelRef,
+        type: "llmconversation-of",
+    },
+    llmModel,
+    interactions: [],
+    version: currentVersion(),
+});
+
+/** Create an interaction containing a user message. */
+export function newUserMessage(
+    content: string,
+    files: InlineFile[],
+): Extract<LLMInteraction, { tag: "user-message" }> {
+    return {
+        tag: "user-message",
+        id: v7(),
+        timestamp: new Date().toISOString(),
+        content,
+        files,
+    };
+}
+
+/** Create an interaction containing a completed LLM message. */
+export function newLLMMessage(content: string): Extract<LLMInteraction, { tag: "llm-message" }> {
+    return {
+        tag: "llm-message",
+        id: v7(),
+        timestamp: new Date().toISOString(),
+        content,
+    };
+}
+
+/** Create an interaction containing one completed `contextExec` call. */
+export function newLLMCodeExecution(
+    toolCallId: string,
+    code: string,
+    result: EvalResult,
+    transaction?: unknown,
+): Extract<LLMInteraction, { tag: "llm-code-execution" }> {
+    return {
+        tag: "llm-code-execution",
+        id: v7(),
+        timestamp: new Date().toISOString(),
+        toolCallId,
+        code,
+        result,
+        ...(transaction === undefined ? {} : { transaction }),
+    };
+}
+
+/** Append an interaction to a conversation's ordered history. */
+export function appendLLMInteraction(
+    conversation: LLMConversationDocument,
+    interaction: LLMInteraction,
+) {
+    conversation.interactions.push(interaction);
+}
+
+/** Resolve a pending feedback request by its stable interaction ID. */
+export function resolveUserFeedbackRequest(
+    conversation: LLMConversationDocument,
+    requestId: Uuid,
+    resolution: Exclude<FeedbackResolution, "unresolved">,
+) {
+    const request = conversation.interactions.find(
+        (interaction): interaction is Extract<LLMInteraction, { tag: "user-feedback-request" }> =>
+            interaction.tag === "user-feedback-request" && interaction.id === requestId,
+    );
+    if (!request || request.resolution !== "unresolved") {
+        return false;
+    }
+    request.resolution = resolution;
+    return true;
+}

--- a/packages/document-types/src/v0/api.rs
+++ b/packages/document-types/src/v0/api.rs
@@ -57,6 +57,9 @@ pub enum LinkType {
     #[serde(rename = "diagram-in")]
     DiagramIn,
 
+    #[serde(rename = "llmconversation-of")]
+    ConversationOf,
+
     #[serde(rename = "instantiation")]
     Instantiation,
 }
@@ -75,6 +78,7 @@ pub(crate) mod arbitrary {
             proptest::sample::select(&[
                 LinkType::AnalysisOf,
                 LinkType::DiagramIn,
+                LinkType::ConversationOf,
                 LinkType::Instantiation,
             ])
             .boxed()

--- a/packages/document-types/src/v0/document.rs
+++ b/packages/document-types/src/v0/document.rs
@@ -64,6 +64,8 @@ pub enum DocumentType {
     Diagram,
     #[cfg_attr(feature = "backend", autosurgeon(rename = "analysis"))]
     Analysis,
+    #[cfg_attr(feature = "backend", autosurgeon(rename = "llmconversation"))]
+    LLMConversation,
 }
 
 impl FromStr for DocumentType {
@@ -74,6 +76,7 @@ impl FromStr for DocumentType {
             "model" => Ok(DocumentType::Model),
             "diagram" => Ok(DocumentType::Diagram),
             "analysis" => Ok(DocumentType::Analysis),
+            "llmconversation" => Ok(DocumentType::LLMConversation),
             other => Err(format!("unknown document type: {other}")),
         }
     }

--- a/packages/document-types/src/v2/document.rs
+++ b/packages/document-types/src/v2/document.rs
@@ -4,6 +4,7 @@ pub use crate::v1::DocumentType;
 
 use super::analysis::Analysis;
 use super::api::Link;
+use super::llm_conversation::LLMConversationDocumentContent;
 use super::notebook::Notebook;
 
 use serde::{Deserialize, Serialize};
@@ -58,6 +59,8 @@ pub enum Document {
     Diagram(DiagramDocumentContent),
     #[serde(rename = "analysis")]
     Analysis(AnalysisDocumentContent),
+    #[serde(rename = "llmconversation")]
+    LLMConversation(LLMConversationDocumentContent),
 }
 
 impl Document {

--- a/packages/document-types/src/v2/llm_conversation.rs
+++ b/packages/document-types/src/v2/llm_conversation.rs
@@ -5,20 +5,13 @@ use serde_json::Value;
 use tsify::Tsify;
 use uuid::Uuid;
 
-/// A supported inline file type.
-#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
-pub enum FileType {
-    CSV,
-}
-
 /// A file stored inline with a user message.
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub struct InlineFile {
     pub filename: String,
-    #[serde(rename = "fileType")]
-    pub file_type: FileType,
+    #[serde(rename = "mediaType")]
+    pub media_type: String,
     pub content: Vec<u8>,
 }
 
@@ -101,7 +94,7 @@ pub enum LLMInteraction {
     UserFeedbackRequest(UserFeedbackRequest),
 }
 
-/// A sequential conversation attached to a CatColab model.
+/// A sequential conversation attached to a CatColab document.
 #[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub struct LLMConversationDocumentContent {

--- a/packages/document-types/src/v2/llm_conversation.rs
+++ b/packages/document-types/src/v2/llm_conversation.rs
@@ -1,0 +1,115 @@
+use super::api::Link;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tsify::Tsify;
+use uuid::Uuid;
+
+/// A supported inline file type.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub enum FileType {
+    CSV,
+}
+
+/// A file stored inline with a user message.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct InlineFile {
+    pub filename: String,
+    #[serde(rename = "fileType")]
+    pub file_type: FileType,
+    pub content: Vec<u8>,
+}
+
+/// The result of executing code requested by the LLM.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
+#[serde(tag = "tag")]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub enum EvalResult {
+    Ok { value: String },
+    Err { error: String },
+}
+
+/// A message submitted by the user.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct UserMessage {
+    pub timestamp: String,
+    pub id: Uuid,
+    pub content: String,
+    pub files: Vec<InlineFile>,
+}
+
+/// A completed textual response from the LLM.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct LLMMessage {
+    pub timestamp: String,
+    pub id: Uuid,
+    pub content: String,
+}
+
+/// A `contextExec` call and its completed result.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct LLMCodeExecution {
+    pub timestamp: String,
+    pub id: Uuid,
+    #[serde(rename = "toolCallId")]
+    pub tool_call_id: String,
+    pub code: String,
+    pub result: EvalResult,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transaction: Option<Value>,
+}
+
+/// The user's resolution of a feedback request.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
+#[serde(rename_all = "lowercase")]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub enum FeedbackResolution {
+    Unresolved,
+    Approved,
+    Rejected,
+}
+
+/// A request for the user to approve or reject a proposed transaction.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct UserFeedbackRequest {
+    pub timestamp: String,
+    pub id: Uuid,
+    #[serde(rename = "codeExecution")]
+    pub code_execution: Uuid,
+    pub content: String,
+    pub resolution: FeedbackResolution,
+}
+
+/// An interaction in an LLM conversation.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
+#[serde(tag = "tag")]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub enum LLMInteraction {
+    #[serde(rename = "user-message")]
+    UserMessage(UserMessage),
+    #[serde(rename = "llm-message")]
+    LLMMessage(LLMMessage),
+    #[serde(rename = "llm-code-execution")]
+    LLMCodeExecution(LLMCodeExecution),
+    #[serde(rename = "user-feedback-request")]
+    UserFeedbackRequest(UserFeedbackRequest),
+}
+
+/// A sequential conversation attached to a CatColab model.
+#[derive(PartialEq, Eq, Debug, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct LLMConversationDocumentContent {
+    pub name: String,
+    #[serde(rename = "llmConversationOf")]
+    pub conversation_of: Link,
+    #[serde(rename = "llmModel")]
+    pub llm_model: String,
+    pub interactions: Vec<LLMInteraction>,
+    pub version: String,
+}

--- a/packages/document-types/src/v2/mod.rs
+++ b/packages/document-types/src/v2/mod.rs
@@ -4,6 +4,7 @@ pub use v1::{analysis, api, diagram_judgment, model, model_judgment, path, theor
 
 pub mod cell;
 pub mod document;
+pub mod llm_conversation;
 pub mod notebook;
 
 pub use analysis::*;
@@ -11,6 +12,7 @@ pub use api::*;
 pub use cell::*;
 pub use diagram_judgment::*;
 pub use document::*;
+pub use llm_conversation::*;
 pub use model::*;
 pub use model_judgment::*;
 pub use notebook::*;

--- a/packages/frontend/src/model/model_library.ts
+++ b/packages/frontend/src/model/model_library.ts
@@ -311,6 +311,9 @@ function elaborateAndValidateModel(
 
 /** Does the patch to the model document affect its formal content? */
 function isPatchToFormalContent(doc: Document, patch: Patch): boolean {
+    if (doc.type !== "model") {
+        return false;
+    }
     const path = patch.path;
     if (!(path[0] === "type" || path[0] === "theory" || path[0] === "notebook")) {
         // Ignore changes to top-level data like document name.

--- a/packages/frontend/src/page/document_breadcrumbs.tsx
+++ b/packages/frontend/src/page/document_breadcrumbs.tsx
@@ -41,6 +41,8 @@ export function getParentRefId(document: Document): string | null {
             return document.diagramIn._id;
         case "analysis":
             return document.analysisOf._id;
+        case "llmconversation":
+            return document.llmConversationOf._id;
         default:
             assertExhaustive(document);
     }

--- a/packages/frontend/src/page/document_menu.tsx
+++ b/packages/frontend/src/page/document_menu.tsx
@@ -60,7 +60,10 @@ export function DocumentMenu(props: {
     const onNewAnalysis = async () => {
         const docRefId = props.docRef.refId;
         const docType = props.liveDoc.doc.type;
-        invariant(docType !== "analysis", "Analysis cannot be created on other analysis");
+        invariant(
+            docType === "model" || docType === "diagram",
+            "Analysis can only be created on a model or diagram",
+        );
 
         const newRef = await createAnalysis(api, docType, api.makeUnversionedRef(docRefId));
         handleDocCreated("analysis", newRef);

--- a/packages/frontend/src/page/document_page.tsx
+++ b/packages/frontend/src/page/document_page.tsx
@@ -571,6 +571,8 @@ async function getLiveDocument(
             const { liveAnalysis, docRef } = await getLiveAnalysis(refId, api, models);
             return { liveDoc: liveAnalysis, docRef };
         }
+        case "llmconversation":
+            throw new Error("LLM conversation pages are not implemented");
         default:
             assertExhaustive(documentType);
     }

--- a/packages/ui-components/src/document_type_icon.tsx
+++ b/packages/ui-components/src/document_type_icon.tsx
@@ -6,7 +6,7 @@ import { Match, Switch } from "solid-js";
 
 import { ModelFileIcon } from "./model_file_icon";
 
-export type DocumentType = "model" | "diagram" | "analysis";
+export type DocumentType = "model" | "diagram" | "analysis" | "llmconversation";
 
 export function DocumentTypeIcon(props: {
     documentType: DocumentType;


### PR DESCRIPTION
## Design decisions

For the complete design please see [outcome on notion](https://app.notion.com/p/toposinstitute/New-LLMConversation-document-type-39169ce79864800d8958d737832d5c46).

## Brief overview

* Add `LLMConversation` as a v2 document type. Each conversation belongs to one model (in the CatColab sense) through a required `conversationOf` link and fixes one OpenRouter model for the conversation.

* Store interactions as one ordered sequence with stable UUIDs. The supported interactions are user messages, LLM messages, `contextExec` executions, and user feedback requests (for future transaction semantics).

* Store inline file content as bytes and use a closed `FileType` enum, currently containing only `CSV`. Follow-up frontend work will match on this type and decode CSV content as UTF-8 when constructing the user message.

* Don't commit to transaction proposal semantics, it's currently opaque JSON values.

## Implementation details

Add the `llmconversation-of` link type and the `llmconversation` document discriminator. The Rust schema is in the `v2/llm_conversation.rs` module (with autogen ts bindings).

Add an `LLMConversationDocument` alias and minimal constructor to `document-methods`. Existing exhaustive document handling is updated only where required by the expanded union. This includes teaching some things that "not analysis" is no longer the correct way to determine acceptable document types.

UI/UX changes are not in-scope.

## Tests

I didn't have too much imagination here, so there's only a test which ensures that a conversation is indexed as depending on its parent model.