### PR TITLE
Upgrade to Rust v1.97

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,16 @@ jobs:
 
       - name: Install Rust toolchain from file
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          # Don't override flags in cargo config files. Warnings are denied
+          # through `CARGO_BUILD_WARNINGS` instead of `RUSTFLAGS`.
+          rustflags: ""
 
       - name: Check clippy warnings
+        env:
+          CARGO_BUILD_WARNINGS: deny
         run: |
-          cargo clippy --all-targets --all-features -- --deny warnings
+          cargo clippy --all-targets --all-features --keep-going
 
   check_rust_docs:
     name: Build Rust docs
@@ -141,6 +147,9 @@ jobs:
 
       - name: Install Rust toolchain from file
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          # Don't override flags in cargo config files.
+          rustflags: ""
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/flake.nix
+++ b/flake.nix
@@ -69,7 +69,7 @@
       rustToolchainFor =
         system: fenix.packages.${system}.fromToolchainFile {
           file = ./rust-toolchain.toml;
-          sha256 = "sha256-vra6TkHITpwRyA5oBKAHSX0Mi6CBDNQD+ryPSpxFsfg=";
+          sha256 = "sha256-OATSZm98Es5kIFuqaba+UvkQtFsVgJEBMmS+t6od5/U=";
         };
 
       pkgsLinux = nixpkgsFor linuxSystem;

--- a/packages/backend/src/user_state.rs
+++ b/packages/backend/src/user_state.rs
@@ -774,7 +774,7 @@ mod unit_tests {
         });
 
         let mut relations = extract_relations_from_json(&content);
-        relations.sort_by(|a, b| a.ref_id.cmp(&b.ref_id));
+        relations.sort_by_key(|a| a.ref_id);
 
         assert_eq!(relations.len(), 2);
         assert_eq!(

--- a/packages/backend/tests/autosave_tests.rs
+++ b/packages/backend/tests/autosave_tests.rs
@@ -49,15 +49,13 @@ mod integration_tests {
             .expect("Repo lookup failed")
             .expect("Document not found in repo");
 
-        doc_handle
-            .with_document(|doc| {
-                doc.transact(|tx| {
-                    tx.put(automerge::ROOT, "name", "Autosaved Name")?;
-                    Ok::<_, automerge::AutomergeError>(())
-                })
-                .map(|_| ())
+        doc_handle.with_document(|doc| {
+            doc.transact(|tx| {
+                tx.put(automerge::ROOT, "name", "Autosaved Name")?;
+                Ok::<_, automerge::AutomergeError>(())
             })
             .expect("Failed to mutate document");
+        });
 
         tokio::time::sleep(std::time::Duration::from_millis(800)).await;
 

--- a/packages/catlog/examples/tt/main.rs
+++ b/packages/catlog/examples/tt/main.rs
@@ -36,7 +36,7 @@ fn main() -> io::Result<()> {
         };
 
         if let Err(e) = watcher.watch(Path::new(&args.path), RecursiveMode::Recursive) {
-            eprintln!("could not watch {}: {}", &args.path, e)
+            eprintln!("could not watch {}: {}", args.path, e)
         }
 
         for res in rx {

--- a/packages/catlog/src/tt/batch.rs
+++ b/packages/catlog/src/tt/batch.rs
@@ -136,7 +136,7 @@ pub fn run(path: &str, output: &BatchOutput) -> io::Result<bool> {
     let src = match fs::read_to_string(path) {
         Ok(s) => s,
         Err(e) => {
-            eprintln!("Could not read {}: {}", &path, e);
+            eprintln!("Could not read {}: {}", path, e);
             return Ok(false);
         }
     };

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.97.0"
 components = ["clippy", "rust-analyzer", "rust-src"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Rust v1.97 improves how denying warnings is handled by `cargo`: https://blog.rust-lang.org/2026/07/09/Rust-1.97.0/#cargo-support-for-denying-warnings

Also note that `setup-rust-toolchain` will likely not be properly configured for this change out-of-the-box until v2: https://github.com/actions-rust-lang/setup-rust-toolchain/issues/98