### PR TITLE
Script to autogenerate tikz macros from Quarto macros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,5 @@ CHANGELOG.html
 
 # VSCode
 .vscode/*
+
+/.luarc.json

--- a/rfc/_templates/tikz.tex
+++ b/rfc/_templates/tikz.tex
@@ -6,47 +6,10 @@
 \usepackage{ebproof}
 \ebproofnewstyle{small}{template=\footnotesize$\inserttext$}
 
-% WARNING: the macros here are (currently) manually copied from _macros.qmd
-
-\renewcommand{\cal}[1]{\mathcal{#1}}
-\renewcommand{\vec}[1]{\underline{#1}}
-\newcommand{\vecvec}[1]{\underline{\underline{#1}}}
-
-% Category theory
-\newcommand{\Ob}{\operatorname{Ob}}
-\newcommand{\Hom}{\operatorname{Hom}}
-\newcommand{\dom}{\operatorname{dom}}
-\newcommand{\cod}{\operatorname{cod}}
-\newcommand{\id}{\operatorname{id}}
-\newcommand{\op}{\mathrm{op}}
-
-% Categories
-\newcommand{\cat}[1]{\mathsf{#1}}
-\newcommand{\Set}{\cat{Set}}
-
-% Double categories
-\newcommand{\dbl}[1]{\mathbb{#1}}
-\newcommand{\SSet}{\mathbb{S}\mathsf{et}}
-\newcommand{\CCat}{\mathbb{C}\mathsf{at}}
-\newcommand{\Rel}{\mathbb{R}\mathsf{el}}
-\newcommand{\Span}{\mathbb{S}\mathsf{pan}}
-\newcommand{\Prof}{\mathbb{P}\mathsf{rof}}
-\newcommand{\Mod}{\mathbb{M}\mathsf{od}}
-
-% Arrows
-\newcommand{\xto}[1]{\xrightarrow{#1}}
-\newcommand{\proto}{\mathrel{\mkern3mu\vcenter{\hbox{$\shortmid$}}\mkern-10mu{\to}}}
-\newcommand{\xproto}[1]{\overset{#1}{\proto}}
-\newcommand{\proTo}{\mathrel{\mkern3mu\vcenter{\hbox{$\shortmid$}}\mkern-10mu{\Rightarrow}}}
-
-% Monads
-\newcommand{\List}{\operatorname{List}}
-\newcommand{\Disc}{\operatorname{Disc}}
-\newcommand{\coDisc}{\operatorname{coDisc}}
-
-% Type theory
-\newcommand{\context}{\mathsf{cx}}
-\newcommand{\type}{\mathsf{ty}}
+% Shared math macros are injected from _macros.qmd at build time by
+% filters.lua, replacing the marker on the line below this comment. Do not
+% define macros here; add them to _macros.qmd so prose and tikz stay in sync.
+@MACROS
 
 @OPTIONAL_PREAMBLE
 

--- a/rfc/filters.lua
+++ b/rfc/filters.lua
@@ -4,6 +4,28 @@ local rootdir = os.getenv "QUARTO_PROJECT_DIR"
 local cachedir = rootdir .. "/.svg-cache"
 local tikz_user_preamble = ""
 
+-- The math macros shared between prose (KaTeX, via `{{< include _macros.qmd >}}`)
+-- and tikz blocks (lualatex): read once from _macros.qmd and spliced into the
+-- template at its @MACROS marker, with HTML comments converted to TeX comments.
+local function load_shared_macros()
+  local f = io.open(rootdir .. "/_macros.qmd", "r")
+  if f == nil then return "" end
+  local content = f:read "*all"
+  f:close()
+  return (content:gsub("<!%-%-(.-)%-%->", function(c) return (("%" .. c):gsub("\n", "\n%%")) end))
+end
+
+local tikz_shared_macros = load_shared_macros()
+
+-- Substitute both markers in a template prefix. Function-valued replacements
+-- so that `%` in the substituted text is taken literally rather than as a
+-- gsub capture reference.
+local function resolve_preamble(template_before)
+  return template_before
+    :gsub("@MACROS", function() return tikz_shared_macros end)
+    :gsub("@OPTIONAL_PREAMBLE", function() return tikz_user_preamble end)
+end
+
 local thisfile = io.open(rootdir .. "/filters.lua")
 local thiscontent = thisfile:read "*all"
 thisfile:close()
@@ -56,7 +78,7 @@ local function tikz2image(template)
     system.with_temporary_directory("tikz2image", function(tmpdir)
       system.with_working_directory(tmpdir, function()
         local f = io.open("tikz.tex", "w")
-        local before = template[1]:gsub("@OPTIONAL_PREAMBLE", tikz_user_preamble)
+        local before = resolve_preamble(template[1])
         f:write(before .. trim(src) .. template[2])
         f:close()
         print()
@@ -101,7 +123,7 @@ local function handle_codeblock(el)
     if FORMAT:match "latex" then
       return pandoc.RawBlock("latex", el.text)
     end
-    local before = tikz_template[1]:gsub("@OPTIONAL_PREAMBLE", tikz_user_preamble)
+    local before = resolve_preamble(tikz_template[1])
     return pandoc.Div(
       memoize_svg(el.text, tikz2image(tikz_template), before .. tikz_template[2]),
       { class = "tikz" }


### PR DESCRIPTION
We currently have to hand-copy macros we want in tikz in RFCs from the quarto macros file, which sucks. Claude wrote a script to automate this which, though I've never written a line of lua in my life, looks reasonable and seems behaviorally correct. 