### PR TITLE
Fix deployment concurrency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,10 @@ on:
 env:
   BRANCH_NAME: ${{ github.event.workflow_run.head_branch }}
 
+concurrency:
+  group: deploy-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
 permissions:
   deployments: write
   statuses: write


### PR DESCRIPTION
I noticed there is a race when deleting "previous" deployments if another job is still running. The fix is to limit the concurrency (to one) and cancel any previous jobs. 