### PR TITLE
Support `QualifiedName` across instantations in instance document-type

### DIFF
--- a/packages/document-types/src/v2/instance.rs
+++ b/packages/document-types/src/v2/instance.rs
@@ -7,6 +7,7 @@ use uuid::Uuid;
 /// attribute morphism then we provide the value of the type; if the column corresponds to a
 /// mapping morphism then we provide the uuid of the row.
 #[derive(PartialEq, Debug, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
 pub enum FieldValue {
     /// Base type: the empty type.
     Null,
@@ -24,20 +25,90 @@ pub enum FieldValue {
 
 /// A single row of a table.
 #[derive(PartialEq, Debug, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi, hashmap_as_object)]
 pub struct TableRow {
     /// The row "number".
     pub id: Uuid,
-    /// The content of the row, given as a map from column IDs to values.
-    pub fields: HashMap<Uuid, FieldValue>,
+    /// The content of the row, given as a map from morphism `QualifiedName` to values.
+    pub fields: HashMap<String, FieldValue>,
 }
 
 /// A single table, corresponding to a single entity.
 #[derive(PartialEq, Debug, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi, hashmap_as_object)]
 pub struct Table {
-    /// The uuid of the entity to which this table corresponds.
-    pub id: Uuid,
+    /// The `QualifiedName` of the entity to which this table corresponds.
+    pub id: String,
     /// The rows of the table.
     pub rows: HashMap<Uuid, TableRow>,
     /// The order of the rows of the table.
     pub row_order: Vec<Uuid>,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde_json::Value;
+
+    #[test]
+    fn table_round_trips_through_json_with_string_keys() {
+        let row_id = Uuid::from_u128(1);
+        let col_id = Uuid::from_u128(2);
+        let ent_id = Uuid::from_u128(3);
+
+        let mut fields = HashMap::new();
+        fields.insert(col_id.to_string(), FieldValue::Int(42));
+
+        let mut rows = HashMap::new();
+        rows.insert(row_id, TableRow { id: row_id, fields });
+
+        let table = Table {
+            id: ent_id.to_string(),
+            rows,
+            row_order: vec![row_id],
+        };
+
+        let value = serde_json::to_value(&table).expect("serialize to JSON");
+
+        // Map keys must be plain strings in the resulting JSON object.
+        let rows_obj = value.get("rows").and_then(Value::as_object).expect("rows object");
+        assert!(rows_obj.contains_key(&row_id.to_string()));
+
+        let round_tripped: Table = serde_json::from_value(value).expect("deserialize from JSON");
+        assert_eq!(round_tripped, table);
+    }
+
+    #[test]
+    fn multi_segment_key_round_trips() {
+        let a = Uuid::from_u128(10);
+        let b = Uuid::from_u128(11);
+        let ent_id = Uuid::from_u128(12);
+        let row_id = Uuid::from_u128(13);
+
+        // Paths of UUIDs are represented as dot-separated strings.
+        let key = format!("{a}.{b}");
+
+        let mut fields = HashMap::new();
+        fields.insert(key.clone(), FieldValue::RowRef(row_id));
+
+        let mut rows = HashMap::new();
+        rows.insert(row_id, TableRow { id: row_id, fields });
+
+        let table = Table {
+            id: ent_id.to_string(),
+            rows,
+            row_order: vec![row_id],
+        };
+
+        let value = serde_json::to_value(&table).expect("serialize to JSON");
+
+        let fields_obj = value
+            .pointer(&format!("/rows/{row_id}/fields"))
+            .and_then(Value::as_object)
+            .expect("fields object");
+        assert!(fields_obj.contains_key(&key));
+
+        let round_tripped: Table = serde_json::from_value(value).expect("deserialize from JSON");
+        assert_eq!(round_tripped, table);
+    }
 }


### PR DESCRIPTION
The current instance document type can not reference formal content in instantiated models. Since we don't want to depend on catlog for `QualifiedName` this is the best solution I came up with. 