### PR TITLE
OBEE-27: preparatory work for LLMConversation in frontend

### DIFF
--- a/packages/backend/tests/llm_conversation_tests.rs
+++ b/packages/backend/tests/llm_conversation_tests.rs
@@ -27,7 +27,7 @@ mod integration_tests {
                 "_server": "test",
                 "type": "llmconversation-of"
             },
-            "llmModel": "openai/gpt-oss-20b:free",
+            "llmModel": "test-model",
             "interactions": []
         })
     }

--- a/packages/document-methods/src/llm_conversation.ts
+++ b/packages/document-methods/src/llm_conversation.ts
@@ -80,6 +80,18 @@ export function appendLLMInteraction(
     conversation.interactions.push(interaction);
 }
 
+/** Reject every pending feedback request superseded by a new user message. */
+export function rejectPendingFeedbackRequests(conversation: LLMConversationDocument): void {
+    for (const interaction of conversation.interactions) {
+        if (
+            interaction.tag === "user-feedback-request" &&
+            interaction.resolution === "unresolved"
+        ) {
+            interaction.resolution = "rejected";
+        }
+    }
+}
+
 /** Resolve a pending feedback request by its stable interaction ID. */
 export function resolveUserFeedbackRequest(
     conversation: LLMConversationDocument,

--- a/packages/frontend/src/api/document.ts
+++ b/packages/frontend/src/api/document.ts
@@ -12,6 +12,7 @@ import invariant from "tiny-invariant";
 
 import type { Permissions } from "catcolab-api";
 import { type Document, migrateDocument } from "catlog-wasm";
+import { assertExhaustive } from "../util/assert_exhaustive";
 
 /** Live document, typically retrieved from the backend.
 
@@ -49,6 +50,24 @@ export type LiveDocWithRef<Doc extends Document = Document> = {
 
 /** The type discriminator for documents */
 export type DocumentType = Document["type"];
+
+/** Human-readable name for a document type. */
+export function documentTypeLabel(documentType: DocumentType): string {
+    switch (documentType) {
+        case "model":
+            return "model";
+        case "diagram":
+            return "diagram";
+        case "analysis":
+            return "analysis";
+        case "instance":
+            return "instance";
+        case "llmconversation":
+            return "LLM conversation";
+        default:
+            return assertExhaustive(documentType);
+    }
+}
 
 /** Info about a document ref in the CatColab backend. */
 export type DocRef = {

--- a/packages/frontend/src/inference/chat.ts
+++ b/packages/frontend/src/inference/chat.ts
@@ -10,7 +10,8 @@ import type {
 import { type ContextExecScope, type EvalResult, contextExec } from "./context_exec";
 
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
-const MODEL = "z-ai/glm-5.2";
+/** Default LLM used for newly created CatColab conversations. */
+export const DEFAULT_LLM_MODEL = "z-ai/glm-5.2";
 
 /** Maximum model completions, including tool-use continuations, in one user turn. */
 export const MAX_CHAT_COMPLETIONS_PER_TURN = 10;
@@ -56,7 +57,7 @@ export async function runOpenAIChatTurn(
     openAITranscript: readonly OpenAITranscriptMessage[],
     scope: ContextExecScope,
     onContent?: (delta: string, snapshot: string) => void,
-    model = MODEL,
+    model = DEFAULT_LLM_MODEL,
 ): Promise<OpenAIChatTurnResult> {
     const contextScope: ContextExecScope = { files: EMPTY_FILES, ...scope };
 

--- a/packages/frontend/src/inference/context_exec.ts
+++ b/packages/frontend/src/inference/context_exec.ts
@@ -1,4 +1,5 @@
 import type { EvalResult } from "catcolab-document-types";
+import { errorMessage } from "../util/error";
 
 export type { EvalResult } from "catcolab-document-types";
 
@@ -31,9 +32,8 @@ export async function contextExec(code: string, scope: ContextExecScope): Promis
 
         const value = await fn(...bindings.map(([, value]) => value));
         return { tag: "Ok", value: truncateResult(stringify(value)) };
-    } catch (err) {
-        const error = err instanceof Error ? err.message : String(err);
-        return { tag: "Err", error: truncateResult(error) };
+    } catch (error) {
+        return { tag: "Err", error: truncateResult(errorMessage(error)) };
     }
 }
 

--- a/packages/frontend/src/llm_conversation/conversation_attachment_policy.ts
+++ b/packages/frontend/src/llm_conversation/conversation_attachment_policy.ts
@@ -1,0 +1,52 @@
+import type { JsResult } from "catlog-wasm";
+
+export const ALLOWED_CONVERSATION_FILE_MEDIA_TYPES: ReadonlySet<string> = new Set(["text/csv"]);
+
+const MAX_FILE_BYTES = 8 * 1024;
+const MAX_TOTAL_BYTES = 64 * 1024;
+
+export type ConversationAttachmentMetadata = {
+    filename: string;
+    mediaType: string;
+    byteLength: number;
+};
+
+/** Validate attachment metadata against the conversation attachment policy. */
+export function validateConversationAttachments(
+    files: readonly ConversationAttachmentMetadata[],
+): JsResult<void, string> {
+    for (const file of files) {
+        if (!ALLOWED_CONVERSATION_FILE_MEDIA_TYPES.has(file.mediaType)) {
+            return { tag: "Err", content: `${file.filename} has an unsupported media type.` };
+        }
+        if (file.byteLength > MAX_FILE_BYTES) {
+            return {
+                tag: "Err",
+                content: `${file.filename} exceeds the ${formatBytes(MAX_FILE_BYTES)} per-file limit.`,
+            };
+        }
+    }
+
+    if (fileBytes(files) > MAX_TOTAL_BYTES) {
+        return {
+            tag: "Err",
+            content: `Attachments must total no more than ${formatBytes(MAX_TOTAL_BYTES)} per LLM conversation.`,
+        };
+    }
+    return { tag: "Ok", content: undefined };
+}
+
+/** Remaining capacity for a complete projected attachment set. */
+export function remainingConversationAttachmentBytes(
+    files: readonly ConversationAttachmentMetadata[],
+): number {
+    return MAX_TOTAL_BYTES - fileBytes(files);
+}
+
+function fileBytes(files: readonly ConversationAttachmentMetadata[]): number {
+    return files.reduce((total, file) => total + file.byteLength, 0);
+}
+
+function formatBytes(bytes: number): string {
+    return `${bytes / 1024} KiB`;
+}

--- a/packages/frontend/src/llm_conversation/document.test.ts
+++ b/packages/frontend/src/llm_conversation/document.test.ts
@@ -10,7 +10,11 @@ import type {
     OpenAITranscript,
 } from "../inference/chat.ts";
 import type { ContextExecScope } from "../inference/context_exec.ts";
-import { type LiveLLMConversationDoc, runLLMConversationTurn } from "./document.ts";
+import {
+    type LiveLLMConversationDoc,
+    retryLastLLMConversationResponse,
+    runLLMConversationTurn,
+} from "./document.ts";
 
 const inference = vi.hoisted(() => ({
     createInferenceClient: vi.fn<(apiKey: string) => unknown>(),
@@ -60,12 +64,6 @@ const inputFile: InlineFile = {
     content: Array.from(new TextEncoder().encode("left,right\n0,1\n")),
 };
 
-const binaryInputFile: InlineFile = {
-    filename: "data.bin",
-    mediaType: "application/octet-stream",
-    content: [0, 255],
-};
-
 const generatedMessageDelta: GeneratedOpenAIMessage[] = [
     {
         role: "assistant",
@@ -99,22 +97,21 @@ describe("LLM conversation turns", () => {
         });
 
         assert.deepStrictEqual(
-            await runLLMConversationTurn({
+            await runLLMConversationTurn(
                 conversation,
-                inferenceKey: { tag: "Ready", key: "inference-key" },
-                userInput: {
+                { tag: "Ready", key: "inference-key" },
+                {
                     content: "Inspect the attached file.",
-                    files: [inputFile, binaryInputFile],
+                    files: [inputFile],
                 },
-                contextExecScope: {},
-            }),
+                {},
+            ),
             { tag: "Completed", content: "The values are 0 and 1." },
         );
 
         const scope = inference.runOpenAIChatTurn.mock.calls[0]?.[2] as ContextExecScope;
         assert.deepStrictEqual(scope.files, {
             "values.csv": "left,right\n0,1\n",
-            "data.bin": [0, 255],
         });
         assert.strictEqual(inference.runOpenAIChatTurn.mock.calls[0]?.[4], "test-model");
 
@@ -132,25 +129,134 @@ describe("LLM conversation turns", () => {
         assert.strictEqual(response.content, "The values are 0 and 1.");
     });
 
+    test("rejects pending feedback requests when a user sends a new message", async () => {
+        const conversation = makeLiveConversation();
+        conversation.liveDoc.changeDoc((doc) => {
+            doc.interactions.push({
+                tag: "user-feedback-request",
+                id: "feedback-request",
+                timestamp: new Date().toISOString(),
+                codeExecution: "code-execution",
+                content: "Apply the proposed changes?",
+                resolution: "unresolved",
+            });
+        });
+        inference.createInferenceClient.mockReturnValue({});
+        inference.runOpenAIChatTurn.mockResolvedValue({
+            content: "A response.",
+            generatedMessageDelta: [{ role: "assistant", content: "A response." }],
+        });
+
+        await runLLMConversationTurn(
+            conversation,
+            { tag: "Ready", key: "inference-key" },
+            { content: "Do something else.", files: [] },
+            {},
+        );
+
+        const request = conversation.liveDoc.docHandle.doc().interactions[0];
+        assert(request?.tag === "user-feedback-request");
+        assert.strictEqual(request.resolution, "rejected");
+    });
+
+    test("persists tool output when the model produces no final text", async () => {
+        const conversation = makeLiveConversation();
+        inference.createInferenceClient.mockReturnValue({});
+        inference.runOpenAIChatTurn.mockResolvedValue({
+            content: "",
+            generatedMessageDelta: generatedMessageDelta.slice(0, 2),
+        });
+
+        assert.deepStrictEqual(
+            await runLLMConversationTurn(
+                conversation,
+                { tag: "Ready", key: "inference-key" },
+                { content: "Inspect the attached file.", files: [inputFile] },
+                {},
+            ),
+            { tag: "Completed", content: "" },
+        );
+
+        const interactions = conversation.liveDoc.docHandle.doc().interactions;
+        assert.deepStrictEqual(
+            interactions.map((interaction) => interaction.tag),
+            ["user-message", "llm-code-execution"],
+        );
+    });
+
     test("retains the user message when inference fails", async () => {
         const conversation = makeLiveConversation();
         inference.createInferenceClient.mockReturnValue({});
         inference.runOpenAIChatTurn.mockRejectedValue(new Error("network failed"));
 
-        assert.deepStrictEqual(
-            await runLLMConversationTurn({
-                conversation,
-                inferenceKey: { tag: "Ready", key: "inference-key" },
-                userInput: { content: "What is the meaning of life?", files: [] },
-                contextExecScope: {},
-            }),
-            { tag: "Failed", message: "network failed" }, // we may never know
+        const result = await runLLMConversationTurn(
+            conversation,
+            { tag: "Ready", key: "inference-key" },
+            { content: "What is the meaning of life?", files: [] },
+            {},
         );
+        assert.deepStrictEqual(result, { tag: "Retryable", error: "network failed" });
 
         const interactions = conversation.liveDoc.docHandle.doc().interactions;
         assert.strictEqual(interactions.length, 1);
         const user = interactions[0];
         assert(user?.tag === "user-message");
         assert.strictEqual(user.content, "What is the meaning of life?");
+    });
+
+    test("retries without duplicating the persisted user message", async () => {
+        const conversation = makeLiveConversation();
+        const savedUserMessage = LLMConversation.newUserMessage("Please answer this.", []);
+        conversation.liveDoc.changeDoc((doc) => {
+            LLMConversation.appendLLMInteraction(doc, savedUserMessage);
+        });
+        inference.createInferenceClient.mockReturnValue({});
+        inference.runOpenAIChatTurn.mockReset();
+        inference.runOpenAIChatTurn.mockResolvedValue({
+            content: "A usable response.",
+            generatedMessageDelta: [{ role: "assistant", content: "A usable response." }],
+        });
+
+        assert.deepStrictEqual(
+            await retryLastLLMConversationResponse(
+                conversation,
+                { tag: "Ready", key: "inference-key" },
+                {},
+            ),
+            { tag: "Completed", content: "A usable response." },
+        );
+        const interactions = conversation.liveDoc.docHandle.doc().interactions;
+        assert.deepStrictEqual(
+            interactions.map((interaction) => interaction.tag),
+            ["user-message", "llm-message"],
+        );
+        assert.strictEqual(inference.runOpenAIChatTurn.mock.calls.length, 1);
+        const retryTranscript = inference.runOpenAIChatTurn.mock.calls[0]?.[1];
+        assert.deepStrictEqual(retryTranscript, [{ role: "user", content: "Please answer this." }]);
+    });
+
+    test("does not retry when the latest interaction is not a user message", async () => {
+        const conversation = makeLiveConversation();
+        conversation.liveDoc.changeDoc((doc) => {
+            LLMConversation.appendLLMInteraction(
+                doc,
+                LLMConversation.newLLMMessage("Already answered."),
+            );
+        });
+        inference.createInferenceClient.mockClear();
+        inference.runOpenAIChatTurn.mockClear();
+
+        const result = await retryLastLLMConversationResponse(
+            conversation,
+            { tag: "Ready", key: "inference-key" },
+            {},
+        );
+
+        assert.deepStrictEqual(result, {
+            tag: "Failed",
+            error: "The latest interaction is not a user message.",
+        });
+        assert.strictEqual(inference.createInferenceClient.mock.calls.length, 0);
+        assert.strictEqual(inference.runOpenAIChatTurn.mock.calls.length, 0);
     });
 });

--- a/packages/frontend/src/llm_conversation/document.ts
+++ b/packages/frontend/src/llm_conversation/document.ts
@@ -19,6 +19,11 @@ import type { ContextExecScope } from "../inference/context_exec.ts";
 import * as LLMConversationAdapter from "../inference/llm_conversation_adapter.ts";
 import type { LiveModelDoc, ModelLibrary } from "../model";
 import type { InferenceKeyResult } from "../user/inference_key_context.tsx";
+import { errorMessage } from "../util/error.ts";
+import {
+    type ConversationAttachmentMetadata,
+    validateConversationAttachments,
+} from "./conversation_attachment_policy.ts";
 
 /** A live LLM conversation and the model it is attached to. */
 export type LiveLLMConversationDoc = {
@@ -34,12 +39,33 @@ export type LLMConversationUserInput = {
     files: InlineFile[];
 };
 
+/** Project a persisted inline file into attachment policy metadata. */
+export function inlineFileMetadata(file: InlineFile): ConversationAttachmentMetadata {
+    return {
+        filename: file.filename,
+        mediaType: file.mediaType,
+        byteLength: file.content.length,
+    };
+}
+
+/** Project all persisted conversation attachments into attachment policy metadata. */
+export function conversationAttachmentMetadata(
+    interactions: readonly LLMInteraction[],
+): ConversationAttachmentMetadata[] {
+    const result: ConversationAttachmentMetadata[] = [];
+    for (const interaction of interactions) {
+        if (interaction.tag === "user-message") {
+            result.push(...interaction.files.map(inlineFileMetadata));
+        }
+    }
+    return result;
+}
+
 /** Outcome of attempting one LLM conversation turn. */
 export type LLMConversationTurnResult =
     | { tag: "Completed"; content: string }
-    | { tag: "Unavailable" }
-    | { tag: "Deleted" }
-    | { tag: "Failed"; message: string };
+    | { tag: "Failed"; error: string }
+    | { tag: "Retryable"; error: string };
 
 /** Create a new LLM conversation attached to a model. */
 export function createLLMConversation(
@@ -82,39 +108,75 @@ export function resolveLLMConversationFeedback(
  * Persist a user message, run one OpenAI turn, then persist its completed output.
  * Streaming assistant text is reported only through `onContent` and is never persisted.
  */
-export async function runLLMConversationTurn(args: {
-    conversation: LiveLLMConversationDoc;
-    inferenceKey: InferenceKeyResult;
-    userInput: LLMConversationUserInput;
-    contextExecScope: ContextExecScope;
-    onContent?: (delta: string, snapshot: string) => void;
-}): Promise<LLMConversationTurnResult> {
-    const { conversation, inferenceKey, userInput, contextExecScope, onContent } = args;
+export async function runLLMConversationTurn(
+    conversation: LiveLLMConversationDoc,
+    inferenceKey: InferenceKeyResult,
+    userInput: LLMConversationUserInput,
+    contextExecScope: ContextExecScope,
+    onContent?: (delta: string, snapshot: string) => void,
+): Promise<LLMConversationTurnResult> {
     if (conversation.docRef.isDeleted) {
-        return { tag: "Deleted" };
+        return { tag: "Failed", error: "This LLM conversation has been deleted." };
     }
     if (inferenceKey.tag !== "Ready") {
-        return { tag: "Unavailable" };
+        return { tag: "Failed", error: "Inference is unavailable." };
+    }
+
+    const inputValidation = validateUserInput(conversation.liveDoc.doc.interactions, userInput);
+    if (inputValidation.tag === "Err") {
+        return { tag: "Failed", error: inputValidation.content };
     }
 
     try {
         const userInteraction = LLMConversation.newUserMessage(userInput.content, userInput.files);
         conversation.liveDoc.changeDoc((doc) => {
-            for (const interaction of doc.interactions) {
-                if (
-                    interaction.tag === "user-feedback-request" &&
-                    interaction.resolution === "unresolved"
-                ) {
-                    interaction.resolution = "rejected";
-                }
-            }
+            LLMConversation.rejectPendingFeedbackRequests(doc);
             LLMConversation.appendLLMInteraction(doc, userInteraction);
         });
 
+        return generateLLMConversationResponse(
+            conversation,
+            inferenceKey,
+            contextExecScope,
+            onContent,
+        );
+    } catch (error) {
+        return { tag: "Failed", error: errorMessage(error) };
+    }
+}
+
+/** Retry the latest persisted user message without adding it to the conversation again. */
+export async function retryLastLLMConversationResponse(
+    conversation: LiveLLMConversationDoc,
+    inferenceKey: InferenceKeyResult,
+    contextExecScope: ContextExecScope,
+    onContent?: (delta: string, snapshot: string) => void,
+): Promise<LLMConversationTurnResult> {
+    if (conversation.docRef.isDeleted) {
+        return { tag: "Failed", error: "This LLM conversation has been deleted." };
+    }
+    if (inferenceKey.tag !== "Ready") {
+        return { tag: "Failed", error: "Inference is unavailable." };
+    }
+    const latestInteraction = conversation.liveDoc.doc.interactions.at(-1);
+    if (latestInteraction?.tag !== "user-message") {
+        return { tag: "Failed", error: "The latest interaction is not a user message." };
+    }
+
+    return generateLLMConversationResponse(conversation, inferenceKey, contextExecScope, onContent);
+}
+
+/** Generate and persist a response to the current persisted conversation. */
+async function generateLLMConversationResponse(
+    conversation: LiveLLMConversationDoc,
+    inferenceKey: Extract<InferenceKeyResult, { tag: "Ready" }>,
+    contextExecScope: ContextExecScope,
+    onContent?: (delta: string, snapshot: string) => void,
+): Promise<LLMConversationTurnResult> {
+    try {
         const persistedConversation = conversation.liveDoc.docHandle.doc();
         const context =
             LLMConversationAdapter.prepareLLMConversationInference(persistedConversation);
-
         const result = await runOpenAIChatTurn(
             createInferenceClient(inferenceKey.key),
             context.transcript,
@@ -126,17 +188,29 @@ export async function runLLMConversationTurn(args: {
             result.generatedMessageDelta,
         );
         if (generated.tag === "Err") {
-            return { tag: "Failed", message: generated.content };
+            return { tag: "Retryable", error: generated.content };
+        }
+        if (generated.content.length === 0 && result.content.trim().length === 0) {
+            return { tag: "Retryable", error: "The model produced no usable output." };
         }
 
         conversation.liveDoc.changeDoc((doc) => {
             for (const interaction of generated.content) {
                 LLMConversation.appendLLMInteraction(doc, interaction);
             }
+            if (
+                !generated.content.some((interaction) => interaction.tag === "llm-message") &&
+                result.content.trim().length > 0
+            ) {
+                LLMConversation.appendLLMInteraction(
+                    doc,
+                    LLMConversation.newLLMMessage(result.content),
+                );
+            }
         });
         return { tag: "Completed", content: result.content };
     } catch (error) {
-        return { tag: "Failed", message: errorMessage(error) };
+        return { tag: "Retryable", error: errorMessage(error) };
     }
 }
 
@@ -154,10 +228,17 @@ function generatedOpenAIMessageDeltaToLLMInteractions(
 
         const toolCalls = message.tool_calls ?? [];
         if (toolCalls.length === 0) {
+            // Some providers emit an empty assistant message between tool-use
+            // continuations. It has no user-visible content to persist.
+            if (message.content === null || message.content === undefined) {
+                continue;
+            }
             if (typeof message.content !== "string") {
                 return { tag: "Err", content: "Expected assistant content to be a string" };
             }
-            interactions.push(LLMConversation.newLLMMessage(message.content));
+            if (message.content.trim().length > 0) {
+                interactions.push(LLMConversation.newLLMMessage(message.content));
+            }
             continue;
         }
 
@@ -198,6 +279,15 @@ function generatedOpenAIMessageDeltaToLLMInteractions(
     return { tag: "Ok", content: interactions };
 }
 
-function errorMessage(error: unknown): string {
-    return error instanceof Error ? error.message : String(error);
+function validateUserInput(
+    interactions: readonly LLMInteraction[],
+    input: LLMConversationUserInput,
+): JsResult<void, string> {
+    if (!input.content.trim() && input.files.length === 0) {
+        return { tag: "Err", content: "A message or attachment is required." };
+    }
+    return validateConversationAttachments([
+        ...conversationAttachmentMetadata(interactions),
+        ...input.files.map(inlineFileMetadata),
+    ]);
 }

--- a/packages/frontend/src/page/document_page.tsx
+++ b/packages/frontend/src/page/document_page.tsx
@@ -32,7 +32,7 @@ import {
 import { getLiveAnalysis, type LiveAnalysisDoc } from "../analysis";
 import { AnalysisNotebookEditor } from "../analysis/analysis_editor";
 import { AnalysisInfo } from "../analysis/analysis_info";
-import { type Api, type DocRef, type DocumentType, useApi } from "../api";
+import { type Api, type DocRef, type DocumentType, documentTypeLabel, useApi } from "../api";
 import { getLiveDiagram, type LiveDiagramDoc } from "../diagram";
 import { DiagramNotebookEditor } from "../diagram/diagram_editor";
 import { DiagramInfo } from "../diagram/diagram_info";
@@ -489,8 +489,8 @@ export function DocumentPane(props: {
                                 </Show>
                             }
                         >
-                            This {props.doc.type} has been deleted and will not be listed in your
-                            documents.
+                            This {documentTypeLabel(props.doc.type)} has been deleted and will not
+                            be listed in your documents.
                         </WarningBanner>
                     </Show>
                     <div class="notebook-container">

--- a/packages/frontend/src/page/document_page_sidebar.tsx
+++ b/packages/frontend/src/page/document_page_sidebar.tsx
@@ -6,6 +6,7 @@ import { DocumentTypeIcon, type FocusHandle } from "catcolab-ui-components";
 import type { Document, Link } from "catlog-wasm";
 import { type Api, type LiveDocWithRef, useApi } from "../api";
 import { TheoryLibraryContext } from "../theory";
+import { isDocumentVisible, useUserSettings } from "../user/user_settings";
 import { useUserState } from "../user/user_state_context";
 import { DocumentMenu } from "./document_menu";
 
@@ -49,6 +50,9 @@ async function getDocParent(doc: Document, api: Api): Promise<LiveDocWithRef | u
             break;
         case "analysis":
             parentLink = doc.analysisOf;
+            break;
+        case "llmconversation":
+            parentLink = doc.llmConversationOf;
             break;
         default:
             break;
@@ -107,21 +111,24 @@ function DocumentsTreeNode(props: {
 }) {
     const api = useApi();
     const userState = useUserState();
+    const { settings } = useUserSettings();
 
     const childRefIds = createMemo(() => {
         const docRefId = props.doc.docRef.refId;
         if (!docRefId) {
             return [];
         }
-        const docInfo = userState.documents[docRefId];
-        if (!docInfo) {
-            return [];
-        }
-        return docInfo.usedBy
-            .filter(
-                (rel) => rel.relationType === "diagram-in" || rel.relationType === "analysis-of",
-            )
-            .map((rel) => uuidStringify(rel.refId));
+
+        return (
+            userState.documents[docRefId]?.usedBy
+                .filter(
+                    (relation) =>
+                        relation.relationType === "diagram-in" ||
+                        relation.relationType === "analysis-of" ||
+                        relation.relationType === "llmconversation-of",
+                )
+                .map((relation) => uuidStringify(relation.refId)) ?? []
+        );
     });
 
     const childDocSource = createMemo(() => {
@@ -169,6 +176,12 @@ function DocumentsTreeNode(props: {
         return filtered;
     });
 
+    const visibleChildDocs = createMemo(() =>
+        (childDocs() ?? []).filter((child) =>
+            isDocumentVisible({ typeName: child.liveDoc.doc.type }, settings()),
+        ),
+    );
+
     return (
         <>
             <DocumentsTreeLeaf
@@ -181,7 +194,7 @@ function DocumentsTreeNode(props: {
                 refetchPrimaryDoc={props.refetchPrimaryDoc}
                 refetchSecondaryDoc={props.refetchSecondaryDoc}
             />
-            <For each={childDocs()}>
+            <For each={visibleChildDocs()}>
                 {(child) => (
                     <DocumentsTreeNode
                         doc={child}

--- a/packages/frontend/src/page/menubar.tsx
+++ b/packages/frontend/src/page/menubar.tsx
@@ -24,7 +24,7 @@ import invariant from "tiny-invariant";
 import { serializeAutomergeDocument } from "catcolab-document-types";
 import { IconButton } from "catcolab-ui-components";
 import type { Document } from "catlog-wasm";
-import { useApi } from "../api";
+import { documentTypeLabel, useApi } from "../api";
 import type { LiveDoc } from "../api/document";
 import { createModel } from "../model/document";
 import { TheoryLibraryContext } from "../theory";
@@ -184,7 +184,7 @@ export function DuplicateMenuItem(props: { liveDoc: LiveDoc }) {
     return (
         <MenuItem onSelect={onDuplicate}>
             <Copy />
-            <MenuItemLabel>{`Duplicate ${props.liveDoc.doc.type}`}</MenuItemLabel>
+            <MenuItemLabel>{`Duplicate ${documentTypeLabel(props.liveDoc.doc.type)}`}</MenuItemLabel>
         </MenuItem>
     );
 }
@@ -214,7 +214,7 @@ export function ExportJSONMenuItem(props: { liveDoc: LiveDoc }) {
     return (
         <MenuItem onSelect={onExportJSON}>
             <Export />
-            <MenuItemLabel>{`Export ${props.liveDoc.doc.type}`}</MenuItemLabel>
+            <MenuItemLabel>{`Export ${documentTypeLabel(props.liveDoc.doc.type)}`}</MenuItemLabel>
         </MenuItem>
     );
 }
@@ -231,7 +231,7 @@ export function CopyJSONMenuItem(props: { liveDoc: LiveDoc }) {
     return (
         <MenuItem onSelect={onCopyJSON}>
             <CopyToClipboard />
-            <MenuItemLabel>{`Copy ${props.liveDoc.doc.type} to clipboard`}</MenuItemLabel>
+            <MenuItemLabel>{`Copy ${documentTypeLabel(props.liveDoc.doc.type)} to clipboard`}</MenuItemLabel>
         </MenuItem>
     );
 }
@@ -308,7 +308,7 @@ function DocumentsMenuItem() {
 export function DeleteMenuItem(props: {
     refId: string;
     name: string | null;
-    typeName: string;
+    typeName: Document["type"];
     canDelete: boolean;
     onDeleted?: () => void;
 }) {
@@ -319,7 +319,7 @@ export function DeleteMenuItem(props: {
         const success = await actions.showDeleteDialog({
             refId: props.refId,
             name: props.name,
-            typeName: props.typeName,
+            typeName: documentTypeLabel(props.typeName),
         });
         if (success) {
             props.onDeleted?.();
@@ -329,7 +329,7 @@ export function DeleteMenuItem(props: {
     return (
         <MenuItem disabled={!props.canDelete} onSelect={handleDelete}>
             <X />
-            <MenuItemLabel>{`Delete ${props.typeName}`}</MenuItemLabel>
+            <MenuItemLabel>{`Delete ${documentTypeLabel(props.typeName)}`}</MenuItemLabel>
         </MenuItem>
     );
 }
@@ -337,7 +337,7 @@ export function DeleteMenuItem(props: {
 /** Menu item to restore a deleted document. */
 export function RestoreMenuItem(props: {
     refId: string;
-    typeName: string;
+    typeName: Document["type"];
     onRestored?: () => void;
 }) {
     const api = useApi();
@@ -359,7 +359,7 @@ export function RestoreMenuItem(props: {
     return (
         <MenuItem onSelect={handleRestore}>
             <RotateCcw />
-            <MenuItemLabel>{`Restore deleted ${props.typeName}`}</MenuItemLabel>
+            <MenuItemLabel>{`Restore deleted ${documentTypeLabel(props.typeName)}`}</MenuItemLabel>
         </MenuItem>
     );
 }

--- a/packages/frontend/src/user/document_list.tsx
+++ b/packages/frontend/src/user/document_list.tsx
@@ -7,7 +7,9 @@ import { stringify as uuidStringify } from "uuid";
 
 import type { UserSettings } from "catcolab-api";
 import { RelativeTime, createVirtualList, DocumentTypeIcon } from "catcolab-ui-components";
+import type { LinkType } from "catlog-wasm";
 import { TheoryLibraryContext } from "../theory";
+import { assertExhaustive } from "../util/assert_exhaustive";
 import { isDocumentVisible } from "./user_settings";
 import { currentUserPermission, formatOwners, useUserState } from "./user_state_context";
 
@@ -42,6 +44,45 @@ export function filterDocuments(
 
 /** Fixed row height in pixels — must match --doc-row-height in CSS. */
 const ROW_HEIGHT = 45;
+
+type ParentDocumentDetails = {
+    relationType: LinkType;
+    prefix: string;
+    orphanedPrefix: string;
+};
+
+function parentDocumentDetails(typeName: DocInfo["typeName"]): ParentDocumentDetails | undefined {
+    switch (typeName) {
+        case "model":
+            return undefined;
+        case "diagram":
+            return {
+                relationType: "diagram-in",
+                prefix: "Diagram in ",
+                orphanedPrefix: "Orphaned diagram",
+            };
+        case "instance":
+            return {
+                relationType: "instance-of",
+                prefix: "Instance of ",
+                orphanedPrefix: "Orphaned instance",
+            };
+        case "analysis":
+            return {
+                relationType: "analysis-of",
+                prefix: "Analysis of ",
+                orphanedPrefix: "Orphaned analysis",
+            };
+        case "llmconversation":
+            return {
+                relationType: "llmconversation-of",
+                prefix: "LLM conversation about ",
+                orphanedPrefix: "Orphaned LLM conversation",
+            };
+        default:
+            return assertExhaustive(typeName);
+    }
+}
 
 interface DocumentListProps {
     documents: () => (DocInfo & { refId: string })[];
@@ -142,46 +183,32 @@ function DocumentRow(props: DocumentRowProps) {
     });
 
     const parentInfo = createMemo(() => {
-        // Derive the parent ref ID from dependsOn relations.
-        const parentRelType =
-            props.doc.typeName === "diagram"
-                ? "diagram-in"
-                : props.doc.typeName === "analysis"
-                  ? "analysis-of"
-                  : undefined;
-        if (!parentRelType) {
+        const details = parentDocumentDetails(props.doc.typeName);
+        if (!details) {
             return undefined;
         }
-        const rel = props.doc.dependsOn.find((r) => r.relationType === parentRelType);
-        if (!rel) {
+        const relation = props.doc.dependsOn.find(
+            (relation) => relation.relationType === details.relationType,
+        );
+        if (!relation) {
             return undefined;
         }
-        const parentId = uuidStringify(rel.refId);
+        const parentId = uuidStringify(relation.refId);
         const parentDoc = userState.documents[parentId];
-
-        // If parent document doesn't exist, show as orphaned
         if (!parentDoc) {
-            let prefix = "";
-            if (props.doc.typeName === "diagram") {
-                prefix = "Orphaned diagram";
-            } else if (props.doc.typeName === "analysis") {
-                prefix = "Orphaned analysis";
-            } else {
-                return undefined;
-            }
-            return { prefix, parentId: undefined, parentName: undefined, parentType: undefined };
+            return {
+                prefix: details.orphanedPrefix,
+                parentId: undefined,
+                parentName: undefined,
+                parentType: undefined,
+            };
         }
-
-        const parentName = parentDoc.name || "Untitled";
-        let prefix = "";
-        if (props.doc.typeName === "diagram") {
-            prefix = "Diagram in ";
-        } else if (props.doc.typeName === "analysis") {
-            prefix = "Analysis of ";
-        } else {
-            return undefined;
-        }
-        return { prefix, parentId, parentName, parentType: parentDoc.typeName };
+        return {
+            prefix: details.prefix,
+            parentId,
+            parentName: parentDoc.name || "Untitled",
+            parentType: parentDoc.typeName,
+        };
     });
 
     return (

--- a/packages/frontend/src/user/documents.tsx
+++ b/packages/frontend/src/user/documents.tsx
@@ -7,6 +7,7 @@ import { createMemo, createSignal, useContext } from "solid-js";
 import invariant from "tiny-invariant";
 
 import { IconButton } from "catcolab-ui-components";
+import { documentTypeLabel } from "../api";
 import { BrandedToolbar, PageActionsContext } from "../page";
 import { DocumentList, filterDocuments } from "./document_list";
 import { LoginGate } from "./login";
@@ -98,7 +99,7 @@ function DeleteButton(props: { doc: DocInfo & { refId: string } }) {
         await actions.showDeleteDialog({
             refId: props.doc.refId,
             name: props.doc.name,
-            typeName: props.doc.typeName,
+            typeName: documentTypeLabel(props.doc.typeName),
         });
     };
 

--- a/packages/frontend/src/util/error.ts
+++ b/packages/frontend/src/util/error.ts
@@ -1,0 +1,4 @@
+/** Convert an arbitrary caught value to an error message. */
+export function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}

--- a/packages/ui-components/src/document_type_icon.tsx
+++ b/packages/ui-components/src/document_type_icon.tsx
@@ -1,6 +1,7 @@
 import ChartSpline from "lucide-solid/icons/chart-spline";
 import File from "lucide-solid/icons/file";
 import FileX from "lucide-solid/icons/file-x";
+import MessageSquare from "lucide-solid/icons/message-square";
 import Network from "lucide-solid/icons/network";
 import Table from "lucide-solid/icons/table";
 import { Match, Switch } from "solid-js";
@@ -33,6 +34,9 @@ export function DocumentTypeIcon(props: {
             </Match>
             <Match when={props.documentType === "instance"}>
                 <Table />
+            </Match>
+            <Match when={props.documentType === "llmconversation"}>
+                <MessageSquare />
             </Match>
         </Switch>
     );


### PR DESCRIPTION
* Attachment functionality/policy: enforce a running total per conversation and cap per turn, filter on media type
* Unspaghettify document labels and links, centralise functionality and allow choosing UI labels separately from code names
* Take the opportunity to use `LinkType` from catlog(-wasm)
* Extract feedback resolution policy/logic on new message
* Implement retries (`retryLastLLMConversationResponse` for the future UI)
* Better fallback logic when the LLM does something unexpected, simplify `LLMConversationTurnResult` to track the relevant details

While it's true that this change makes it possible, in principle, to display LLM Conversation documents in the left bar/my documents there is no current way to create these (and everyone is opted-out by default) so they won't appear in practice.