### PR TITLE
OBEE-28: implement in-memory binder, route all views/changes through that interface

### DIFF
--- a/packages/documents/package.json
+++ b/packages/documents/package.json
@@ -19,7 +19,8 @@
     "dependencies": {
         "catcolab-document-methods": "link:../document-methods",
         "catcolab-document-types": "link:../document-types/pkg",
-        "catlog-wasm": "link:../catlog-wasm/dist/pkg-browser"
+        "catlog-wasm": "link:../catlog-wasm/dist/pkg-browser",
+        "uuid": "^13.0.0"
     },
     "devDependencies": {
         "@automerge/automerge": "^3.3.1",
@@ -39,7 +40,6 @@
         "prosemirror-view": "^1.41.9",
         "solid-js": "^1.9.10",
         "typescript": "^6.0.3",
-        "uuid": "^13.0.0",
         "vite": "^7.2.2",
         "vite-plugin-solid": "^2.11.10",
         "vite-plugin-wasm": "^3.5.0",

--- a/packages/documents/pnpm-lock.yaml
+++ b/packages/documents/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       catlog-wasm:
         specifier: link:../catlog-wasm/dist/pkg-browser
         version: link:../catlog-wasm/dist/pkg-browser
+      uuid:
+        specifier: ^13.0.0
+        version: 13.0.2
     devDependencies:
       '@automerge/automerge':
         specifier: ^3.3.1
@@ -69,9 +72,6 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
-      uuid:
-        specifier: ^13.0.0
-        version: 13.0.2
       vite:
         specifier: ^7.2.2
         version: 7.3.6(@types/node@24.13.3)

--- a/packages/documents/src/binder.ts
+++ b/packages/documents/src/binder.ts
@@ -1,6 +1,8 @@
 import { Model } from "catcolab-document-methods";
+import type { DocumentStore } from "./document-store";
+import { createInMemoryStore } from "./document-store/in-memory";
 import type { ModelDocument } from "./model/document";
-import { modelNotebookFromDoc, type Notebook } from "./model/notebook";
+import { modelNotebookFromStore, type Notebook } from "./model/notebook";
 import type { Shape } from "./shape";
 
 export interface Binder {
@@ -10,16 +12,31 @@ export interface Binder {
     ): Promise<Notebook<S, ModelDocument>>;
 }
 
+/* The following two functions cannot be refined to overloads of a single
+   function of the form `function foo<T>(opt?: T)`. The reason being is that
+   this allows callers the nonsensical pattern foo<S>() for some concrete S and
+   the implementation will have to ignore S. In general this pattern would be
+   even worse, as the compiler would set T to unknown in `foo()`.
+ */
+
 export function createBinder(): Binder {
+    return createBinderWithStore(createInMemoryStore());
+}
+
+export function createBinderWithStore<Handle>(store: DocumentStore<Handle>): Binder {
     return {
         async createNotebook<S extends Shape & { readonly theory: string }>(
             shape: S,
             options: { title: string },
         ) {
-            const document = Model.newModelDocument({ theory: shape.theory });
+            const document = Model.newModelDocument({
+                theory: shape.theory,
+            });
             document.name = options.title;
 
-            return modelNotebookFromDoc(shape, document);
+            const handle = await store.createHandle(document);
+
+            return modelNotebookFromStore(shape, store, handle);
         },
     };
 }

--- a/packages/documents/src/document-store/document-store.ts
+++ b/packages/documents/src/document-store/document-store.ts
@@ -1,0 +1,27 @@
+import type { Document } from "catcolab-document-types";
+import type { Result } from "../result";
+
+export interface DocumentRef {
+    id: string;
+    version: string | null;
+    server?: string;
+}
+
+export interface DocumentStore<Handle> {
+    // An async function to create a document handle from initial data.
+    createHandle(initialDoc: Document): Promise<Handle>;
+    // An async function to get a document handle from a `DocumentRef`,
+    // as a `Result` (`Ok` with the handle, or `Err` with issues).
+    getHandle(ref: DocumentRef): Promise<Result<Handle>>;
+    // Apply modifications to a handle.
+    changeDocument(handle: Handle, fn: (doc: Document) => void): void;
+    // Subscribe change callbacks to our store for `onChange`. Returns a
+    // function to unsubscribe.
+    subscribe(handle: Handle, callback: () => void): () => void;
+    // Copy values (with any proxies removed)
+    copyValue<T>(handle: Handle, value: T): T;
+    // Get the reference for a handle
+    getDocumentRef(handle: Handle): DocumentRef;
+    // Get a document view from a handle
+    getDocumentView(handle: Handle): Readonly<Document>;
+}

--- a/packages/documents/src/document-store/in-memory.ts
+++ b/packages/documents/src/document-store/in-memory.ts
@@ -1,0 +1,98 @@
+import { v7 } from "uuid";
+
+import type { Document } from "catcolab-document-types";
+import type { Result } from "../result";
+import type { DocumentStore, DocumentRef } from "./document-store";
+
+export function createInMemoryStore(): DocumentStore<Document> {
+    const idToDocument = new Map<string, Document>();
+    const documentToId = new WeakMap<Document, string>();
+    const documentToCallbacks = new WeakMap<Document, Set<() => void>>();
+
+    function requireDocumentId(handle: Document): string {
+        const id = documentToId.get(handle);
+        if (id === undefined) {
+            throw new Error("Document handle is not registered with this store.");
+        }
+        return id;
+    }
+
+    return {
+        async createHandle(initialDoc: Document): Promise<Document> {
+            const uuid = v7();
+            idToDocument.set(uuid, initialDoc);
+            documentToCallbacks.set(initialDoc, new Set());
+            documentToId.set(initialDoc, uuid);
+            return initialDoc;
+        },
+
+        async getHandle(ref: DocumentRef): Promise<Result<Document>> {
+            if (ref.server !== undefined && ref.server !== "") {
+                return {
+                    tag: "Err",
+                    content: [
+                        {
+                            message: "Cannot resolve non-local document from in-memory store.",
+                        },
+                    ],
+                };
+            }
+
+            if (ref.version !== null) {
+                return {
+                    tag: "Err",
+                    content: [
+                        {
+                            message: "Cannot resolve versioned document from in-memory store.",
+                        },
+                    ],
+                };
+            }
+
+            const document = idToDocument.get(ref.id);
+            if (document) {
+                return { tag: "Ok", content: document };
+            }
+
+            return {
+                tag: "Err",
+                content: [{ message: `Unable to find document ${ref.id} in in-memory store.` }],
+            };
+        },
+
+        changeDocument(handle: Document, fn: (doc: Document) => void): void {
+            requireDocumentId(handle);
+            fn(handle);
+
+            // Make an array to prevent mutation of the callback set during iteration.
+            for (const callback of Array.from(documentToCallbacks.get(handle)!)) {
+                callback();
+            }
+        },
+
+        subscribe(handle: Document, callback: () => void): () => void {
+            requireDocumentId(handle);
+
+            const callbacks = documentToCallbacks.get(handle)!;
+            callbacks.add(callback);
+
+            return () => {
+                callbacks.delete(callback);
+            };
+        },
+
+        copyValue<T>(handle: Document, value: T): T {
+            requireDocumentId(handle);
+            return structuredClone(value);
+        },
+
+        getDocumentRef(handle: Document): DocumentRef {
+            return { id: requireDocumentId(handle), version: null };
+        },
+
+        getDocumentView(handle: Document): Readonly<Document> {
+            requireDocumentId(handle);
+            return handle;
+        },
+    };
+}

--- a/packages/documents/src/document-store/index.ts
+++ b/packages/documents/src/document-store/index.ts
@@ -1,0 +1,2 @@
+export type { DocumentRef, DocumentStore } from "./document-store";
+export { createInMemoryStore } from "./in-memory";

--- a/packages/documents/src/index.ts
+++ b/packages/documents/src/index.ts
@@ -1,8 +1,10 @@
-export { createBinder } from "./binder";
+export { createBinder, createBinderWithStore } from "./binder";
 export type { Binder } from "./binder";
+export type { DocumentStore, DocumentRef } from "./document-store";
+export type { Issue, PathSegment, Result } from "./result";
+export { createInMemoryStore } from "./document-store";
 export type { MorphismCell, ObjectCell } from "./model/cell";
 export type { ModelDocument } from "./model/document";
-export { modelNotebookFromDoc as notebookFromModel } from "./model/notebook";
 export type { Notebook } from "./model/notebook";
 export type { NotebookDocument } from "./notebook-document";
 export type { RichTextCell } from "./rich-text";

--- a/packages/documents/src/model/cell.ts
+++ b/packages/documents/src/model/cell.ts
@@ -1,5 +1,6 @@
 import { Nb } from "catcolab-document-methods";
 import type { Ob } from "catcolab-document-types";
+import type { DocumentStore } from "../document-store";
 import { getRichTextCell, type RichTextCell } from "../rich-text";
 import { findMorphismType, findObjectType } from "../shape";
 import type {
@@ -12,7 +13,6 @@ import type {
     Shape,
 } from "../shape";
 import { getModelJudgment, type ModelDocument } from "./document";
-
 export interface ObjectCell<O extends ObjectType> {
     readonly kind: "object";
     readonly id: string;
@@ -44,8 +44,9 @@ export type CellOf<S extends Shape> =
     | ObjectCell<ObjectTypesOf<S>>
     | MorphismCell<S, MorphismTypesOf<S>>;
 
-export function getObjectCell<O extends ObjectType>(
-    document: ModelDocument,
+export function getObjectCell<Handle, O extends ObjectType>(
+    store: DocumentStore<Handle>,
+    handle: Handle,
     cellId: string,
     type: O,
 ): ObjectCell<O> {
@@ -54,6 +55,7 @@ export function getObjectCell<O extends ObjectType>(
         id: cellId,
         type,
         get label() {
+            const document = store.getDocumentView(handle) as Readonly<ModelDocument>;
             const judgment = getModelJudgment(document, cellId);
             if (judgment.tag !== "object") {
                 throw new Error(`Cell ${cellId} is not an object.`);
@@ -64,20 +66,24 @@ export function getObjectCell<O extends ObjectType>(
             if (patch.label === undefined) {
                 return;
             }
-            const judgment = getModelJudgment(document, cellId);
-            if (judgment.tag !== "object") {
-                throw new Error(`Cell ${cellId} is not an object.`);
-            }
-            judgment.name = patch.label ?? "";
+            store.changeDocument(handle, (document) => {
+                const judgment = getModelJudgment(document as ModelDocument, cellId);
+                if (judgment.tag !== "object") {
+                    throw new Error(`Cell ${cellId} is not an object.`);
+                }
+                judgment.name = patch.label ?? "";
+            });
         },
     };
 }
 
-function objectCellFromOb<S extends Shape>(
+function objectCellFromOb<Handle, S extends Shape>(
     shape: S,
-    document: ModelDocument,
+    store: DocumentStore<Handle>,
+    handle: Handle,
     endpoint: Ob | null,
 ): ObjectCell<ObjectTypesOf<S>> | null {
+    const document = store.getDocumentView(handle) as Readonly<ModelDocument>;
     if (endpoint?.tag !== "Basic") {
         return null;
     }
@@ -89,7 +95,7 @@ function objectCellFromOb<S extends Shape>(
         }
         if (cell.content.id === endpoint.content) {
             const type = findObjectType(shape, cell.content.obType);
-            return type ? getObjectCell(document, cellId, type) : null;
+            return type ? getObjectCell(store, handle, cellId, type) : null;
         }
     }
 
@@ -97,7 +103,7 @@ function objectCellFromOb<S extends Shape>(
 }
 
 export function obFromObjectCell(
-    document: ModelDocument,
+    document: Readonly<ModelDocument>,
     endpoint: ObjectCell<ObjectType> | null,
 ): Ob | null {
     if (!endpoint) {
@@ -110,9 +116,10 @@ export function obFromObjectCell(
     return { tag: "Basic", content: judgment.id };
 }
 
-export function getMorphismCell<S extends Shape, M extends MorphismTypesOf<S>>(
+export function getMorphismCell<Handle, S extends Shape, M extends MorphismTypesOf<S>>(
     shape: S,
-    document: ModelDocument,
+    store: DocumentStore<Handle>,
+    handle: Handle,
     cellId: string,
     type: M,
 ): MorphismCell<S, M> {
@@ -121,6 +128,7 @@ export function getMorphismCell<S extends Shape, M extends MorphismTypesOf<S>>(
         id: cellId,
         type,
         get label() {
+            const document = store.getDocumentView(handle) as Readonly<ModelDocument>;
             const judgment = getModelJudgment(document, cellId);
             if (judgment.tag !== "morphism") {
                 throw new Error(`Cell ${cellId} is not a morphism.`);
@@ -128,56 +136,64 @@ export function getMorphismCell<S extends Shape, M extends MorphismTypesOf<S>>(
             return judgment.name;
         },
         get from() {
+            const document = store.getDocumentView(handle) as Readonly<ModelDocument>;
             const judgment = getModelJudgment(document, cellId);
             if (judgment.tag !== "morphism") {
                 throw new Error(`Cell ${cellId} is not a morphism.`);
             }
-            return objectCellFromOb(shape, document, judgment.dom) as ObjectCell<
+            return objectCellFromOb(shape, store, handle, judgment.dom) as ObjectCell<
                 DomainObjectTypesOf<S, M>
             > | null;
         },
         get to() {
+            const document = store.getDocumentView(handle) as Readonly<ModelDocument>;
             const judgment = getModelJudgment(document, cellId);
             if (judgment.tag !== "morphism") {
                 throw new Error(`Cell ${cellId} is not a morphism.`);
             }
-            return objectCellFromOb(shape, document, judgment.cod) as ObjectCell<
+            return objectCellFromOb(shape, store, handle, judgment.cod) as ObjectCell<
                 CodomainObjectTypesOf<S, M>
             > | null;
         },
         update(patch) {
-            const judgment = getModelJudgment(document, cellId);
-            if (judgment.tag !== "morphism") {
-                throw new Error(`Cell ${cellId} is not a morphism.`);
-            }
-            const dom = Object.hasOwn(patch, "from")
-                ? obFromObjectCell(document, patch.from ?? null)
-                : undefined;
-            const cod = Object.hasOwn(patch, "to")
-                ? obFromObjectCell(document, patch.to ?? null)
-                : undefined;
+            store.changeDocument(handle, (document) => {
+                const modelDocument = document as ModelDocument;
+                const judgment = getModelJudgment(modelDocument, cellId);
+                if (judgment.tag !== "morphism") {
+                    throw new Error(`Cell ${cellId} is not a morphism.`);
+                }
 
-            if (patch.label !== undefined) {
-                judgment.name = patch.label ?? "";
-            }
-            if (dom !== undefined) {
-                judgment.dom = dom;
-            }
-            if (cod !== undefined) {
-                judgment.cod = cod;
-            }
+                const dom = Object.hasOwn(patch, "from")
+                    ? obFromObjectCell(modelDocument, patch.from ?? null)
+                    : undefined;
+                const cod = Object.hasOwn(patch, "to")
+                    ? obFromObjectCell(modelDocument, patch.to ?? null)
+                    : undefined;
+
+                if (patch.label !== undefined) {
+                    judgment.name = patch.label ?? "";
+                }
+                if (dom !== undefined) {
+                    judgment.dom = dom;
+                }
+                if (cod !== undefined) {
+                    judgment.cod = cod;
+                }
+            });
         },
     };
 }
 
-export function getModelCell<S extends Shape>(
+export function getModelCell<Handle, S extends Shape>(
     shape: S,
-    document: ModelDocument,
+    store: DocumentStore<Handle>,
+    handle: Handle,
     cellId: string,
 ): CellOf<S> {
+    const document = store.getDocumentView(handle) as Readonly<ModelDocument>;
     const cell = Nb.getCellById(document.notebook, cellId);
     if (cell.tag === "rich-text") {
-        return getRichTextCell(document, cellId);
+        return getRichTextCell(store, handle, cellId);
     }
 
     switch (cell.content.tag) {
@@ -186,14 +202,14 @@ export function getModelCell<S extends Shape>(
             if (!type) {
                 throw new Error(`Object cell ${cellId} is not supported by the notebook shape.`);
             }
-            return getObjectCell(document, cellId, type);
+            return getObjectCell(store, handle, cellId, type);
         }
         case "morphism": {
             const type = findMorphismType(shape, cell.content.morType);
             if (!type) {
                 throw new Error(`Morphism cell ${cellId} is not supported by the notebook shape.`);
             }
-            return getMorphismCell(shape, document, cellId, type);
+            return getMorphismCell(shape, store, handle, cellId, type);
         }
         default:
             throw new Error(`Formal cell ${cellId} is not supported yet.`);

--- a/packages/documents/src/model/document.ts
+++ b/packages/documents/src/model/document.ts
@@ -3,7 +3,7 @@ import type { ModelJudgment } from "catcolab-document-types";
 
 export type { ModelDocument } from "catcolab-document-methods";
 
-export function getModelJudgment(document: ModelDocument, cellId: string): ModelJudgment {
+export function getModelJudgment(document: Readonly<ModelDocument>, cellId: string): ModelJudgment {
     const cell = Nb.getCellById(document.notebook, cellId);
     if (cell.tag !== "formal") {
         throw new Error(`Cell ${cellId} is not formal.`);

--- a/packages/documents/src/model/notebook.ts
+++ b/packages/documents/src/model/notebook.ts
@@ -1,5 +1,6 @@
 import { Model, Nb } from "catcolab-document-methods";
 import type { ModelJudgment } from "catcolab-document-types";
+import type { DocumentStore } from "../document-store";
 import type { NotebookDocument } from "../notebook-document";
 import { getRichTextCell, type RichTextCell } from "../rich-text";
 import type {
@@ -52,30 +53,43 @@ type AddedCellOf<S extends Shape, T extends CellTypeOf<S>> = T extends RichTextT
 
 export interface Notebook<S extends Shape, D extends NotebookDocument = NotebookDocument> {
     readonly shape: S;
-    readonly document: D;
+    readonly document: Readonly<D>;
     readonly title: string;
 
     add<T extends CellTypeOf<S>>(type: T, values: CellValuesOf<S, T>): AddedCellOf<S, T>;
     cells(): readonly CellOf<S>[];
     update(patch: Partial<{ title: string }>): void;
+    dump(): D;
+    onChange(callback: () => void): () => void;
 }
 
-export function modelNotebookFromDoc<S extends Shape, D extends ModelDocument>(
+export function modelNotebookFromStore<Handle, S extends Shape>(
     shape: S,
-    document: D,
-): Notebook<S, D> {
+    store: DocumentStore<Handle>,
+    handle: Handle,
+): Notebook<S, ModelDocument> {
+    function appendCell(
+        cell: ReturnType<typeof Nb.newRichTextCell> | Nb.FormalCell<ModelJudgment>,
+    ) {
+        store.changeDocument(handle, (document) => {
+            Nb.appendCell((document as ModelDocument).notebook, cell);
+        });
+    }
+
     return {
         shape,
-        document,
+        get document() {
+            return store.getDocumentView(handle) as Readonly<ModelDocument>;
+        },
         get title() {
-            return document.name;
+            return (store.getDocumentView(handle) as Readonly<ModelDocument>).name;
         },
         add<T extends CellTypeOf<S>>(type: T, values: CellValuesOf<S, T>) {
             if (type.kind === "rich-text") {
                 const richText = values as { content: string };
                 const cell = Nb.newRichTextCell(richText.content);
-                Nb.appendCell(document.notebook, cell);
-                return getRichTextCell(document, cell.id) as AddedCellOf<S, T>;
+                appendCell(cell);
+                return getRichTextCell(store, handle, cell.id) as AddedCellOf<S, T>;
             }
 
             if (type.kind === "object") {
@@ -83,36 +97,50 @@ export function modelNotebookFromDoc<S extends Shape, D extends ModelDocument>(
                 const judgment = Model.newObjectDecl(type.obType);
                 judgment.name = object.label ?? "";
                 const cell = Nb.newFormalCell<ModelJudgment>(judgment);
-                Nb.appendCell(document.notebook, cell);
-                return getObjectCell(document, cell.id, type as ObjectTypesOf<S>) as AddedCellOf<
-                    S,
-                    T
-                >;
+                appendCell(cell);
+                return getObjectCell(
+                    store,
+                    handle,
+                    cell.id,
+                    type as ObjectTypesOf<S>,
+                ) as AddedCellOf<S, T>;
             }
 
             const morphism = values as CellValuesOf<S, MorphismTypesOf<S>>;
             const judgment = Model.newMorphismDecl(type.morType);
             judgment.name = morphism.label ?? "";
+            const document = store.getDocumentView(handle) as Readonly<ModelDocument>;
             judgment.dom = obFromObjectCell(document, morphism.from);
             judgment.cod = obFromObjectCell(document, morphism.to);
             const cell = Nb.newFormalCell<ModelJudgment>(judgment);
-            Nb.appendCell(document.notebook, cell);
+            appendCell(cell);
             return getMorphismCell(
                 shape,
-                document,
+                store,
+                handle,
                 cell.id,
                 type as MorphismTypesOf<S>,
             ) as AddedCellOf<S, T>;
         },
         cells() {
+            const document = store.getDocumentView(handle) as Readonly<ModelDocument>;
             return document.notebook.cellOrder.map((cellId) =>
-                getModelCell(shape, document, cellId),
+                getModelCell(shape, store, handle, cellId),
             );
         },
         update(patch) {
             if (patch.title !== undefined) {
-                document.name = patch.title;
+                store.changeDocument(handle, (document) => {
+                    (document as ModelDocument).name = patch.title as string;
+                });
             }
+        },
+        dump() {
+            const document = store.getDocumentView(handle) as Readonly<ModelDocument>;
+            return store.copyValue(handle, document) as ModelDocument;
+        },
+        onChange(callback) {
+            return store.subscribe(handle, callback);
         },
     };
 }

--- a/packages/documents/src/result.ts
+++ b/packages/documents/src/result.ts
@@ -1,0 +1,18 @@
+/** The result of a fallible operation. */
+export type Result<T, E = ReadonlyArray<Issue>> =
+    | { readonly tag: "Ok"; readonly content: T }
+    | { readonly tag: "Err"; readonly content: E };
+
+/** The issue interface of the failure output. */
+export interface Issue {
+    /** The error message of the issue. */
+    readonly message: string;
+    /** The path of the issue, if any. */
+    readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined;
+}
+
+/** The path segment interface of the issue. */
+export interface PathSegment {
+    /** The key representing a path segment. */
+    readonly key: PropertyKey;
+}

--- a/packages/documents/src/rich-text.ts
+++ b/packages/documents/src/rich-text.ts
@@ -1,14 +1,16 @@
+import type { RichTextContent } from "catcolab-document-types";
+import type { DocumentStore } from "./document-store";
 import type { NotebookDocument } from "./notebook-document";
 
 export interface RichTextCell {
     readonly kind: "rich-text";
     readonly id: string;
-    readonly content: string;
+    readonly content: RichTextContent;
 
-    update(patch: Partial<{ content: string }>): void;
+    update(patch: Partial<{ content: RichTextContent }>): void;
 }
 
-function getStoredRichTextCell(document: NotebookDocument, cellId: string) {
+function getStoredRichTextCell(document: Readonly<NotebookDocument>, cellId: string) {
     const cell = document.notebook.cellContents[cellId];
     if (!cell) {
         throw new Error(`Cell ${cellId} does not exist.`);
@@ -19,18 +21,26 @@ function getStoredRichTextCell(document: NotebookDocument, cellId: string) {
     return cell;
 }
 
-export function getRichTextCell(document: NotebookDocument, cellId: string): RichTextCell {
+export function getRichTextCell<Handle>(
+    store: DocumentStore<Handle>,
+    handle: Handle,
+    cellId: string,
+): RichTextCell {
     return {
         kind: "rich-text",
         id: cellId,
         get content() {
+            const document = store.getDocumentView(handle) as Readonly<NotebookDocument>;
             return getStoredRichTextCell(document, cellId).content;
         },
         update(patch) {
-            if (patch.content === undefined) {
+            const content = patch.content;
+            if (content === undefined) {
                 return;
             }
-            getStoredRichTextCell(document, cellId).content = patch.content;
+            store.changeDocument(handle, (document) => {
+                getStoredRichTextCell(document as NotebookDocument, cellId).content = content;
+            });
         },
     };
 }


### PR DESCRIPTION
The only salient point here is that there does not appear to be a satisfactory way to have `createBinder<Handle>(store?: ...)` overload `createBinder()`, so instead we have `createBinder()` (no args) and `createBinderWithStore<Handle>(store: ...)` both exported.