### PR TITLE
Refactor ID fields in tabular instance document-type

### DIFF
--- a/packages/document-types/src/v2/document.rs
+++ b/packages/document-types/src/v2/document.rs
@@ -10,7 +10,6 @@ use super::notebook::Notebook;
 
 use serde::{Deserialize, Serialize};
 use tsify::Tsify;
-use uuid::Uuid;
 
 /// This is the content of a model document. For legacy reasons, we reserve
 /// the name "ModelDocument" for `Document & { type: "model" }`.
@@ -45,7 +44,8 @@ pub struct InstanceDocumentContent {
     pub name: String,
     #[serde(rename = "instanceOf")]
     pub instance_of: Link,
-    pub tables: HashMap<Uuid, Table>,
+    /// Tables keyed by their schema entity `QualifiedName`.
+    pub tables: HashMap<String, Table>,
     pub version: String,
 }
 

--- a/packages/document-types/src/v2/instance.rs
+++ b/packages/document-types/src/v2/instance.rs
@@ -36,10 +36,12 @@ pub struct TableRow {
 #[tsify(into_wasm_abi, from_wasm_abi, hashmap_as_object)]
 pub struct Table {
     /// The `QualifiedName` of the entity to which this table corresponds.
+    #[serde(rename = "entityId")]
     pub entity_id: String,
     /// The rows of the table.
     pub rows: HashMap<Uuid, TableRow>,
     /// The order of the rows of the table.
+    #[serde(rename = "rowOrder")]
     pub row_order: Vec<Uuid>,
 }
 

--- a/packages/document-types/src/v2/instance.rs
+++ b/packages/document-types/src/v2/instance.rs
@@ -35,9 +35,6 @@ pub struct TableRow {
 #[derive(PartialEq, Debug, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi, hashmap_as_object)]
 pub struct Table {
-    /// The `QualifiedName` of the entity to which this table corresponds.
-    #[serde(rename = "entityId")]
-    pub entity_id: String,
     /// The rows of the table.
     pub rows: HashMap<Uuid, TableRow>,
     /// The order of the rows of the table.
@@ -51,10 +48,10 @@ mod test {
     use serde_json::Value;
 
     #[test]
-    fn table_round_trips_through_json_with_string_keys() {
+    fn tables_are_keyed_by_schema_entity_id_in_json() {
         let row_id = Uuid::from_u128(1);
         let col_id = Uuid::from_u128(2);
-        let ent_id = Uuid::from_u128(3);
+        let ent_id = Uuid::from_u128(3).to_string();
 
         let mut fields = HashMap::new();
         fields.insert(col_id.to_string(), FieldValue::Int(42));
@@ -62,27 +59,27 @@ mod test {
         let mut rows = HashMap::new();
         rows.insert(row_id, TableRow { fields });
 
-        let table = Table {
-            entity_id: ent_id.to_string(),
-            rows,
-            row_order: vec![row_id],
-        };
+        let table = Table { rows, row_order: vec![row_id] };
 
-        let value = serde_json::to_value(&table).expect("serialize to JSON");
+        let mut tables = HashMap::new();
+        tables.insert(ent_id.clone(), table);
 
-        // Map keys must be plain strings in the resulting JSON object.
-        let rows_obj = value.get("rows").and_then(Value::as_object).expect("rows object");
+        let value = serde_json::to_value(&tables).expect("serialize to JSON");
+
+        // Schema entity and row IDs must be plain strings in JSON objects.
+        let table_obj = value.get(&ent_id).and_then(Value::as_object).expect("table object");
+        let rows_obj = table_obj.get("rows").and_then(Value::as_object).expect("rows object");
         assert!(rows_obj.contains_key(&row_id.to_string()));
 
-        let round_tripped: Table = serde_json::from_value(value).expect("deserialize from JSON");
-        assert_eq!(round_tripped, table);
+        let round_tripped: HashMap<String, Table> =
+            serde_json::from_value(value).expect("deserialize from JSON");
+        assert_eq!(round_tripped, tables);
     }
 
     #[test]
     fn multi_segment_key_round_trips() {
         let a = Uuid::from_u128(10);
         let b = Uuid::from_u128(11);
-        let ent_id = Uuid::from_u128(12);
         let row_id = Uuid::from_u128(13);
 
         // Paths of UUIDs are represented as dot-separated strings.
@@ -94,11 +91,7 @@ mod test {
         let mut rows = HashMap::new();
         rows.insert(row_id, TableRow { fields });
 
-        let table = Table {
-            entity_id: ent_id.to_string(),
-            rows,
-            row_order: vec![row_id],
-        };
+        let table = Table { rows, row_order: vec![row_id] };
 
         let value = serde_json::to_value(&table).expect("serialize to JSON");
 

--- a/packages/document-types/src/v2/instance.rs
+++ b/packages/document-types/src/v2/instance.rs
@@ -36,7 +36,7 @@ pub struct TableRow {
 #[tsify(into_wasm_abi, from_wasm_abi, hashmap_as_object)]
 pub struct Table {
     /// The `QualifiedName` of the entity to which this table corresponds.
-    pub id: String,
+    pub entity_id: String,
     /// The rows of the table.
     pub rows: HashMap<Uuid, TableRow>,
     /// The order of the rows of the table.
@@ -61,7 +61,7 @@ mod test {
         rows.insert(row_id, TableRow { fields });
 
         let table = Table {
-            id: ent_id.to_string(),
+            entity_id: ent_id.to_string(),
             rows,
             row_order: vec![row_id],
         };
@@ -93,7 +93,7 @@ mod test {
         rows.insert(row_id, TableRow { fields });
 
         let table = Table {
-            id: ent_id.to_string(),
+            entity_id: ent_id.to_string(),
             rows,
             row_order: vec![row_id],
         };

--- a/packages/document-types/src/v2/instance.rs
+++ b/packages/document-types/src/v2/instance.rs
@@ -27,8 +27,6 @@ pub enum FieldValue {
 #[derive(PartialEq, Debug, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi, hashmap_as_object)]
 pub struct TableRow {
-    /// The row "number".
-    pub id: Uuid,
     /// The content of the row, given as a map from morphism `QualifiedName` to values.
     pub fields: HashMap<String, FieldValue>,
 }
@@ -60,7 +58,7 @@ mod test {
         fields.insert(col_id.to_string(), FieldValue::Int(42));
 
         let mut rows = HashMap::new();
-        rows.insert(row_id, TableRow { id: row_id, fields });
+        rows.insert(row_id, TableRow { fields });
 
         let table = Table {
             id: ent_id.to_string(),
@@ -92,7 +90,7 @@ mod test {
         fields.insert(key.clone(), FieldValue::RowRef(row_id));
 
         let mut rows = HashMap::new();
-        rows.insert(row_id, TableRow { id: row_id, fields });
+        rows.insert(row_id, TableRow { fields });
 
         let table = Table {
             id: ent_id.to_string(),


### PR DESCRIPTION
Two changes to the instance document type:

1. Remove `id` field from `TableRow`. Since we already store `TableRow` in a hashmap with id keys.
2. ~~Rename the `Table.id` to `Table.entity_id` because, when e.g. working on the TS API, having a `table.id` that is not the table id is confusing.~~ Remove `id` field from `Table` for the same reason.