### PR TITLE
OBEE-29 add CellKind, iterator/filter to API

### DIFF
--- a/packages/documents/src/index.ts
+++ b/packages/documents/src/index.ts
@@ -1,9 +1,10 @@
 export { createBinder, createBinderWithStore } from "./binder";
+export { CellKind } from "./model/cell";
 export type { Binder } from "./binder";
 export type { DocumentStore, DocumentRef } from "./document-store";
 export type { Issue, PathSegment, Result } from "./result";
 export { createInMemoryStore } from "./document-store";
-export type { MorphismCell, ObjectCell } from "./model/cell";
+export type { CellOf as NotebookCell, MorphismCell, ObjectCell } from "./model/cell";
 export type { ModelDocument } from "./model/document";
 export type { Notebook } from "./model/notebook";
 export type { NotebookDocument } from "./notebook-document";

--- a/packages/documents/src/model/cell.ts
+++ b/packages/documents/src/model/cell.ts
@@ -13,6 +13,14 @@ import type {
     Shape,
 } from "../shape";
 import { getModelJudgment, type ModelDocument } from "./document";
+
+/** Runtime names for the discriminants on notebook cell handles. */
+export const CellKind = {
+    RichText: "rich-text" satisfies RichTextCell["kind"],
+    Object: "object" satisfies ObjectCell<ObjectType>["kind"],
+    Morphism: "morphism" satisfies MorphismCell<Shape, MorphismType>["kind"],
+} as const;
+
 export interface ObjectCell<O extends ObjectType> {
     readonly kind: "object";
     readonly id: string;

--- a/packages/documents/src/model/notebook.ts
+++ b/packages/documents/src/model/notebook.ts
@@ -4,6 +4,7 @@ import type { DocumentStore } from "../document-store";
 import type { NotebookDocument } from "../notebook-document";
 import { getRichTextCell, type RichTextCell } from "../rich-text";
 import type {
+    AnyCellType,
     CellTypeOf,
     CodomainObjectTypesOf,
     DomainObjectTypesOf,
@@ -24,6 +25,7 @@ import {
     type ObjectCell,
 } from "./cell";
 import type { ModelDocument } from "./document";
+import { morphismTypesEqual, objectTypesEqual } from "./equality";
 
 /**
  * The value given to [`Notebook.add`].
@@ -51,6 +53,112 @@ type AddedCellOf<S extends Shape, T extends CellTypeOf<S>> = T extends RichTextT
         ? MorphismCell<S, T>
         : never;
 
+function isCellType(value: AnyCellType | Shape): value is AnyCellType {
+    return "kind" in value;
+}
+
+function shapeSupportsCell(shape: Shape, type: AnyCellType): boolean {
+    switch (type.kind) {
+        case "rich-text":
+            return true;
+        case "object":
+            if (shape.objects === undefined) {
+                return false;
+            }
+            for (const candidate of shape.objects) {
+                if (objectTypesEqual(candidate.obType, type.obType)) {
+                    return true;
+                }
+            }
+            return false;
+        case "morphism":
+            if (shape.morphisms === undefined) {
+                return false;
+            }
+            for (const candidate of shape.morphisms) {
+                if (morphismTypesEqual(candidate.morType, type.morType)) {
+                    return true;
+                }
+            }
+            return false;
+    }
+}
+
+function shapeSupportsShape(shape: Shape, required: Shape): boolean {
+    if (required.objects !== undefined) {
+        for (const type of required.objects) {
+            if (!shapeSupportsCell(shape, type)) {
+                return false;
+            }
+        }
+    }
+
+    if (required.morphisms !== undefined) {
+        for (const type of required.morphisms) {
+            if (!shapeSupportsCell(shape, type)) {
+                return false;
+            }
+        }
+    }
+
+    if (required.informal !== undefined) {
+        for (const type of required.informal) {
+            if (!shapeSupportsCell(shape, type)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+function cellMatchesFilter<S extends Shape>(cell: CellOf<S>, filter: AnyCellType | Shape): boolean {
+    if (isCellType(filter)) {
+        switch (filter.kind) {
+            case "rich-text":
+                return cell.kind === "rich-text";
+            case "object":
+                if (cell.kind !== "object") {
+                    return false;
+                }
+                return objectTypesEqual(cell.type.obType, filter.obType);
+            case "morphism":
+                if (cell.kind !== "morphism") {
+                    return false;
+                }
+                return morphismTypesEqual(cell.type.morType, filter.morType);
+        }
+    }
+
+    switch (cell.kind) {
+        case "rich-text":
+            if (filter.informal === undefined) {
+                return false;
+            }
+            return filter.informal.length > 0;
+        case "object":
+            if (filter.objects === undefined) {
+                return false;
+            }
+            for (const type of filter.objects) {
+                if (objectTypesEqual(cell.type.obType, type.obType)) {
+                    return true;
+                }
+            }
+            return false;
+        case "morphism":
+            if (filter.morphisms === undefined) {
+                return false;
+            }
+            for (const type of filter.morphisms) {
+                if (morphismTypesEqual(cell.type.morType, type.morType)) {
+                    return true;
+                }
+            }
+            return false;
+    }
+}
+
 export interface Notebook<S extends Shape, D extends NotebookDocument = NotebookDocument> {
     readonly shape: S;
     readonly document: Readonly<D>;
@@ -58,6 +166,8 @@ export interface Notebook<S extends Shape, D extends NotebookDocument = Notebook
 
     add<T extends CellTypeOf<S>>(type: T, values: CellValuesOf<S, T>): AddedCellOf<S, T>;
     cells(): readonly CellOf<S>[];
+    cellsOf(typeOrShape: AnyCellType | Shape): readonly CellOf<S>[];
+    supports(typeOrShape: AnyCellType | Shape): boolean;
     update(patch: Partial<{ title: string }>): void;
     dump(): D;
     onChange(callback: () => void): () => void;
@@ -127,6 +237,15 @@ export function modelNotebookFromStore<Handle, S extends Shape>(
             return document.notebook.cellOrder.map((cellId) =>
                 getModelCell(shape, store, handle, cellId),
             );
+        },
+        cellsOf(filter: AnyCellType | Shape) {
+            return this.cells().filter((cell) => cellMatchesFilter(cell, filter));
+        },
+        supports(filter) {
+            if (isCellType(filter)) {
+                return shapeSupportsCell(shape, filter);
+            }
+            return shapeSupportsShape(shape, filter);
         },
         update(patch) {
             if (patch.title !== undefined) {

--- a/packages/documents/src/shape.ts
+++ b/packages/documents/src/shape.ts
@@ -55,6 +55,7 @@ export function defineShape<const S extends Shape>(shape: S): S {
 export type RichTextType = typeof RichText;
 export type ObjectTypesOf<S extends Shape> = NonNullable<S["objects"]>[number];
 export type MorphismTypesOf<S extends Shape> = NonNullable<S["morphisms"]>[number];
+export type AnyCellType = RichTextType | ObjectType | MorphismType;
 export type CellTypeOf<S extends Shape> = RichTextType | ObjectTypesOf<S> | MorphismTypesOf<S>;
 
 type MatchingObjectTypesOf<O, EndpointObType> = O extends ObjectType


### PR DESCRIPTION
The current type wizardry is too clever for me to follow or replicate, consequently there are no informative type constraints on these methods. For now our priority is using this from JavaScript, so we can revisit the type system later on to make narrowing and other TypeScript-only, advanced features possible