### PR TITLE
OBEE-28 Replace `createBinderWithStore` with overload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Typescript documents package tests
         run: |
-          pnpm --filter catcolab-documents exec vitest run test/creating-and-editing.test.ts test/definitions.test.ts
+          pnpm --filter catcolab-documents exec vitest run test/creating-and-editing.test.ts test/definitions.test.ts test/binder.test-d.ts
 
       - name: Typescript logic package tests
         run: |

--- a/packages/documents/src/binder.ts
+++ b/packages/documents/src/binder.ts
@@ -1,30 +1,40 @@
 import { Model } from "catcolab-document-methods";
+import type { Document } from "catcolab-document-types";
 import type { DocumentStore } from "./document-store";
 import { createInMemoryStore } from "./document-store/in-memory";
 import type { ModelDocument } from "./model/document";
 import { modelNotebookFromStore, type Notebook } from "./model/notebook";
 import type { Shape } from "./shape";
 
-export interface Binder {
+export interface Binder<Handle> {
+    /** The document store backing this binder. */
+    readonly store: DocumentStore<Handle>;
+
     createNotebook<S extends Shape & { readonly theory: string }>(
         shape: S,
         options: { title: string },
     ): Promise<Notebook<S, ModelDocument>>;
 }
 
-/* The following two functions cannot be refined to overloads of a single
-   function of the form `function foo<T>(opt?: T)`. The reason being is that
-   this allows callers the nonsensical pattern foo<S>() for some concrete S and
-   the implementation will have to ignore S. In general this pattern would be
-   even worse, as the compiler would set T to unknown in `foo()`.
+/* Overloads rather than a single signature `createBinder<Handle>(store?:
+   DocumentStore<Handle>)`: a single optional-parameter signature would allow
+   the nonsensical pattern `createBinder<S>()` for some concrete S, which the
+   implementation would have to ignore. With overloads, an explicit type
+   argument requires the store argument, the zero-argument form takes no type
+   arguments, and the zero-argument form's return type is specific to the
+   in-memory store's handle type.
  */
-
-export function createBinder(): Binder {
-    return createBinderWithStore(createInMemoryStore());
+export function createBinder(): Binder<Document>;
+export function createBinder<Handle>(store: DocumentStore<Handle>): Binder<Handle>;
+export function createBinder<Handle>(
+    store?: DocumentStore<Handle>,
+): Binder<Document> | Binder<Handle> {
+    return store === undefined ? binderFromStore(createInMemoryStore()) : binderFromStore(store);
 }
 
-export function createBinderWithStore<Handle>(store: DocumentStore<Handle>): Binder {
+function binderFromStore<Handle>(store: DocumentStore<Handle>): Binder<Handle> {
     return {
+        store,
         async createNotebook<S extends Shape & { readonly theory: string }>(
             shape: S,
             options: { title: string },

--- a/packages/documents/src/index.ts
+++ b/packages/documents/src/index.ts
@@ -1,4 +1,4 @@
-export { createBinder, createBinderWithStore } from "./binder";
+export { createBinder } from "./binder";
 export { CellKind } from "./model/cell";
 export type { Binder } from "./binder";
 export type { DocumentStore, DocumentRef } from "./document-store";

--- a/packages/documents/test/binder.test-d.ts
+++ b/packages/documents/test/binder.test-d.ts
@@ -1,0 +1,23 @@
+import { describe, expectTypeOf, test } from "vitest";
+
+import type { Document } from "catcolab-document-types";
+// Type-level tests for the binder API. These cases are checked by the
+// compiler only (vitest typecheck mode); nothing here executes.
+import { createBinder, type Binder } from "catcolab-documents";
+
+describe("binder type errors", () => {
+    test("createBinder does not accept a type argument without a store", () => {
+        interface InvalidHandle {
+            bogus: true;
+        }
+
+        // @ts-expect-error An explicit handle type requires passing a store:
+        // `createBinder<Handle>(store)`. The zero-argument overload takes no
+        // type arguments.
+        createBinder<InvalidHandle>();
+    });
+
+    test("createBinder without arguments is typed with the in-memory handle", () => {
+        expectTypeOf(createBinder()).toEqualTypeOf<Binder<Document>>();
+    });
+});

--- a/packages/documents/tsconfig.test.json
+++ b/packages/documents/tsconfig.test.json
@@ -12,6 +12,7 @@
         "vitest.db-dump.config.ts",
         "test/creating-and-editing.test.ts",
         "test/creating-and-editing.test-d.ts",
-        "test/definitions.test.ts"
+        "test/definitions.test.ts",
+        "test/binder.test-d.ts"
     ]
 }


### PR DESCRIPTION
Referring to the inability to overload nicely in #1384, I randomly realized it should be possible after all.