### PR TITLE
OBEE-35: getCoreTheory, supportsInstances, validate model notebooks, deletion, pipe elab errors

### DIFF
--- a/packages/catlog-wasm/src/latex.rs
+++ b/packages/catlog-wasm/src/latex.rs
@@ -222,6 +222,7 @@ mod tests {
         let model = DblModel {
             model: inner.into(),
             ty: None,
+            elaboration_errors: Vec::new(),
             ob_namespace,
             mor_namespace: Namespace::new_for_uuid(),
         };

--- a/packages/catlog-wasm/src/model.rs
+++ b/packages/catlog-wasm/src/model.rs
@@ -323,6 +323,10 @@ pub struct DblModel {
     #[wasm_bindgen(skip)]
     pub ty: Option<(tt::stx::TyS, tt::val::TyV)>,
 
+    /// Errors found while elaborating the model's notebook.
+    #[wasm_bindgen(skip)]
+    pub elaboration_errors: Vec<InvalidDblModel>,
+
     /// The namespace for the objects.
     #[wasm_bindgen(skip)]
     pub ob_namespace: Namespace,
@@ -343,6 +347,7 @@ impl DblModel {
         Self {
             model,
             ty: None,
+            elaboration_errors: Vec::new(),
             ob_namespace: Namespace::new_for_uuid(),
             mor_namespace: Namespace::new_for_uuid(),
         }
@@ -353,6 +358,7 @@ impl DblModel {
         Self {
             model,
             ty: self.ty.clone(),
+            elaboration_errors: self.elaboration_errors.clone(),
             ob_namespace: self.ob_namespace.clone(),
             mor_namespace: self.mor_namespace.clone(),
         }
@@ -656,7 +662,16 @@ impl DblModel {
         let result = all_the_same!(match &self.model {
             DblModelBox::[Discrete, DiscreteTab, ModalUnital, ModalNonUnital](model) => model.validate()
         });
-        ModelValidationResult(result.map_err(|errs| errs.into()).into())
+        let mut errors = self.elaboration_errors.clone();
+        if let Err(model_errors) = result {
+            errors.extend(model_errors);
+        }
+        let result = if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        };
+        ModelValidationResult(result.into())
     }
 
     /// Extracts a composition pattern (UWD) from the model.
@@ -748,11 +763,13 @@ pub fn elaborate_model(
         let ref_id = ustr(&ref_id);
         let mut elab = ElaboratorNext::new(theory.clone(), &instantiated.toplevel, ref_id);
         let (ty_s, ty_v) = elab.notebook(notebook.0.formal_content());
+        let elaboration_errors = elab.errors().to_vec();
         let (model, namespace) =
             tt::modelgen::Model::from_ty(&instantiated.toplevel, &theory.definition, &ty_v);
         Ok(DblModel {
             model: model.into(),
             ty: Some((ty_s, ty_v)),
+            elaboration_errors,
             ob_namespace: namespace.clone(),
             mor_namespace: namespace.clone(),
         })

--- a/packages/documents/src/model/cell.ts
+++ b/packages/documents/src/model/cell.ts
@@ -1,6 +1,7 @@
 import { Nb } from "catcolab-document-methods";
 import type { Ob } from "catcolab-document-types";
 import type { DocumentStore } from "../document-store";
+import { deleteNotebookCell } from "../notebook-document";
 import { getRichTextCell, type RichTextCell } from "../rich-text";
 import { findMorphismType, findObjectType } from "../shape";
 import type {
@@ -12,7 +13,7 @@ import type {
     ObjectTypesOf,
     Shape,
 } from "../shape";
-import { getModelJudgment, type ModelDocument } from "./document";
+import { tryGetModelJudgment, type ModelDocument } from "./document";
 
 /** Runtime names for the discriminants on notebook cell handles. */
 export const CellKind = {
@@ -25,18 +26,19 @@ export interface ObjectCell<O extends ObjectType> {
     readonly kind: "object";
     readonly id: string;
     readonly type: O;
-    readonly label: string;
+    readonly label: string | undefined;
 
     update(patch: Partial<{ label: string | null }>): void;
+    delete(): void;
 }
 
 export interface MorphismCell<S extends Shape, M extends MorphismType> {
     readonly kind: "morphism";
     readonly id: string;
     readonly type: M;
-    readonly label: string;
-    readonly from: ObjectCell<DomainObjectTypesOf<S, M>> | null;
-    readonly to: ObjectCell<CodomainObjectTypesOf<S, M>> | null;
+    readonly label: string | undefined;
+    readonly from: ObjectCell<DomainObjectTypesOf<S, M>> | null | undefined;
+    readonly to: ObjectCell<CodomainObjectTypesOf<S, M>> | null | undefined;
 
     update(
         patch: Partial<{
@@ -45,6 +47,7 @@ export interface MorphismCell<S extends Shape, M extends MorphismType> {
             to: ObjectCell<CodomainObjectTypesOf<S, M>> | null;
         }>,
     ): void;
+    delete(): void;
 }
 
 export type CellOf<S extends Shape> =
@@ -57,6 +60,7 @@ export function getObjectCell<Handle, O extends ObjectType>(
     handle: Handle,
     cellId: string,
     type: O,
+    onFormalChange: () => void,
 ): ObjectCell<O> {
     return {
         kind: "object",
@@ -64,7 +68,10 @@ export function getObjectCell<Handle, O extends ObjectType>(
         type,
         get label() {
             const document = store.getDocumentView(handle) as Readonly<ModelDocument>;
-            const judgment = getModelJudgment(document, cellId);
+            const judgment = tryGetModelJudgment(document, cellId);
+            if (!judgment) {
+                return undefined;
+            }
             if (judgment.tag !== "object") {
                 throw new Error(`Cell ${cellId} is not an object.`);
             }
@@ -74,13 +81,31 @@ export function getObjectCell<Handle, O extends ObjectType>(
             if (patch.label === undefined) {
                 return;
             }
-            store.changeDocument(handle, (document) => {
-                const judgment = getModelJudgment(document as ModelDocument, cellId);
+            const document = store.getDocumentView(handle) as Readonly<ModelDocument>;
+            if (!tryGetModelJudgment(document, cellId)) {
+                return;
+            }
+
+            let updated = false;
+            store.changeDocument(handle, (storedDocument) => {
+                const judgment = tryGetModelJudgment(storedDocument as ModelDocument, cellId);
+                if (!judgment) {
+                    return;
+                }
                 if (judgment.tag !== "object") {
                     throw new Error(`Cell ${cellId} is not an object.`);
                 }
                 judgment.name = patch.label ?? "";
+                updated = true;
             });
+            if (updated) {
+                onFormalChange();
+            }
+        },
+        delete() {
+            if (deleteNotebookCell(store, handle, cellId)) {
+                onFormalChange();
+            }
         },
     };
 }
@@ -90,6 +115,7 @@ function objectCellFromOb<Handle, S extends Shape>(
     store: DocumentStore<Handle>,
     handle: Handle,
     endpoint: Ob | null,
+    onFormalChange: () => void,
 ): ObjectCell<ObjectTypesOf<S>> | null {
     const document = store.getDocumentView(handle) as Readonly<ModelDocument>;
     if (endpoint?.tag !== "Basic") {
@@ -103,7 +129,7 @@ function objectCellFromOb<Handle, S extends Shape>(
         }
         if (cell.content.id === endpoint.content) {
             const type = findObjectType(shape, cell.content.obType);
-            return type ? getObjectCell(store, handle, cellId, type) : null;
+            return type ? getObjectCell(store, handle, cellId, type, onFormalChange) : null;
         }
     }
 
@@ -117,7 +143,10 @@ export function obFromObjectCell(
     if (!endpoint) {
         return null;
     }
-    const judgment = getModelJudgment(document, endpoint.id);
+    const judgment = tryGetModelJudgment(document, endpoint.id);
+    if (!judgment) {
+        throw new Error(`Cell ${endpoint.id} does not exist.`);
+    }
     if (judgment.tag !== "object") {
         throw new Error(`Cell ${endpoint.id} is not an object.`);
     }
@@ -130,6 +159,7 @@ export function getMorphismCell<Handle, S extends Shape, M extends MorphismTypes
     handle: Handle,
     cellId: string,
     type: M,
+    onFormalChange: () => void,
 ): MorphismCell<S, M> {
     return {
         kind: "morphism",
@@ -137,7 +167,10 @@ export function getMorphismCell<Handle, S extends Shape, M extends MorphismTypes
         type,
         get label() {
             const document = store.getDocumentView(handle) as Readonly<ModelDocument>;
-            const judgment = getModelJudgment(document, cellId);
+            const judgment = tryGetModelJudgment(document, cellId);
+            if (!judgment) {
+                return undefined;
+            }
             if (judgment.tag !== "morphism") {
                 throw new Error(`Cell ${cellId} is not a morphism.`);
             }
@@ -145,28 +178,51 @@ export function getMorphismCell<Handle, S extends Shape, M extends MorphismTypes
         },
         get from() {
             const document = store.getDocumentView(handle) as Readonly<ModelDocument>;
-            const judgment = getModelJudgment(document, cellId);
+            const judgment = tryGetModelJudgment(document, cellId);
+            if (!judgment) {
+                return undefined;
+            }
             if (judgment.tag !== "morphism") {
                 throw new Error(`Cell ${cellId} is not a morphism.`);
             }
-            return objectCellFromOb(shape, store, handle, judgment.dom) as ObjectCell<
-                DomainObjectTypesOf<S, M>
-            > | null;
+            return objectCellFromOb(
+                shape,
+                store,
+                handle,
+                judgment.dom,
+                onFormalChange,
+            ) as ObjectCell<DomainObjectTypesOf<S, M>> | null;
         },
         get to() {
             const document = store.getDocumentView(handle) as Readonly<ModelDocument>;
-            const judgment = getModelJudgment(document, cellId);
+            const judgment = tryGetModelJudgment(document, cellId);
+            if (!judgment) {
+                return undefined;
+            }
             if (judgment.tag !== "morphism") {
                 throw new Error(`Cell ${cellId} is not a morphism.`);
             }
-            return objectCellFromOb(shape, store, handle, judgment.cod) as ObjectCell<
-                CodomainObjectTypesOf<S, M>
-            > | null;
+            return objectCellFromOb(
+                shape,
+                store,
+                handle,
+                judgment.cod,
+                onFormalChange,
+            ) as ObjectCell<CodomainObjectTypesOf<S, M>> | null;
         },
         update(patch) {
-            store.changeDocument(handle, (document) => {
-                const modelDocument = document as ModelDocument;
-                const judgment = getModelJudgment(modelDocument, cellId);
+            const document = store.getDocumentView(handle) as Readonly<ModelDocument>;
+            if (!tryGetModelJudgment(document, cellId)) {
+                return;
+            }
+
+            let updated = false;
+            store.changeDocument(handle, (storedDocument) => {
+                const modelDocument = storedDocument as ModelDocument;
+                const judgment = tryGetModelJudgment(modelDocument, cellId);
+                if (!judgment) {
+                    return;
+                }
                 if (judgment.tag !== "morphism") {
                     throw new Error(`Cell ${cellId} is not a morphism.`);
                 }
@@ -187,7 +243,16 @@ export function getMorphismCell<Handle, S extends Shape, M extends MorphismTypes
                 if (cod !== undefined) {
                     judgment.cod = cod;
                 }
+                updated = true;
             });
+            if (updated) {
+                onFormalChange();
+            }
+        },
+        delete() {
+            if (deleteNotebookCell(store, handle, cellId)) {
+                onFormalChange();
+            }
         },
     };
 }
@@ -197,6 +262,7 @@ export function getModelCell<Handle, S extends Shape>(
     store: DocumentStore<Handle>,
     handle: Handle,
     cellId: string,
+    onFormalChange: () => void,
 ): CellOf<S> {
     const document = store.getDocumentView(handle) as Readonly<ModelDocument>;
     const cell = Nb.getCellById(document.notebook, cellId);
@@ -210,14 +276,14 @@ export function getModelCell<Handle, S extends Shape>(
             if (!type) {
                 throw new Error(`Object cell ${cellId} is not supported by the notebook shape.`);
             }
-            return getObjectCell(store, handle, cellId, type);
+            return getObjectCell(store, handle, cellId, type, onFormalChange);
         }
         case "morphism": {
             const type = findMorphismType(shape, cell.content.morType);
             if (!type) {
                 throw new Error(`Morphism cell ${cellId} is not supported by the notebook shape.`);
             }
-            return getMorphismCell(shape, store, handle, cellId, type);
+            return getMorphismCell(shape, store, handle, cellId, type, onFormalChange);
         }
         default:
             throw new Error(`Formal cell ${cellId} is not supported yet.`);

--- a/packages/documents/src/model/cell.ts
+++ b/packages/documents/src/model/cell.ts
@@ -60,7 +60,6 @@ export function getObjectCell<Handle, O extends ObjectType>(
     handle: Handle,
     cellId: string,
     type: O,
-    onFormalChange: () => void,
 ): ObjectCell<O> {
     return {
         kind: "object",
@@ -86,7 +85,6 @@ export function getObjectCell<Handle, O extends ObjectType>(
                 return;
             }
 
-            let updated = false;
             store.changeDocument(handle, (storedDocument) => {
                 const judgment = tryGetModelJudgment(storedDocument as ModelDocument, cellId);
                 if (!judgment) {
@@ -96,16 +94,10 @@ export function getObjectCell<Handle, O extends ObjectType>(
                     throw new Error(`Cell ${cellId} is not an object.`);
                 }
                 judgment.name = patch.label ?? "";
-                updated = true;
             });
-            if (updated) {
-                onFormalChange();
-            }
         },
         delete() {
-            if (deleteNotebookCell(store, handle, cellId)) {
-                onFormalChange();
-            }
+            deleteNotebookCell(store, handle, cellId);
         },
     };
 }
@@ -115,7 +107,6 @@ function objectCellFromOb<Handle, S extends Shape>(
     store: DocumentStore<Handle>,
     handle: Handle,
     endpoint: Ob | null,
-    onFormalChange: () => void,
 ): ObjectCell<ObjectTypesOf<S>> | null {
     const document = store.getDocumentView(handle) as Readonly<ModelDocument>;
     if (endpoint?.tag !== "Basic") {
@@ -129,7 +120,7 @@ function objectCellFromOb<Handle, S extends Shape>(
         }
         if (cell.content.id === endpoint.content) {
             const type = findObjectType(shape, cell.content.obType);
-            return type ? getObjectCell(store, handle, cellId, type, onFormalChange) : null;
+            return type ? getObjectCell(store, handle, cellId, type) : null;
         }
     }
 
@@ -159,7 +150,6 @@ export function getMorphismCell<Handle, S extends Shape, M extends MorphismTypes
     handle: Handle,
     cellId: string,
     type: M,
-    onFormalChange: () => void,
 ): MorphismCell<S, M> {
     return {
         kind: "morphism",
@@ -185,13 +175,9 @@ export function getMorphismCell<Handle, S extends Shape, M extends MorphismTypes
             if (judgment.tag !== "morphism") {
                 throw new Error(`Cell ${cellId} is not a morphism.`);
             }
-            return objectCellFromOb(
-                shape,
-                store,
-                handle,
-                judgment.dom,
-                onFormalChange,
-            ) as ObjectCell<DomainObjectTypesOf<S, M>> | null;
+            return objectCellFromOb(shape, store, handle, judgment.dom) as ObjectCell<
+                DomainObjectTypesOf<S, M>
+            > | null;
         },
         get to() {
             const document = store.getDocumentView(handle) as Readonly<ModelDocument>;
@@ -202,13 +188,9 @@ export function getMorphismCell<Handle, S extends Shape, M extends MorphismTypes
             if (judgment.tag !== "morphism") {
                 throw new Error(`Cell ${cellId} is not a morphism.`);
             }
-            return objectCellFromOb(
-                shape,
-                store,
-                handle,
-                judgment.cod,
-                onFormalChange,
-            ) as ObjectCell<CodomainObjectTypesOf<S, M>> | null;
+            return objectCellFromOb(shape, store, handle, judgment.cod) as ObjectCell<
+                CodomainObjectTypesOf<S, M>
+            > | null;
         },
         update(patch) {
             const document = store.getDocumentView(handle) as Readonly<ModelDocument>;
@@ -216,7 +198,6 @@ export function getMorphismCell<Handle, S extends Shape, M extends MorphismTypes
                 return;
             }
 
-            let updated = false;
             store.changeDocument(handle, (storedDocument) => {
                 const modelDocument = storedDocument as ModelDocument;
                 const judgment = tryGetModelJudgment(modelDocument, cellId);
@@ -243,16 +224,10 @@ export function getMorphismCell<Handle, S extends Shape, M extends MorphismTypes
                 if (cod !== undefined) {
                     judgment.cod = cod;
                 }
-                updated = true;
             });
-            if (updated) {
-                onFormalChange();
-            }
         },
         delete() {
-            if (deleteNotebookCell(store, handle, cellId)) {
-                onFormalChange();
-            }
+            deleteNotebookCell(store, handle, cellId);
         },
     };
 }
@@ -262,7 +237,6 @@ export function getModelCell<Handle, S extends Shape>(
     store: DocumentStore<Handle>,
     handle: Handle,
     cellId: string,
-    onFormalChange: () => void,
 ): CellOf<S> {
     const document = store.getDocumentView(handle) as Readonly<ModelDocument>;
     const cell = Nb.getCellById(document.notebook, cellId);
@@ -276,14 +250,14 @@ export function getModelCell<Handle, S extends Shape>(
             if (!type) {
                 throw new Error(`Object cell ${cellId} is not supported by the notebook shape.`);
             }
-            return getObjectCell(store, handle, cellId, type, onFormalChange);
+            return getObjectCell(store, handle, cellId, type);
         }
         case "morphism": {
             const type = findMorphismType(shape, cell.content.morType);
             if (!type) {
                 throw new Error(`Morphism cell ${cellId} is not supported by the notebook shape.`);
             }
-            return getMorphismCell(shape, store, handle, cellId, type, onFormalChange);
+            return getMorphismCell(shape, store, handle, cellId, type);
         }
         default:
             throw new Error(`Formal cell ${cellId} is not supported yet.`);

--- a/packages/documents/src/model/document.ts
+++ b/packages/documents/src/model/document.ts
@@ -1,10 +1,16 @@
-import { Nb, type ModelDocument } from "catcolab-document-methods";
+import type { ModelDocument } from "catcolab-document-methods";
 import type { ModelJudgment } from "catcolab-document-types";
 
 export type { ModelDocument } from "catcolab-document-methods";
 
-export function getModelJudgment(document: Readonly<ModelDocument>, cellId: string): ModelJudgment {
-    const cell = Nb.getCellById(document.notebook, cellId);
+export function tryGetModelJudgment(
+    document: Readonly<ModelDocument>,
+    cellId: string,
+): ModelJudgment | undefined {
+    const cell = document.notebook.cellContents[cellId];
+    if (!cell) {
+        return undefined;
+    }
     if (cell.tag !== "formal") {
         throw new Error(`Cell ${cellId} is not formal.`);
     }

--- a/packages/documents/src/model/notebook.ts
+++ b/packages/documents/src/model/notebook.ts
@@ -1,7 +1,9 @@
 import { Model, Nb } from "catcolab-document-methods";
 import type { ModelJudgment } from "catcolab-document-types";
+import type { DblModel, DblTheory } from "catlog-wasm";
 import type { DocumentStore } from "../document-store";
 import type { NotebookDocument } from "../notebook-document";
+import type { Result } from "../result";
 import { getRichTextCell, type RichTextCell } from "../rich-text";
 import type {
     AnyCellType,
@@ -26,6 +28,7 @@ import {
 } from "./cell";
 import type { ModelDocument } from "./document";
 import { morphismTypesEqual, objectTypesEqual } from "./equality";
+import { validateModelDocument } from "./validation";
 
 /**
  * The value given to [`Notebook.add`].
@@ -171,6 +174,8 @@ export interface Notebook<S extends Shape, D extends NotebookDocument = Notebook
     update(patch: Partial<{ title: string }>): void;
     dump(): D;
     onChange(callback: () => void): () => void;
+    validate(): Promise<Result<DblModel>>;
+    onValidate(callback: (result: Result<DblModel>) => void): () => void;
 }
 
 export function modelNotebookFromStore<Handle, S extends Shape>(
@@ -178,12 +183,84 @@ export function modelNotebookFromStore<Handle, S extends Shape>(
     store: DocumentStore<Handle>,
     handle: Handle,
 ): Notebook<S, ModelDocument> {
+    const validationCallbacks = new Set<(result: Result<DblModel>) => void>();
+    let cachedValidation: Result<DblModel> | undefined;
+    let coreTheory: Promise<DblTheory> | undefined;
+    let validationGeneration = 0;
+
+    function validationResultsEqual(left: Result<DblModel>, right: Result<DblModel>): boolean {
+        if (left.tag !== right.tag) {
+            return false;
+        }
+        if (left.tag === "Ok") {
+            return true;
+        }
+        return (
+            right.tag === "Err" && JSON.stringify(left.content) === JSON.stringify(right.content)
+        );
+    }
+
+    async function didValidityChange(): Promise<Result<DblModel>> {
+        const generation = ++validationGeneration;
+        let result: Result<DblModel>;
+        if (!shape.getCoreTheory) {
+            let shapeName = "unnamed";
+            if (shape.theory) {
+                shapeName = shape.theory;
+            }
+            result = {
+                tag: "Err",
+                content: [{ message: `Shape \`${shapeName}\` has no core theory` }],
+            };
+        } else {
+            try {
+                if (!coreTheory) {
+                    coreTheory = shape.getCoreTheory();
+                }
+                const theory = await coreTheory;
+                const document = store.copyValue(
+                    handle,
+                    store.getDocumentView(handle),
+                ) as ModelDocument;
+                result = await validateModelDocument(
+                    document,
+                    theory,
+                    store.getDocumentRef(handle).id,
+                );
+            } catch (error) {
+                result = {
+                    tag: "Err",
+                    content: [{ message: `Failed to load core theory: ${String(error)}` }],
+                };
+            }
+        }
+
+        if (generation === validationGeneration) {
+            const changed =
+                cachedValidation === undefined || !validationResultsEqual(cachedValidation, result);
+            cachedValidation = result;
+            if (changed) {
+                for (const callback of Array.from(validationCallbacks)) {
+                    callback(result);
+                }
+            }
+        }
+        return result;
+    }
+
+    function onFormalChange(): void {
+        void didValidityChange();
+    }
+
     function appendCell(
         cell: ReturnType<typeof Nb.newRichTextCell> | Nb.FormalCell<ModelJudgment>,
-    ) {
+    ): void {
         store.changeDocument(handle, (document) => {
             Nb.appendCell((document as ModelDocument).notebook, cell);
         });
+        if (cell.tag === "formal") {
+            onFormalChange();
+        }
     }
 
     return {
@@ -213,6 +290,7 @@ export function modelNotebookFromStore<Handle, S extends Shape>(
                     handle,
                     cell.id,
                     type as ObjectTypesOf<S>,
+                    onFormalChange,
                 ) as AddedCellOf<S, T>;
             }
 
@@ -230,12 +308,13 @@ export function modelNotebookFromStore<Handle, S extends Shape>(
                 handle,
                 cell.id,
                 type as MorphismTypesOf<S>,
+                onFormalChange,
             ) as AddedCellOf<S, T>;
         },
         cells() {
             const document = store.getDocumentView(handle) as Readonly<ModelDocument>;
             return document.notebook.cellOrder.map((cellId) =>
-                getModelCell(shape, store, handle, cellId),
+                getModelCell(shape, store, handle, cellId, onFormalChange),
             );
         },
         cellsOf(filter: AnyCellType | Shape) {
@@ -260,6 +339,25 @@ export function modelNotebookFromStore<Handle, S extends Shape>(
         },
         onChange(callback) {
             return store.subscribe(handle, callback);
+        },
+        validate() {
+            return didValidityChange();
+        },
+        onValidate(callback) {
+            validationCallbacks.add(callback);
+            const current = cachedValidation;
+            if (current) {
+                queueMicrotask(() => {
+                    if (validationCallbacks.has(callback)) {
+                        callback(current);
+                    }
+                });
+            } else {
+                void didValidityChange();
+            }
+            return () => {
+                validationCallbacks.delete(callback);
+            };
         },
     };
 }

--- a/packages/documents/src/model/notebook.ts
+++ b/packages/documents/src/model/notebook.ts
@@ -185,18 +185,6 @@ export function modelNotebookFromStore<Handle, S extends Shape>(
 ): Notebook<S, ModelDocument> {
     let coreTheory: Promise<DblTheory> | undefined;
 
-    function validationResultsEqual(left: Result<DblModel>, right: Result<DblModel>): boolean {
-        if (left.tag !== right.tag) {
-            return false;
-        }
-        if (left.tag === "Ok") {
-            return true;
-        }
-        return (
-            right.tag === "Err" && JSON.stringify(left.content) === JSON.stringify(right.content)
-        );
-    }
-
     async function validateCurrentDocument(): Promise<Result<DblModel>> {
         let result: Result<DblModel>;
         if (!shape.getCoreTheory) {
@@ -322,17 +310,12 @@ export function modelNotebookFromStore<Handle, S extends Shape>(
         },
         onValidate(callback) {
             let active = true;
-            let previous: Result<DblModel> | undefined;
 
             async function validateAndNotify(): Promise<void> {
                 const result = await validateCurrentDocument();
                 if (!active) {
                     return;
                 }
-                if (previous && validationResultsEqual(previous, result)) {
-                    return;
-                }
-                previous = result;
                 callback(result);
             }
 

--- a/packages/documents/src/model/notebook.ts
+++ b/packages/documents/src/model/notebook.ts
@@ -183,10 +183,7 @@ export function modelNotebookFromStore<Handle, S extends Shape>(
     store: DocumentStore<Handle>,
     handle: Handle,
 ): Notebook<S, ModelDocument> {
-    const validationCallbacks = new Set<(result: Result<DblModel>) => void>();
-    let cachedValidation: Result<DblModel> | undefined;
     let coreTheory: Promise<DblTheory> | undefined;
-    let validationGeneration = 0;
 
     function validationResultsEqual(left: Result<DblModel>, right: Result<DblModel>): boolean {
         if (left.tag !== right.tag) {
@@ -200,8 +197,7 @@ export function modelNotebookFromStore<Handle, S extends Shape>(
         );
     }
 
-    async function didValidityChange(): Promise<Result<DblModel>> {
-        const generation = ++validationGeneration;
+    async function validateCurrentDocument(): Promise<Result<DblModel>> {
         let result: Result<DblModel>;
         if (!shape.getCoreTheory) {
             let shapeName = "unnamed";
@@ -235,21 +231,7 @@ export function modelNotebookFromStore<Handle, S extends Shape>(
             }
         }
 
-        if (generation === validationGeneration) {
-            const changed =
-                cachedValidation === undefined || !validationResultsEqual(cachedValidation, result);
-            cachedValidation = result;
-            if (changed) {
-                for (const callback of Array.from(validationCallbacks)) {
-                    callback(result);
-                }
-            }
-        }
         return result;
-    }
-
-    function onFormalChange(): void {
-        void didValidityChange();
     }
 
     function appendCell(
@@ -258,9 +240,6 @@ export function modelNotebookFromStore<Handle, S extends Shape>(
         store.changeDocument(handle, (document) => {
             Nb.appendCell((document as ModelDocument).notebook, cell);
         });
-        if (cell.tag === "formal") {
-            onFormalChange();
-        }
     }
 
     return {
@@ -290,7 +269,6 @@ export function modelNotebookFromStore<Handle, S extends Shape>(
                     handle,
                     cell.id,
                     type as ObjectTypesOf<S>,
-                    onFormalChange,
                 ) as AddedCellOf<S, T>;
             }
 
@@ -308,13 +286,12 @@ export function modelNotebookFromStore<Handle, S extends Shape>(
                 handle,
                 cell.id,
                 type as MorphismTypesOf<S>,
-                onFormalChange,
             ) as AddedCellOf<S, T>;
         },
         cells() {
             const document = store.getDocumentView(handle) as Readonly<ModelDocument>;
             return document.notebook.cellOrder.map((cellId) =>
-                getModelCell(shape, store, handle, cellId, onFormalChange),
+                getModelCell(shape, store, handle, cellId),
             );
         },
         cellsOf(filter: AnyCellType | Shape) {
@@ -341,22 +318,32 @@ export function modelNotebookFromStore<Handle, S extends Shape>(
             return store.subscribe(handle, callback);
         },
         validate() {
-            return didValidityChange();
+            return validateCurrentDocument();
         },
         onValidate(callback) {
-            validationCallbacks.add(callback);
-            const current = cachedValidation;
-            if (current) {
-                queueMicrotask(() => {
-                    if (validationCallbacks.has(callback)) {
-                        callback(current);
-                    }
-                });
-            } else {
-                void didValidityChange();
+            let active = true;
+            let previous: Result<DblModel> | undefined;
+
+            async function validateAndNotify(): Promise<void> {
+                const result = await validateCurrentDocument();
+                if (!active) {
+                    return;
+                }
+                if (previous && validationResultsEqual(previous, result)) {
+                    return;
+                }
+                previous = result;
+                callback(result);
             }
+
+            const unsubscribe = store.subscribe(handle, () => {
+                void validateAndNotify();
+            });
+            void validateAndNotify();
+
             return () => {
-                validationCallbacks.delete(callback);
+                active = false;
+                unsubscribe();
             };
         },
     };

--- a/packages/documents/src/model/validation.ts
+++ b/packages/documents/src/model/validation.ts
@@ -1,0 +1,119 @@
+import type { FormalCell, ModelDocument } from "catcolab-document-methods";
+import type { ModelJudgment, Notebook } from "catcolab-document-types";
+import type { DblModel, DblTheory, InvalidDblModel } from "catlog-wasm";
+import type { Issue, Result } from "../result";
+
+function formalCellForGenerator(
+    notebook: Notebook<ModelJudgment>,
+    generatorId: string,
+): FormalCell<ModelJudgment> | undefined {
+    for (const cellId of notebook.cellOrder) {
+        const cell = notebook.cellContents[cellId];
+        if (cell?.tag === "formal" && "id" in cell.content && cell.content.id === generatorId) {
+            return cell;
+        }
+    }
+    return undefined;
+}
+
+function generatorName(notebook: Notebook<ModelJudgment>, generatorId: string): string {
+    const cell = formalCellForGenerator(notebook, generatorId);
+    if (!cell || !cell.content.name) {
+        return generatorId;
+    }
+    return cell.content.name;
+}
+
+function generatorPath(
+    notebook: Notebook<ModelJudgment>,
+    generatorId: string,
+    property?: string,
+): PropertyKey[] | undefined {
+    const cell = formalCellForGenerator(notebook, generatorId);
+    if (!cell) {
+        return undefined;
+    }
+    const path: PropertyKey[] = ["notebook", "cellContents", cell.id, "content"];
+    if (property) {
+        path.push(property);
+    }
+    return path;
+}
+
+function invalidModelIssue(notebook: Notebook<ModelJudgment>, error: InvalidDblModel): Issue {
+    switch (error.tag) {
+        case "Dom":
+            return {
+                message: `Morphism \`${generatorName(notebook, error.content)}\` has no domain`,
+                path: generatorPath(notebook, error.content, "dom"),
+            };
+        case "Cod":
+            return {
+                message: `Morphism \`${generatorName(notebook, error.content)}\` has no codomain`,
+                path: generatorPath(notebook, error.content, "cod"),
+            };
+        case "ObType":
+            return {
+                message: `Object \`${generatorName(notebook, error.content)}\` has an invalid type`,
+                path: generatorPath(notebook, error.content, "obType"),
+            };
+        case "MorType":
+            return {
+                message: `Morphism \`${generatorName(notebook, error.content)}\` has an invalid type`,
+                path: generatorPath(notebook, error.content, "morType"),
+            };
+        case "DomType":
+            return {
+                message: `Morphism \`${generatorName(notebook, error.content)}\` has a mistyped domain`,
+                path: generatorPath(notebook, error.content, "dom"),
+            };
+        case "CodType":
+            return {
+                message: `Morphism \`${generatorName(notebook, error.content)}\` has a mistyped codomain`,
+                path: generatorPath(notebook, error.content, "cod"),
+            };
+        case "Eqn":
+            return {
+                message: "An equation in the model is invalid",
+            };
+        case "UnsupportedFeature":
+            return {
+                message: `The model uses an unsupported feature: ${error.content.tag}`,
+            };
+        case "InvalidLink":
+            return {
+                message: `Instantiation \`${generatorName(notebook, error.content)}\` is invalid`,
+                path: generatorPath(notebook, error.content),
+            };
+    }
+}
+
+/** Elaborate and validate a model document against its core theory. */
+export async function validateModelDocument(
+    document: Readonly<ModelDocument>,
+    theory: DblTheory,
+    refId: string,
+): Promise<Result<DblModel>> {
+    const { DblModelMap, elaborateModel } = await import("catlog-wasm");
+    const instantiatedModels = new DblModelMap();
+    let model: DblModel;
+    try {
+        model = elaborateModel(document.notebook, instantiatedModels, theory, refId);
+    } catch (error) {
+        return {
+            tag: "Err",
+            content: [{ message: `Failed to elaborate model: ${String(error)}` }],
+        };
+    } finally {
+        instantiatedModels.free();
+    }
+
+    const validation = model.validate();
+    if (validation.tag === "Err") {
+        return {
+            tag: "Err",
+            content: validation.content.map((error) => invalidModelIssue(document.notebook, error)),
+        };
+    }
+    return { tag: "Ok", content: model };
+}

--- a/packages/documents/src/notebook-document.ts
+++ b/packages/documents/src/notebook-document.ts
@@ -1,4 +1,31 @@
 import type { Document } from "catcolab-document-types";
+import type { DocumentStore } from "./document-store";
 
 /** A document whose primary content is a notebook. */
 export type NotebookDocument = Extract<Document, { type: "model" | "diagram" | "analysis" }>;
+
+/** Delete a notebook cell by ID, returning whether the cell existed. */
+export function deleteNotebookCell<Handle>(
+    store: DocumentStore<Handle>,
+    handle: Handle,
+    cellId: string,
+): boolean {
+    const document = store.getDocumentView(handle) as Readonly<NotebookDocument>;
+    const currentIndex = document.notebook.cellOrder.indexOf(cellId);
+    if (currentIndex < 0) {
+        return false;
+    }
+
+    let deleted = false;
+    store.changeDocument(handle, (storedDocument) => {
+        const notebook = (storedDocument as NotebookDocument).notebook;
+        const index = notebook.cellOrder.indexOf(cellId);
+        if (index < 0) {
+            return;
+        }
+        delete notebook.cellContents[cellId];
+        notebook.cellOrder.splice(index, 1);
+        deleted = true;
+    });
+    return deleted;
+}

--- a/packages/documents/src/rich-text.ts
+++ b/packages/documents/src/rich-text.ts
@@ -1,19 +1,20 @@
 import type { RichTextContent } from "catcolab-document-types";
 import type { DocumentStore } from "./document-store";
-import type { NotebookDocument } from "./notebook-document";
+import { deleteNotebookCell, type NotebookDocument } from "./notebook-document";
 
 export interface RichTextCell {
     readonly kind: "rich-text";
     readonly id: string;
-    readonly content: RichTextContent;
+    readonly content: RichTextContent | undefined;
 
     update(patch: Partial<{ content: RichTextContent }>): void;
+    delete(): void;
 }
 
-function getStoredRichTextCell(document: Readonly<NotebookDocument>, cellId: string) {
+function tryGetStoredRichTextCell(document: Readonly<NotebookDocument>, cellId: string) {
     const cell = document.notebook.cellContents[cellId];
     if (!cell) {
-        throw new Error(`Cell ${cellId} does not exist.`);
+        return undefined;
     }
     if (cell.tag !== "rich-text") {
         throw new Error(`Cell ${cellId} is not rich text.`);
@@ -31,16 +32,27 @@ export function getRichTextCell<Handle>(
         id: cellId,
         get content() {
             const document = store.getDocumentView(handle) as Readonly<NotebookDocument>;
-            return getStoredRichTextCell(document, cellId).content;
+            return tryGetStoredRichTextCell(document, cellId)?.content;
         },
         update(patch) {
             const content = patch.content;
             if (content === undefined) {
                 return;
             }
-            store.changeDocument(handle, (document) => {
-                getStoredRichTextCell(document as NotebookDocument, cellId).content = content;
+            const document = store.getDocumentView(handle) as Readonly<NotebookDocument>;
+            if (!tryGetStoredRichTextCell(document, cellId)) {
+                return;
+            }
+
+            store.changeDocument(handle, (storedDocument) => {
+                const cell = tryGetStoredRichTextCell(storedDocument as NotebookDocument, cellId);
+                if (cell) {
+                    cell.content = content;
+                }
             });
+        },
+        delete() {
+            deleteNotebookCell(store, handle, cellId);
         },
     };
 }

--- a/packages/documents/src/shape.ts
+++ b/packages/documents/src/shape.ts
@@ -1,4 +1,5 @@
 import type { Modality, MorType, ObOp, ObType } from "catcolab-document-types";
+import type { DblTheory } from "catlog-wasm";
 import { morphismTypesEqual, objectTypesEqual } from "./model/equality";
 
 export interface ObjectType<O extends ObType = ObType> {
@@ -15,9 +16,13 @@ export const RichText = { kind: "rich-text" } as const;
 
 export interface Shape {
     readonly theory?: string;
+    readonly getCoreTheory?: () => Promise<DblTheory>;
     readonly objects?: readonly ObjectType[];
     readonly morphisms?: readonly MorphismType[];
     readonly informal?: readonly RichTextType[];
+    readonly supportsInstances?: {
+        readonly tableObjects: readonly ObjectType[];
+    };
 }
 
 export type MorphismEndpoint =
@@ -49,6 +54,18 @@ export function defineMorphism<const M, const E extends MorphismEndpoints>(
 }
 
 export function defineShape<const S extends Shape>(shape: S): S {
+    if (shape.supportsInstances) {
+        if (!shape.theory || !shape.getCoreTheory) {
+            throw new Error("An instance-capable shape must define a theory and its core theory");
+        }
+        if (
+            shape.supportsInstances.tableObjects.some(
+                (tableObject) => !shape.objects?.includes(tableObject),
+            )
+        ) {
+            throw new Error("Instance table objects must be declared in the shape's objects");
+        }
+    }
     return shape;
 }
 

--- a/packages/documents/test/cell-operations.test.ts
+++ b/packages/documents/test/cell-operations.test.ts
@@ -67,13 +67,14 @@ describe.skip("re-ordering cells", () => {
     });
 });
 
-describe.skip("deleting cells", () => {
+describe("deleting cells", () => {
     test("deleting a cell removes it from the notebook's order and contents", async () => {
-        const { b, names } = await threeObjectNotebook();
+        const { notebook, b, names } = await threeObjectNotebook();
 
         expect(names()).toBe("A, B, C");
         b.delete();
         expect(names()).toBe("A, C");
+        expect(notebook.document.notebook.cellContents[b.id]).toBeUndefined();
     });
 
     test("rich-text cells can be deleted in the same way", async () => {

--- a/packages/documents/test/definitions.test.ts
+++ b/packages/documents/test/definitions.test.ts
@@ -1,4 +1,5 @@
 import { Aspect, SimpleOlog, Type } from "catcolab-logics/simple-olog";
+import { Entity as SchemaEntity, SimpleSchema } from "catcolab-logics/simple-schema";
 import { describe, expect, expectTypeOf, test } from "vitest";
 
 import { defineMorphism, defineObject, defineShape } from "catcolab-documents";
@@ -59,5 +60,25 @@ describe("defining notebook shapes", () => {
             morphisms: [Aspect],
         });
         expectTypeOf(SimpleOlog.theory).toEqualTypeOf<"simple-olog">();
+    });
+
+    test("instance-capable shapes select table objects declared by the shape", () => {
+        expect(SimpleSchema.supportsInstances.tableObjects).toEqual([SchemaEntity]);
+
+        expect(() =>
+            defineShape({
+                objects: [SchemaEntity],
+                supportsInstances: { tableObjects: [SchemaEntity] },
+            }),
+        ).toThrowError("An instance-capable shape must define a theory and its core theory");
+
+        expect(() =>
+            defineShape({
+                theory: "invalid-instance-shape",
+                getCoreTheory: SimpleSchema.getCoreTheory,
+                objects: [Type],
+                supportsInstances: { tableObjects: [SchemaEntity] },
+            }),
+        ).toThrowError("Instance table objects must be declared in the shape's objects");
     });
 });

--- a/packages/documents/test/definitions.test.ts
+++ b/packages/documents/test/definitions.test.ts
@@ -56,8 +56,10 @@ describe("defining notebook shapes", () => {
         expect(OnlyType).toEqual({ objects: [Type] });
         expect(SimpleOlog).toEqual({
             theory: "simple-olog",
+            getCoreTheory: expect.any(Function),
             objects: [Type],
             morphisms: [Aspect],
+            supportsInstances: { tableObjects: [Type] },
         });
         expectTypeOf(SimpleOlog.theory).toEqualTypeOf<"simple-olog">();
     });

--- a/packages/documents/test/validation.test.ts
+++ b/packages/documents/test/validation.test.ts
@@ -17,7 +17,7 @@ async function wellFormedOlog() {
     return notebook;
 }
 
-describe.skip("validate", () => {
+describe("validate", () => {
     test("a well-formed notebook validates to an Ok carrying the model", async () => {
         const notebook = await wellFormedOlog();
 
@@ -38,7 +38,7 @@ describe.skip("validate", () => {
     });
 });
 
-describe.skip("onValidate", () => {
+describe("onValidate", () => {
     test("always calls the callback at least once with the current validation", async () => {
         const notebook = await wellFormedOlog();
 
@@ -66,19 +66,18 @@ describe.skip("onValidate", () => {
         }
         const initialCount = results.length;
 
-        notebook.add(Type, { label: "C" });
+        const source = notebook.cellsOf(Type)[0];
+        if (!source) {
+            throw new Error("Expected a source object");
+        }
+        source.delete();
+
         while (results.length === initialCount) {
             await new Promise((resolve) => setTimeout(resolve));
         }
-
         unsubscribe();
 
-        const latest = results[results.length - 1];
-        expect(latest?.tag).toBe("Ok");
-        if (latest?.tag !== "Ok") {
-            return;
-        }
-        expect(latest.content.obGenerators().length).toBe(3);
+        expect(results[results.length - 1]?.tag).toBe("Err");
     });
 });
 

--- a/packages/logics/src/simple-olog.ts
+++ b/packages/logics/src/simple-olog.ts
@@ -6,6 +6,13 @@ export const Aspect = defineMorphism({ tag: "Hom", content: Type.obType });
 
 export const SimpleOlog = defineShape({
     theory: "simple-olog",
+    getCoreTheory: async () => {
+        const { ThCategory } = await import("catlog-wasm");
+        return new ThCategory().theory();
+    },
     objects: [Type],
     morphisms: [Aspect],
+    supportsInstances: {
+        tableObjects: [Type],
+    },
 });

--- a/packages/logics/src/simple-schema.ts
+++ b/packages/logics/src/simple-schema.ts
@@ -11,7 +11,14 @@ export const Attr = defineMorphism(
 
 export const SimpleSchema = defineShape({
     theory: "simple-schema",
+    getCoreTheory: async () => {
+        const { ThSchema } = await import("catlog-wasm");
+        return new ThSchema().theory();
+    },
     objects: [Entity, AttrType],
     morphisms: [Mapping, Attr],
     informal: [RichText],
+    supportsInstances: {
+        tableObjects: [Entity],
+    },
 });

--- a/packages/logics/test/simple-schema.test.ts
+++ b/packages/logics/test/simple-schema.test.ts
@@ -32,6 +32,20 @@ describe("the simple-schema logic", () => {
         expect(name.type.morType).toEqual({ tag: "Basic", content: "Attr" });
     });
 
+    test("declares how schemas are validated and instantiated", async () => {
+        expect(SimpleSchema.supportsInstances.tableObjects).toEqual([Entity]);
+
+        const theory = await SimpleSchema.getCoreTheory();
+        try {
+            expect(theory.hasObType(Entity.obType)).toBe(true);
+            expect(theory.hasObType(AttrType.obType)).toBe(true);
+            expect(theory.hasMorType(Mapping.morType)).toBe(true);
+            expect(theory.hasMorType(Attr.morType)).toBe(true);
+        } finally {
+            theory.free();
+        }
+    }, 15_000);
+
     test.skip("notebooks validate against the core theory of schemas", async () => {
         const binder = createBinder();
         const notebook = await binder.createNotebook(SimpleSchema, { title: "Example schema" });


### PR DESCRIPTION
Prior to this catlog-wasm was swallowing elaboration errors, this change surfaces them in a minimal way: through the same error stream as all other validation errors. This does mean that callers in typescript will see a bunch of generic Issue that they'll have to inspect to understand where in the pipeline the model validation failed, but it's more information than we had before. If/when it becomes important to distinguish validation from elaboration we can revisit this.

The same approach was taken for supportsInstances as my previous changes on the API: i don't know how to make the typescript type system do very clever things here, so we rely on runtime errors for the most part. Again my reasoning is that this is our immediate use-case, and likely the most important one for the next while.

I'm aware that there is `elaborateAndValidateModel` but (beside being private) this is operating at the wrong layer with a different intention to our `validateModelDocument` --- in particular we need to generate error paths conforming to some interface. It's possible that later work could move/extract the generic `elaborateModel` + `model.validate` operation from `frontend/src/model/model_library.ts` into catcolab-documents in some way, but for now we have two methods with slightly differing semantics.

Validation subscription is implemented by using the change subscription method of the underlying store, so whenever there are validation listeners we incur one validate call per update regardless of the nature of the update. Future logic could improve this by figuring out how to filter the updates to "semantic altering" ones only, but for now this is probably fine.