### PR TITLE
OBEE-34: automerge binder in FE

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -50,6 +50,7 @@
         "catcolab-api": "link:../backend/pkg",
         "catcolab-document-methods": "link:../document-methods",
         "catcolab-document-types": "link:../document-types/pkg",
+        "catcolab-documents": "link:../documents",
         "catcolab-ui-components": "link:../ui-components",
         "catlog-wasm": "link:../catlog-wasm/dist/pkg-browser",
         "echarts": "^6.1.0",

--- a/packages/frontend/pnpm-lock.yaml
+++ b/packages/frontend/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       catcolab-document-types:
         specifier: link:../document-types/pkg
         version: link:../document-types/pkg
+      catcolab-documents:
+        specifier: link:../documents
+        version: link:../documents
       catcolab-ui-components:
         specifier: link:../ui-components
         version: link:../ui-components

--- a/packages/frontend/src/api/document_store.test.ts
+++ b/packages/frontend/src/api/document_store.test.ts
@@ -1,0 +1,94 @@
+import { type DocHandle, Repo } from "@automerge/automerge-repo";
+import { afterAll, describe, expect, test } from "vitest";
+
+import { Model } from "catcolab-document-methods";
+import type { Document } from "catcolab-document-types";
+import { makeLiveDoc } from "./document";
+import { createApiDocumentStore, type DocumentStoreApi } from "./document_store";
+
+const repo = new Repo();
+const documents = new Map<string, DocHandle<Document>>();
+let nextRefId = 0;
+
+const api: DocumentStoreApi = {
+    serverHost: "catcolab.test",
+    async createDoc(initialDoc) {
+        const refId = `ref-${nextRefId++}`;
+        documents.set(refId, repo.create<Document>(initialDoc));
+        return refId;
+    },
+    async getLiveDoc(refId, docType) {
+        const docHandle = documents.get(refId);
+        if (!docHandle) {
+            throw new Error(`Document "${refId}" does not exist.`);
+        }
+        return {
+            liveDoc: makeLiveDoc(docHandle, docType),
+            docRef: {
+                refId,
+                permissions: { anyone: null, user: null, users: null },
+                isDeleted: false,
+            },
+        };
+    },
+};
+
+const store = createApiDocumentStore(api);
+
+afterAll(() => {
+    void repo.shutdown();
+});
+
+describe("API document store", () => {
+    test("creates, changes, subscribes to, and resolves documents", async () => {
+        const document = Model.newModelDocument({ theory: "simple-olog" });
+        document.name = "An Olog";
+
+        const handle = await store.createHandle(document);
+        const ref = store.getDocumentRef(handle);
+        expect(ref).toEqual({ id: "ref-0", version: null, server: "catcolab.test" });
+        expect(store.getDocumentView(handle).name).toBe("An Olog");
+
+        let changes = 0;
+        const unsubscribe = store.subscribe(handle, () => {
+            changes += 1;
+        });
+
+        store.changeDocument(handle, (storedDocument) => {
+            storedDocument.name = "Changed locally";
+        });
+        expect(store.getDocumentView(handle).name).toBe("Changed locally");
+        expect(changes).toBe(1);
+
+        handle.liveDoc.docHandle.change((storedDocument) => {
+            storedDocument.name = "Changed outside the store";
+        });
+        expect(store.getDocumentView(handle).name).toBe("Changed outside the store");
+        expect(changes).toBe(2);
+
+        unsubscribe();
+
+        const resolved = await store.getHandle(ref);
+        expect(resolved).toEqual({ tag: "Ok", content: handle });
+
+        const copy = store.copyValue(handle, store.getDocumentView(handle));
+        expect(copy).toEqual(store.getDocumentView(handle));
+        expect(copy).not.toBe(store.getDocumentView(handle));
+    });
+
+    test("rejects unsupported document references", async () => {
+        const versioned = await store.getHandle({
+            id: "ref-0",
+            version: "version",
+            server: "catcolab.test",
+        });
+        expect(versioned.tag).toBe("Err");
+
+        const remote = await store.getHandle({
+            id: "ref-0",
+            version: null,
+            server: "elsewhere.test",
+        });
+        expect(remote.tag).toBe("Err");
+    });
+});

--- a/packages/frontend/src/api/document_store.ts
+++ b/packages/frontend/src/api/document_store.ts
@@ -1,0 +1,80 @@
+import { unwrap } from "solid-js/store";
+
+import type { Document } from "catcolab-document-types";
+import type { DocumentRef, DocumentStore, Result } from "catcolab-documents";
+import type { LiveDocWithRef } from "./document";
+import type { Api } from "./types";
+
+export type ApiDocumentHandle = LiveDocWithRef<Document>;
+
+export type DocumentStoreApi = Pick<Api, "createDoc" | "getLiveDoc" | "serverHost">;
+
+export function createApiDocumentStore(api: DocumentStoreApi): DocumentStore<ApiDocumentHandle> {
+    const handles = new Map<string, ApiDocumentHandle>();
+
+    async function getOrCreateHandle(refId: string): Promise<ApiDocumentHandle> {
+        const existing = handles.get(refId);
+        if (existing) {
+            return existing;
+        }
+
+        const handle: ApiDocumentHandle = await api.getLiveDoc<Document>(refId);
+        handles.set(refId, handle);
+        return handle;
+    }
+
+    const store: DocumentStore<ApiDocumentHandle> = {
+        async createHandle(initialDoc: Document): Promise<ApiDocumentHandle> {
+            const refId = await api.createDoc(initialDoc);
+            return getOrCreateHandle(refId);
+        },
+        async getHandle(ref: DocumentRef): Promise<Result<ApiDocumentHandle>> {
+            if (ref.version !== null) {
+                return {
+                    tag: "Err",
+                    content: [{ message: "Versioned document references are not supported." }],
+                };
+            }
+            if (ref.server && ref.server !== api.serverHost) {
+                return {
+                    tag: "Err",
+                    content: [
+                        { message: `Cannot resolve a document from server "${ref.server}".` },
+                    ],
+                };
+            }
+
+            try {
+                return { tag: "Ok", content: await getOrCreateHandle(ref.id) };
+            } catch (error: unknown) {
+                return {
+                    tag: "Err",
+                    content: [{ message: `Cannot resolve document "${ref.id}": ${String(error)}` }],
+                };
+            }
+        },
+        changeDocument(handle: ApiDocumentHandle, fn: (doc: Document) => void): void {
+            handle.liveDoc.changeDoc(fn);
+        },
+        subscribe(handle: ApiDocumentHandle, callback: () => void): () => void {
+            const onChange = (): void => callback();
+            handle.liveDoc.docHandle.on("change", onChange);
+            return () => handle.liveDoc.docHandle.off("change", onChange);
+        },
+        copyValue<T>(_handle: ApiDocumentHandle, value: T): T {
+            return structuredClone(unwrap(value));
+        },
+        getDocumentRef(handle: ApiDocumentHandle): DocumentRef {
+            return {
+                id: handle.docRef.refId,
+                version: null,
+                server: api.serverHost,
+            };
+        },
+        getDocumentView(handle: ApiDocumentHandle): Readonly<Document> {
+            return handle.liveDoc.doc;
+        },
+    };
+
+    return store;
+}

--- a/packages/frontend/src/api/index.ts
+++ b/packages/frontend/src/api/index.ts
@@ -1,4 +1,5 @@
 export * from "./context";
 export * from "./document";
+export * from "./document_store";
 export * from "./rpc";
 export * from "./types";


### PR DESCRIPTION
Implement an automerge store in the FE operating on refId. This doesn't make the connection to actual backend documents yet, and given that the functionality here is implemented in terms of `frontend/src/api/types.ts: Api` the test follows the convention of mocking this api.

I was not sure what to do with versions or servers, this seemed reasonable to me but it's possible that some missing knowledge would give a better codepath here.
```typescript
32             if (ref.version !== null) {
33                 return {
34                     tag: "Err",
35                     content: [{ message: "Versioned document references are not supported." }],
36                 };
37             }
38             if (ref.server && ref.server !== api.serverHost) {
39                 return {
40                     tag: "Err",
41                     content: [
42                         { message: `Cannot resolve a document from server "${ref.server}".` },
43                     ],
44                 };
45             }
``` 