### PR TITLE
Pin vitest to 4.1.10 in documents and logics packages

### DIFF
--- a/packages/documents/package.json
+++ b/packages/documents/package.json
@@ -43,6 +43,6 @@
         "vite": "^7.2.2",
         "vite-plugin-solid": "^2.11.10",
         "vite-plugin-wasm": "^3.5.0",
-        "vitest": "^4.0.8"
+        "vitest": "4.1.10"
     }
 }

--- a/packages/documents/pnpm-lock.yaml
+++ b/packages/documents/pnpm-lock.yaml
@@ -82,7 +82,7 @@ importers:
         specifier: ^3.5.0
         version: 3.6.0(vite@7.3.6(@types/node@24.13.3))
       vitest:
-        specifier: ^4.0.8
+        specifier: 4.1.10
         version: 4.1.10(@types/node@24.13.3)(happy-dom@20.10.6)(vite@7.3.6(@types/node@24.13.3))
 
 packages:

--- a/packages/logics/package.json
+++ b/packages/logics/package.json
@@ -28,6 +28,6 @@
         "typescript": "^6.0.3",
         "vite": "^7.2.2",
         "vite-plugin-wasm": "^3.5.0",
-        "vitest": "^4.0.8"
+        "vitest": "4.1.10"
     }
 }

--- a/packages/logics/pnpm-lock.yaml
+++ b/packages/logics/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         specifier: ^3.5.0
         version: 3.6.0(vite@7.3.6(@types/node@24.13.3))
       vitest:
-        specifier: ^4.0.8
+        specifier: 4.1.10
         version: 4.1.10(@types/node@24.13.3)(happy-dom@20.10.6)(vite@7.3.6(@types/node@24.13.3))
 
 packages:


### PR DESCRIPTION
Follows the recommendation of this warning:

> Testing types with tsc and vue-tsc is an experimental feature.
Breaking changes might not follow SemVer, please pin Vitest's version when using it.

The warning remains since it is emitted unconditionally. 