### PR TITLE
Show unnamed as "Unnamed" more consistently

### DIFF
--- a/packages/frontend/src/components/id_input.module.css
+++ b/packages/frontend/src/components/id_input.module.css
@@ -1,0 +1,5 @@
+/* De-emphasize the placeholder label of an unnamed generator, both in the
+   input itself (the inline input inherits its color) and in a completion. */
+.unnamed {
+    color: var(--color-text-placeholder);
+}

--- a/packages/frontend/src/components/id_input.tsx
+++ b/packages/frontend/src/components/id_input.tsx
@@ -19,6 +19,10 @@ import type {
 } from "catlog-wasm";
 
 import "./id_input.css";
+import styles from "./id_input.module.css";
+
+/** Placeholder label displayed for an entity without a name. */
+export const UNNAMED = "Unnamed";
 
 /** Optional props for `IdInput` component.
  */
@@ -56,6 +60,13 @@ export function IdInput(
     const idToLabel = (id: QualifiedName): QualifiedLabel | undefined => props.idToLabel?.(id);
     const idToText = (id: QualifiedName): string | undefined => idToLabel(id)?.join(".");
 
+    // Display text for an id, falling back to a placeholder label for ids
+    // without a name, flagged so it can be styled as de-emphasized.
+    const idToDisplay = (id: QualifiedName): { text: string; isUnnamed: boolean } => {
+        const name = idToText(id);
+        return { text: name || UNNAMED, isUnnamed: !name };
+    };
+
     const textToId = (text: string): NameLookup => {
         let label: LabelSegment = text;
         if (/^\d+$/.test(text)) {
@@ -67,11 +78,7 @@ export function IdInput(
     const [text, setText] = createSignal("");
 
     const updateText = (id: Uuid | null) => {
-        let name = "";
-        if (id) {
-            name = idToText(id) ?? "";
-        }
-        setText(name);
+        setText(id ? idToDisplay(id).text : "");
     };
 
     createEffect(() => updateText(props.id));
@@ -103,16 +110,20 @@ export function IdInput(
     };
 
     const completions = (): Completion[] | undefined =>
-        props.completions?.map((id) => ({
-            name: idToText(id) ?? "",
-            onComplete() {
-                props.setId(id);
-                updateText(id);
-            },
-        }));
+        props.completions?.map((id) => {
+            const label = idToDisplay(id);
+            return {
+                name: label.text,
+                nameClass: label.isUnnamed ? styles.unnamed : undefined,
+                onComplete() {
+                    props.setId(id);
+                    updateText(id);
+                },
+            };
+        });
 
     const isComplete = () => {
-        const name = props.id ? idToText(props.id) : "";
+        const name = props.id ? idToDisplay(props.id).text : "";
         return text() === name;
     };
 
@@ -140,8 +151,15 @@ export function IdInput(
         return typeof label[0] === "string" ? "named" : "anonymous";
     };
 
+    // Grey out the displayed text when it is the placeholder label for an
+    // unnamed id (but not while the user is typing something else).
+    const showsUnnamed = () => props.id != null && isComplete() && idToDisplay(props.id).isUnnamed;
+
     return (
-        <div class={`id-input ${labelType(props.id)}`}>
+        <div
+            class={`id-input ${labelType(props.id)}`}
+            classList={{ [styles.unnamed]: showsUnnamed() }}
+        >
             <InlineInput
                 text={text()}
                 setText={handleNewText}

--- a/packages/frontend/src/model/path_mor_input.tsx
+++ b/packages/frontend/src/model/path_mor_input.tsx
@@ -9,9 +9,11 @@ import {
     type InlineInputOptions,
 } from "catcolab-ui-components";
 import type { Mor, Uuid } from "catlog-wasm";
+import { UNNAMED } from "../components";
 import { LiveModelContext } from "./context";
 
 import "../components/id_input.css";
+import styles from "../components/id_input.module.css";
 
 /** Text wrapping the object name of an identity morphism, e.g. `id(X)`. */
 const ID_PREFIX = "id(";
@@ -57,23 +59,30 @@ export function PathMorInput(
 
     const model = () => liveModel().elaboratedModel();
 
-    // Display text for a morphism: a basic generator's name, or `id(<object>)`
-    // for an identity morphism.
-    const morToText = (mor: Mor | null): string => {
+    // Display label for a morphism: a basic generator's name, or `id(<object>)`
+    // for an identity morphism. Unnamed generators fall back to a placeholder
+    // label, flagged so it can be styled as de-emphasized.
+    const morLabel = (mor: Mor | null): { text: string; isUnnamed: boolean } => {
         if (mor === null) {
-            return "";
+            return { text: "", isUnnamed: false };
         }
         const obId = identityOb(mor);
         if (obId !== null) {
-            const name = model()?.obGeneratorLabel(obId)?.join(".") || "?";
-            return `${ID_PREFIX}${name}${ID_SUFFIX}`;
+            const name = model()?.obGeneratorLabel(obId)?.join(".");
+            return {
+                text: `${ID_PREFIX}${name || UNNAMED}${ID_SUFFIX}`,
+                isUnnamed: !name,
+            };
         }
         const id = basicMor(mor);
         if (id !== null) {
-            return model()?.morGeneratorLabel(id)?.join(".") ?? "";
+            const name = model()?.morGeneratorLabel(id)?.join(".");
+            return { text: name || UNNAMED, isUnnamed: !name };
         }
-        return "";
+        return { text: "", isUnnamed: false };
     };
+
+    const morToText = (mor: Mor | null): string => morLabel(mor).text;
 
     // Resolve display text to a morphism, or `null` if it doesn't name one.
     const textToMor = (text: string): Mor | null => {
@@ -123,14 +132,20 @@ export function PathMorInput(
         if (props.morCompletions === undefined && props.obCompletions === undefined) {
             return undefined;
         }
-        const mors = (props.morCompletions ?? []).map((id): Completion => {
-            const mor: Mor = { tag: "Basic", content: id };
-            return { name: morToText(mor), onComplete: () => setCompletion(mor) };
-        });
-        const identities = (props.obCompletions ?? []).map((obId): Completion => {
-            const mor = identityMor(obId);
-            return { name: morToText(mor), onComplete: () => setCompletion(mor) };
-        });
+        const completion = (mor: Mor): Completion => {
+            const label = morLabel(mor);
+            return {
+                name: label.text,
+                nameClass: label.isUnnamed ? styles.unnamed : undefined,
+                onComplete: () => setCompletion(mor),
+            };
+        };
+        const mors = (props.morCompletions ?? []).map(
+            (id): Completion => completion({ tag: "Basic", content: id }),
+        );
+        const identities = (props.obCompletions ?? []).map(
+            (obId): Completion => completion(identityMor(obId)),
+        );
         return [...mors, ...identities];
     };
 
@@ -146,8 +161,12 @@ export function PathMorInput(
         return null;
     };
 
+    // Grey out the displayed text when it is the placeholder label for an
+    // unnamed generator (but not while the user is typing something else).
+    const showsUnnamed = () => isComplete() && morLabel(props.mor).isUnnamed;
+
     return (
-        <div class="id-input">
+        <div class="id-input" classList={{ [styles.unnamed]: showsUnnamed() }}>
             <InlineInput
                 text={text()}
                 setText={handleNewText}


### PR DESCRIPTION
In completions and morphism and object inputs. Previously there was an almost imperceptible space you could select in completions.

<img width="1373" height="755" alt="image" src="https://github.com/user-attachments/assets/6ee6f14f-c968-42d6-acd3-515de000412d" />
