### PR TITLE
OBEE-36: add instance types and validation

### DIFF
--- a/packages/documents/package.json
+++ b/packages/documents/package.json
@@ -8,12 +8,13 @@
         ".": "./src/index.ts"
     },
     "scripts": {
+        "build:doc-types": "pnpm --prefix ../document-methods run build:wasm",
         "format": "oxfmt .",
         "lint": "oxlint --fix && oxfmt .",
         "test": "vitest run",
         "test:db-dump": "vitest --config vitest.db-dump.config.ts --run",
         "test:watch": "vitest",
-        "check": "tsc -p tsconfig.test.json && pnpm run lint",
+        "check": "pnpm run build:doc-types && tsc -p tsconfig.test.json && pnpm run lint",
         "ci": "tsc -p tsconfig.test.json && oxlint --deny-warnings && oxfmt --check ."
     },
     "dependencies": {

--- a/packages/documents/src/instance/errors.ts
+++ b/packages/documents/src/instance/errors.ts
@@ -1,0 +1,16 @@
+import type { Issue } from "../result";
+
+/** Path addressing a field, relative to the document's `tables` map. */
+export type FieldPath = [
+    string, // Table id.
+    "rows",
+    string, // Row id.
+    "fields",
+    string, // Field id.
+];
+
+/** A problem with one field in an instance table. */
+export interface TableFieldIssue extends Issue {
+    readonly path: FieldPath;
+    readonly issueType: "MissingValue" | "DanglingRowRef" | "MistypedRowRef" | "MistypedLiteral";
+}

--- a/packages/documents/src/instance/instance.ts
+++ b/packages/documents/src/instance/instance.ts
@@ -32,29 +32,29 @@ export interface Instance<H, S extends Shape> {
     updateRow(
         row: TableRow,
         values: Record<string, LiteralValue | TableRow>,
-    ): Promise<Result<undefined, ReadonlyArray<Issue | TableFieldIssue>>>;
+    ): Promise<Result<void, ReadonlyArray<Issue | TableFieldIssue>>>;
     updateRows(
         updates: ReadonlyArray<{
             row: TableRow;
             values: ReadonlyArray<Record<string, LiteralValue | TableRow>>;
         }>,
-    ): Promise<Result<undefined, ReadonlyArray<Issue | TableFieldIssue>>>;
+    ): Promise<Result<void, ReadonlyArray<Issue | TableFieldIssue>>>;
     set(
         row: TableRow,
         morphism: { id: string },
         value: LiteralValue | TableRow,
-    ): Promise<Result<undefined, ReadonlyArray<Issue | TableFieldIssue>>>;
+    ): Promise<Result<void, ReadonlyArray<Issue | TableFieldIssue>>>;
 
     /** Delete stored rows without requiring a valid schema. */
     deleteRow(tableId: string, rowId: string): void;
     deleteRows(rows: ReadonlyArray<{ tableId: string; rowId: string }>): void;
 
     /* Validate both the schema and then the instance */
-    validate(): Promise<Result<undefined, ReadonlyArray<Issue | TableFieldIssue>>>;
+    validate(): Promise<Result<void, ReadonlyArray<Issue | TableFieldIssue>>>;
     /** Subscribe to changes to either the instance document or its schema. */
     onChange(callback: () => void): () => void;
     /** Revalidate initially and whenever either the instance or its schema changes. */
     onValidate(
-        callback: (result: Result<undefined, ReadonlyArray<Issue | TableFieldIssue>>) => void,
+        callback: (result: Result<void, ReadonlyArray<Issue | TableFieldIssue>>) => void,
     ): () => void;
 }

--- a/packages/documents/src/instance/instance.ts
+++ b/packages/documents/src/instance/instance.ts
@@ -1,0 +1,60 @@
+import type { InstanceDocument } from "catcolab-document-methods";
+import type { Issue, Result } from "../result";
+import type { Shape } from "../shape";
+import type { TableFieldIssue } from "./errors";
+import type { FieldValue, InstancePath, InstanceTable, LiteralValue, TableRow } from "./tables";
+
+export type { InstanceDocument } from "catcolab-document-methods";
+
+/** API for an instance document and its schema-derived tables. */
+export interface Instance<H, S extends Shape> {
+    readonly handle: H;
+    readonly shape: S;
+    readonly document: Readonly<InstanceDocument>;
+    readonly title: string;
+
+    tables(): Promise<Result<ReadonlyArray<InstanceTable>>>;
+    get(path: InstancePath): Promise<Result<InstanceTable | TableRow | FieldValue>>;
+
+    update(patch: Partial<{ title: string }>): void;
+    dump(): InstanceDocument;
+
+    addRow(
+        table: InstanceTable,
+        values?: Record<string, LiteralValue | TableRow>,
+    ): Promise<Result<TableRow>>;
+    addRows(
+        additions: ReadonlyArray<{
+            table: InstanceTable;
+            values?: ReadonlyArray<Record<string, LiteralValue | TableRow>>;
+        }>,
+    ): Promise<Result<ReadonlyArray<TableRow>>>;
+    updateRow(
+        row: TableRow,
+        values: Record<string, LiteralValue | TableRow>,
+    ): Promise<Result<undefined, ReadonlyArray<Issue | TableFieldIssue>>>;
+    updateRows(
+        updates: ReadonlyArray<{
+            row: TableRow;
+            values: ReadonlyArray<Record<string, LiteralValue | TableRow>>;
+        }>,
+    ): Promise<Result<undefined, ReadonlyArray<Issue | TableFieldIssue>>>;
+    set(
+        row: TableRow,
+        morphism: { id: string },
+        value: LiteralValue | TableRow,
+    ): Promise<Result<undefined, ReadonlyArray<Issue | TableFieldIssue>>>;
+
+    /** Delete stored rows without requiring a valid schema. */
+    deleteRow(tableId: string, rowId: string): void;
+    deleteRows(rows: ReadonlyArray<{ tableId: string; rowId: string }>): void;
+
+    /* Validate both the schema and then the instance */
+    validate(): Promise<Result<undefined, ReadonlyArray<Issue | TableFieldIssue>>>;
+    /** Subscribe to changes to either the instance document or its schema. */
+    onChange(callback: () => void): () => void;
+    /** Revalidate initially and whenever either the instance or its schema changes. */
+    onValidate(
+        callback: (result: Result<undefined, ReadonlyArray<Issue | TableFieldIssue>>) => void,
+    ): () => void;
+}

--- a/packages/documents/src/instance/tables.ts
+++ b/packages/documents/src/instance/tables.ts
@@ -1,0 +1,60 @@
+import type { FieldPath } from "./errors";
+
+/** Path relative to the document's `tables` map. */
+export type InstancePath = [string, ...string[]];
+
+export type LiteralValue = boolean | number | string | null;
+export type LiteralType = "Bool" | "Int" | "Float" | "String";
+
+export interface InstanceTable {
+    /** The table's id: the same as the schema entity's id. */
+    readonly id: string;
+    /** The schema entity's display label; `""` when unlabeled. */
+    readonly label: string;
+    /** The table's rows, in stored order. */
+    readonly rows: ReadonlyArray<TableRow>;
+    /** The table's headers: the schema morphisms out of its entity. */
+    readonly headers: ReadonlyArray<TableHeader>;
+}
+
+export interface TableHeader {
+    /** The schema morphism's id. */
+    readonly id: string;
+    /** Dot-joined qualified label; empty when unlabeled. */
+    readonly label: string;
+    readonly type:
+        | { readonly tag: LiteralType }
+        | { readonly tag: "RowRef"; readonly content: { readonly id: string } };
+}
+
+export interface TableRow {
+    /** The row's id, derived from its key in the stored table. */
+    readonly id: string;
+    /** The row's zero-based position in the table. */
+    readonly index: number;
+    /** The row's schema-interpreted fields. */
+    readonly fields: ReadonlyArray<FieldValue>;
+}
+
+export type FieldValue =
+    | { readonly tag: "Null"; readonly content: { readonly path: FieldPath } }
+    | {
+          readonly tag: "Bool";
+          readonly content: { readonly path: FieldPath; readonly value: boolean };
+      }
+    | {
+          readonly tag: "Int";
+          readonly content: { readonly path: FieldPath; readonly value: number };
+      }
+    | {
+          readonly tag: "Float";
+          readonly content: { readonly path: FieldPath; readonly value: number };
+      }
+    | {
+          readonly tag: "String";
+          readonly content: { readonly path: FieldPath; readonly value: string };
+      }
+    | {
+          readonly tag: "RowRef";
+          readonly content: { readonly path: FieldPath; readonly id: string };
+      };

--- a/packages/documents/src/instance/validation.ts
+++ b/packages/documents/src/instance/validation.ts
@@ -1,0 +1,142 @@
+/* This code is expected to be replaced by catlog implementations in the future once a commitment to the mathematical account of instances has been made. */
+
+import type { InstanceDocument } from "catcolab-document-methods";
+import type * as DocumentTypes from "catcolab-document-types";
+import type { ObGenerator } from "catlog-wasm";
+import type { FieldPath, TableFieldIssue } from "./errors";
+import type { InstanceTable, LiteralType, TableHeader } from "./tables";
+
+/** Decide which concrete atomic type an attribute type denotes. This function
+    is intended to be temporary and should be replaced once we have an account
+    of typing with which we are satisfied. */
+export function atomicTypeOfAttributeType(attributeType: Pick<ObGenerator, "label">): LiteralType {
+    const name = attributeType.label?.[0];
+    switch (name) {
+        case "Bool":
+        case "Int":
+        case "Float":
+        case "String":
+            return name;
+        default:
+            return "String";
+    }
+}
+
+/** Compare stored fields with tables derived from a validated schema model. */
+export function validateTableFields(
+    document: Readonly<InstanceDocument>,
+    tables: ReadonlyArray<InstanceTable>,
+): TableFieldIssue[] {
+    const tableById = new Map(tables.map((table) => [table.id, table]));
+    const rowTables = new Map<string, Set<string>>();
+
+    for (const [tableId, table] of Object.entries(document.tables)) {
+        for (const rowId of Object.keys(table.rows)) {
+            const tables = rowTables.get(rowId) ?? new Set<string>();
+            tables.add(tableId);
+            rowTables.set(rowId, tables);
+        }
+    }
+
+    const issues: TableFieldIssue[] = [];
+    for (const [tableId, storedTable] of Object.entries(document.tables)) {
+        const table = tableById.get(tableId);
+        if (table === undefined) {
+            continue;
+        }
+        const headerById = new Map(table.headers.map((header) => [header.id, header]));
+        for (const [rowId, row] of Object.entries(storedTable.rows)) {
+            for (const header of table.headers) {
+                const fieldId = header.id;
+                const path = fieldPath(tableId, rowId, fieldId);
+                const value = row.fields[fieldId] ?? "Null";
+                if (value === "Null") {
+                    issues.push({
+                        message: `\`${header.label}\` in table \`${table.label}\` is missing a value`,
+                        path,
+                        issueType: "MissingValue",
+                    });
+                    continue;
+                }
+                if (header.type.tag === "RowRef") {
+                    if (!isStoredRowRef(value)) {
+                        issues.push(mistypedLiteralIssue(table, header, path));
+                        continue;
+                    }
+                    const containingTables = rowTables.get(value.RowRef);
+                    if (containingTables === undefined) {
+                        issues.push({
+                            message: `\`${header.label}\` refers to a row that no longer exists`,
+                            path,
+                            issueType: "DanglingRowRef",
+                        });
+                    } else if (!containingTables.has(header.type.content.id)) {
+                        const actualTableId = containingTables.values().next().value as
+                            | string
+                            | undefined;
+                        let actualLabel = "";
+                        if (actualTableId !== undefined) {
+                            actualLabel = tableById.get(actualTableId)?.label ?? actualTableId;
+                        }
+                        const targetLabel =
+                            tableById.get(header.type.content.id)?.label ?? header.type.content.id;
+                        issues.push({
+                            message: `\`${header.label}\` must be a row of table \`${targetLabel}\` (was a row of table \`${actualLabel}\`)`,
+                            path,
+                            issueType: "MistypedRowRef",
+                        });
+                    }
+                } else if (!storedValueMatchesLiteralType(value, header.type.tag)) {
+                    issues.push(mistypedLiteralIssue(table, header, path));
+                }
+            }
+            for (const fieldId of Object.keys(row.fields)) {
+                if (headerById.has(fieldId)) {
+                    continue;
+                }
+                issues.push({
+                    message: `Field \`${fieldId}\` is not a typed column of table \`${table.label}\``,
+                    path: fieldPath(tableId, rowId, fieldId),
+                    issueType: "MistypedLiteral",
+                });
+            }
+        }
+    }
+    return issues;
+}
+
+function fieldPath(tableId: string, rowId: string, fieldId: string): FieldPath {
+    return [tableId, "rows", rowId, "fields", fieldId];
+}
+
+function isStoredRowRef(value: DocumentTypes.FieldValue): value is { RowRef: string } {
+    return value !== "Null" && "RowRef" in value;
+}
+
+function storedValueMatchesLiteralType(
+    value: Exclude<DocumentTypes.FieldValue, "Null">,
+    type: LiteralType,
+): boolean {
+    switch (type) {
+        case "Bool":
+            return "Bool" in value && typeof value.Bool === "boolean";
+        case "Int":
+            return "Int" in value && Number.isInteger(value.Int);
+        case "Float":
+            return "Float" in value && Number.isFinite(value.Float);
+        case "String":
+            return "String" in value && typeof value.String === "string";
+    }
+}
+
+function mistypedLiteralIssue(
+    table: InstanceTable,
+    header: TableHeader,
+    path: FieldPath,
+): TableFieldIssue {
+    return {
+        message: `\`${header.label}\` in table \`${table.label}\` does not have type ${header.type.tag}`,
+        path,
+        issueType: "MistypedLiteral",
+    };
+}

--- a/packages/documents/src/shape.ts
+++ b/packages/documents/src/shape.ts
@@ -69,6 +69,13 @@ export function defineShape<const S extends Shape>(shape: S): S {
     return shape;
 }
 
+/** A shape that declares support for tabular instances of its models. */
+export type InstanceCapableShape = Shape & {
+    readonly supportsInstances: {
+        readonly tableObjects: readonly ObjectType[];
+    };
+};
+
 export type RichTextType = typeof RichText;
 export type ObjectTypesOf<S extends Shape> = NonNullable<S["objects"]>[number];
 export type MorphismTypesOf<S extends Shape> = NonNullable<S["morphisms"]>[number];

--- a/packages/documents/test/validation.test.ts
+++ b/packages/documents/test/validation.test.ts
@@ -17,7 +17,9 @@ async function wellFormedOlog() {
     return notebook;
 }
 
-describe("validate", () => {
+// the first time tests run we incur the cost of loading the catlog-wasm bundle,
+// so these tests have longer timeouts
+describe("validate", { timeout: 10000 }, () => {
     test("a well-formed notebook validates to an Ok carrying the model", async () => {
         const notebook = await wellFormedOlog();
 
@@ -38,7 +40,7 @@ describe("validate", () => {
     });
 });
 
-describe("onValidate", () => {
+describe("onValidate", { timeout: 10000 }, () => {
     test("always calls the callback at least once with the current validation", async () => {
         const notebook = await wellFormedOlog();
 


### PR DESCRIPTION
*tests will be in the last pr on this stack*

Define instance, table, and error types as well as add runtime support for instance-capable shapes. Add temporary implementations of atomic column typing and instance validation until we decide how we want this to work mathematically. We do not add capability to actually generate anything of these types in this change.

Adjust the pnpm config to build generated document types before checking (we now depend on catlog-wasm) and increase the validation test timeout for loading catlog-wasm.

This change includes the revised interface for instances and usage pattern that Kaspar and i had discussed. See `src/instance/instance.ts` for details.

In order to obtain `tables` for example, the expected pattern is
```typescript
// subscribe to validation
const unsubscribe = instance.onValidate(async (validation) => {
  // ignore invalid schemas or instances
  if (validation.tag !== "Ok") return;
  // both were valid at the callback time, try to read the table content
  const result = await instance.tables();
  // something invalidated either the schema or instance
  if (result.tag !== "Ok") return;
  // use tables...
  const tables = result.content;
});

// finally
unsubscribe();
```