### PR TITLE
OBEE-39: implement table runtime and backing for createInstance factory

### DIFF
--- a/packages/documents/src/instance/instance-runtime.ts
+++ b/packages/documents/src/instance/instance-runtime.ts
@@ -1,0 +1,213 @@
+import type { InstanceDocument } from "catcolab-document-methods";
+import type { DblModel } from "catlog-wasm";
+import type { DocumentStore } from "../document-store";
+import type { ModelDocument } from "../model/document";
+import type { Notebook } from "../model/notebook";
+import type { Issue, Result } from "../result";
+import type { InstanceCapableShape, Shape } from "../shape";
+import type { TableFieldIssue } from "./errors";
+import {
+    addInstanceRowsToStore,
+    instanceTablesFromModel,
+    readInstancePathFromStore,
+    updateInstanceFieldByIdInStore,
+    updateInstanceFieldsByLabelInStore,
+} from "./table-methods";
+import type { FieldValue, InstancePath, InstanceTable, LiteralValue, TableRow } from "./tables";
+import { validateTableFields } from "./validation";
+
+function instanceCapableShape<S extends Shape>(
+    schema: Notebook<S, ModelDocument>,
+): InstanceCapableShape {
+    const shape = schema.shape;
+    if (shape.supportsInstances === undefined) {
+        throw new Error(`Shape \`${shape.theory ?? "unnamed"}\` does not support instances`);
+    }
+    return shape as InstanceCapableShape;
+}
+
+/** Validate the schema, run an operation against the resulting model, and free it.
+
+`operation` is expected to report its own failures as a `Result`; this does not
+catch exceptions, so an operation that throws lets that exception propagate. */
+async function withValidatedSchema<
+    S extends Shape,
+    T,
+    E extends ReadonlyArray<Issue> = ReadonlyArray<Issue>,
+>(
+    schema: Notebook<S, ModelDocument>,
+    operation: (schemaModel: DblModel) => Result<T, E>,
+): Promise<Result<T, E>> {
+    const schemaResult = await schema.validate();
+    if (schemaResult.tag === "Err") {
+        return schemaResult as Result<T, E>;
+    }
+
+    const schemaModel = schemaResult.content;
+    try {
+        return operation(schemaModel);
+    } finally {
+        schemaModel.free();
+    }
+}
+
+export function createTablesMethod<Handle, S extends Shape>(
+    schema: Notebook<S, ModelDocument>,
+    store: DocumentStore<Handle>,
+    handle: Handle,
+): () => Promise<Result<ReadonlyArray<InstanceTable>>> {
+    return () =>
+        withValidatedSchema(schema, (schemaModel) => ({
+            tag: "Ok",
+            content: instanceTablesFromModel(
+                instanceCapableShape(schema),
+                store,
+                handle,
+                schemaModel,
+            ),
+        }));
+}
+
+export function createGetMethod<Handle, S extends Shape>(
+    schema: Notebook<S, ModelDocument>,
+    store: DocumentStore<Handle>,
+    handle: Handle,
+): (path: InstancePath) => Promise<Result<InstanceTable | TableRow | FieldValue>> {
+    return (path) =>
+        withValidatedSchema(schema, (schemaModel) =>
+            readInstancePathFromStore(
+                instanceCapableShape(schema),
+                store,
+                handle,
+                schemaModel,
+                path,
+            ),
+        );
+}
+
+export function createAddRowsMethod<Handle, S extends Shape>(
+    schema: Notebook<S, ModelDocument>,
+    store: DocumentStore<Handle>,
+    handle: Handle,
+): (
+    additions: ReadonlyArray<{
+        table: InstanceTable;
+        values?: ReadonlyArray<Record<string, LiteralValue | TableRow>>;
+    }>,
+) => Promise<Result<ReadonlyArray<TableRow>>> {
+    return (additions) =>
+        withValidatedSchema(schema, (schemaModel) =>
+            addInstanceRowsToStore(
+                instanceCapableShape(schema),
+                store,
+                handle,
+                schemaModel,
+                additions.map(({ table, values }) => ({ table, values: values ?? [{}] })),
+            ),
+        );
+}
+
+export function createAddRowMethod(
+    addRows: ReturnType<typeof createAddRowsMethod>,
+): (
+    table: InstanceTable,
+    values?: Record<string, LiteralValue | TableRow>,
+) => Promise<Result<TableRow>> {
+    return async (table, values = {}) => {
+        const result = await addRows([{ table, values: [values] }]);
+        if (result.tag === "Err") {
+            return result;
+        }
+        const row = result.content[0];
+        return row === undefined
+            ? { tag: "Err", content: [{ message: "Adding one row did not return a row" }] }
+            : { tag: "Ok", content: row };
+    };
+}
+
+export function createUpdateRowsMethod<Handle, S extends Shape>(
+    schema: Notebook<S, ModelDocument>,
+    store: DocumentStore<Handle>,
+    handle: Handle,
+): (
+    updates: ReadonlyArray<{
+        row: TableRow;
+        values: ReadonlyArray<Record<string, LiteralValue | TableRow>>;
+    }>,
+) => Promise<Result<undefined, ReadonlyArray<Issue | TableFieldIssue>>> {
+    return (updates) =>
+        withValidatedSchema(schema, (schemaModel) =>
+            updateInstanceFieldsByLabelInStore(
+                instanceCapableShape(schema),
+                store,
+                handle,
+                schemaModel,
+                updates,
+            ),
+        );
+}
+
+export function createUpdateRowMethod(
+    updateRows: ReturnType<typeof createUpdateRowsMethod>,
+): (
+    row: TableRow,
+    values: Record<string, LiteralValue | TableRow>,
+) => Promise<Result<undefined, ReadonlyArray<Issue | TableFieldIssue>>> {
+    return (row, values) => updateRows([{ row, values: [values] }]);
+}
+
+export function createSetMethod<Handle, S extends Shape>(
+    schema: Notebook<S, ModelDocument>,
+    store: DocumentStore<Handle>,
+    handle: Handle,
+): (
+    row: TableRow,
+    morphism: { id: string },
+    value: LiteralValue | TableRow,
+) => Promise<Result<undefined, ReadonlyArray<Issue | TableFieldIssue>>> {
+    return (row, morphism, value) =>
+        withValidatedSchema(schema, (schemaModel) =>
+            updateInstanceFieldByIdInStore(
+                instanceCapableShape(schema),
+                store,
+                handle,
+                schemaModel,
+                row,
+                morphism,
+                value,
+            ),
+        );
+}
+
+/** Build a validator that combines schema validation with instance-content
+validation. */
+export function createSchemaResultValidator<Handle, S extends Shape>(
+    schema: Notebook<S, ModelDocument>,
+    store: DocumentStore<Handle>,
+    handle: Handle,
+): (schemaResult: Result<DblModel>) => Result<undefined, ReadonlyArray<Issue | TableFieldIssue>> {
+    return (schemaResult) => {
+        if (schemaResult.tag === "Err") {
+            return schemaResult;
+        }
+
+        const schemaModel = schemaResult.content;
+        try {
+            const tables = instanceTablesFromModel(
+                instanceCapableShape(schema),
+                store,
+                handle,
+                schemaModel,
+            );
+            const issues: TableFieldIssue[] = validateTableFields(
+                store.getDocumentView(handle) as Readonly<InstanceDocument>,
+                tables,
+            );
+            return issues.length === 0
+                ? { tag: "Ok", content: undefined }
+                : { tag: "Err", content: issues };
+        } finally {
+            schemaModel.free();
+        }
+    };
+}

--- a/packages/documents/src/instance/table-methods.ts
+++ b/packages/documents/src/instance/table-methods.ts
@@ -1,0 +1,419 @@
+import { v7 as uuid } from "uuid";
+
+import type { InstanceDocument } from "catcolab-document-methods";
+import type * as DocumentTypes from "catcolab-document-types";
+import type { DblModel, ObGenerator } from "catlog-wasm";
+import type { DocumentStore } from "../document-store";
+import { objectTypesEqual } from "../model/equality";
+import type { Issue, Result } from "../result";
+import type { InstanceCapableShape } from "../shape";
+import type { FieldPath } from "./errors";
+import type {
+    FieldValue,
+    InstancePath,
+    InstanceTable,
+    LiteralValue,
+    TableHeader,
+    TableRow,
+} from "./tables";
+import { atomicTypeOfAttributeType } from "./validation";
+
+/** Read one table, row, or field using a validated schema model.
+
+Addressing failures are reported as issues. */
+export function readInstancePathFromStore<Handle>(
+    shape: InstanceCapableShape,
+    store: DocumentStore<Handle>,
+    handle: Handle,
+    schemaModel: DblModel,
+    path: InstancePath,
+): Result<InstanceTable | TableRow | FieldValue> {
+    const schemaTables = instanceTablesFromModel(shape, store, handle, schemaModel);
+    const schemaTableById = new Map(
+        schemaTables.map((schemaTable) => [schemaTable.id, schemaTable]),
+    );
+    const document = store.getDocumentView(handle) as Readonly<InstanceDocument>;
+    const [tableId, rowsSegment, rowId, fieldsSegment, fieldId, ...rest] = path;
+    const schemaTable = schemaTableById.get(tableId);
+    if (schemaTable === undefined) {
+        return pathError(`Table \`${tableId}\` does not exist`);
+    }
+    if (path.length === 1) {
+        return { tag: "Ok", content: schemaTable };
+    }
+    if (rowsSegment !== "rows" || rowId === undefined) {
+        return pathError("An instance path after a table must address a row");
+    }
+    const storedRow = document.tables[tableId]?.rows[rowId];
+    if (storedRow === undefined) {
+        return pathError(`Row \`${rowId}\` does not exist in table \`${tableId}\``);
+    }
+    const row = makeRow(store, handle, schemaTable, rowId);
+    if (path.length === 3) {
+        return { tag: "Ok", content: row };
+    }
+    if (fieldsSegment !== "fields" || fieldId === undefined || rest.length > 0) {
+        return pathError("An instance path after a row must address a field");
+    }
+    if (!schemaTable.headers.some((header) => header.id === fieldId)) {
+        return pathError(`Field \`${fieldId}\` does not exist in table \`${tableId}\``);
+    }
+    const stored = storedRow.fields[fieldId] ?? "Null";
+    return {
+        tag: "Ok",
+        content: fieldValueFromStored([tableId, "rows", rowId, "fields", fieldId], stored),
+    };
+}
+
+/** Add rows using a validated schema model.
+
+Only addressing failures are reported as issues. Every update that fails to
+address is skipped and the rest are still applied. */
+export function addInstanceRowsToStore<Handle>(
+    shape: InstanceCapableShape,
+    store: DocumentStore<Handle>,
+    handle: Handle,
+    schemaModel: DblModel,
+    additions: ReadonlyArray<{
+        table: InstanceTable;
+        values: ReadonlyArray<Record<string, LiteralValue | TableRow>>;
+    }>,
+): Result<ReadonlyArray<TableRow>> {
+    const schemaTables = instanceTablesFromModel(shape, store, handle, schemaModel);
+    const schemaTableById = new Map(
+        schemaTables.map((schemaTable) => [schemaTable.id, schemaTable]),
+    );
+
+    const issues: Issue[] = [];
+    const addedRows: Array<{ schemaTable: InstanceTable; id: string }> = [];
+
+    store.changeDocument(handle, (changedDocument) => {
+        const instanceDocument = changedDocument as InstanceDocument;
+        for (const { table, values } of additions) {
+            const schemaTable = schemaTableById.get(table.id);
+            if (schemaTable === undefined) {
+                issues.push({
+                    message: `Table \`${table.id}\` does not exist in the current schema`,
+                });
+                continue;
+            }
+            for (const rowValues of values) {
+                const fields = encodeFieldsByLabel(schemaTable, rowValues, issues);
+                const id = freshRowId(instanceDocument);
+                let storedTable = instanceDocument.tables[schemaTable.id];
+                if (storedTable === undefined) {
+                    storedTable = { rows: {}, rowOrder: [] };
+                    instanceDocument.tables[schemaTable.id] = storedTable;
+                }
+                storedTable.rows[id] = { fields };
+                storedTable.rowOrder.push(id);
+                addedRows.push({ schemaTable, id });
+            }
+        }
+    });
+
+    if (issues.length > 0) {
+        return { tag: "Err", content: issues };
+    }
+    return {
+        tag: "Ok",
+        content: addedRows.map(({ schemaTable, id }) => makeRow(store, handle, schemaTable, id)),
+    };
+}
+
+/** Update fields by header label using a validated schema model.
+
+Only addressing failures are reported as issues. Every update that fails to
+address is skipped and the rest are still applied. */
+export function updateInstanceFieldsByLabelInStore<Handle>(
+    shape: InstanceCapableShape,
+    store: DocumentStore<Handle>,
+    handle: Handle,
+    schemaModel: DblModel,
+    updates: ReadonlyArray<{
+        row: TableRow;
+        values: ReadonlyArray<Record<string, LiteralValue | TableRow>>;
+    }>,
+): Result<undefined> {
+    const schemaTables = instanceTablesFromModel(shape, store, handle, schemaModel);
+
+    const issues: Issue[] = [];
+    store.changeDocument(handle, (changedDocument) => {
+        const instanceDocument = changedDocument as InstanceDocument;
+        for (const { row, values } of updates) {
+            const schemaTable = schemaTableForRow(instanceDocument, schemaTables, row, issues);
+            if (schemaTable === undefined) {
+                continue;
+            }
+            const storedRow = instanceDocument.tables[schemaTable.id]?.rows[row.id];
+            if (storedRow === undefined) {
+                continue;
+            }
+            for (const rowValues of values) {
+                Object.assign(
+                    storedRow.fields,
+                    encodeFieldsByLabel(schemaTable, rowValues, issues),
+                );
+            }
+        }
+    });
+
+    return issues.length > 0 ? { tag: "Err", content: issues } : { tag: "Ok", content: undefined };
+}
+
+/** Update one field by header id using a validated schema model.
+
+Only addressing failures (an unknown row or an unknown field) are reported as
+issues. */
+export function updateInstanceFieldByIdInStore<Handle>(
+    shape: InstanceCapableShape,
+    store: DocumentStore<Handle>,
+    handle: Handle,
+    schemaModel: DblModel,
+    row: TableRow,
+    field: { id: string },
+    value: LiteralValue | TableRow,
+): Result<undefined> {
+    const schemaTables = instanceTablesFromModel(shape, store, handle, schemaModel);
+
+    const issues: Issue[] = [];
+    store.changeDocument(handle, (changedDocument) => {
+        const instanceDocument = changedDocument as InstanceDocument;
+        const schemaTable = schemaTableForRow(instanceDocument, schemaTables, row, issues);
+        if (schemaTable === undefined) {
+            return;
+        }
+        const storedRow = instanceDocument.tables[schemaTable.id]?.rows[row.id];
+        if (storedRow === undefined) {
+            return;
+        }
+        const header = schemaTable.headers.find((header) => header.id === field.id);
+        if (header === undefined) {
+            issues.push({
+                message: `Field \`${field.id}\` is not a header of table \`${schemaTable.label}\``,
+            });
+            return;
+        }
+        storedRow.fields[field.id] = encodeFieldValue(header, value);
+    });
+
+    return issues.length > 0 ? { tag: "Err", content: issues } : { tag: "Ok", content: undefined };
+}
+
+function freshRowId(document: Readonly<InstanceDocument>): string {
+    let id = uuid();
+    while (Object.values(document.tables).some((table) => table.rows[id] !== undefined)) {
+        id = uuid();
+    }
+    return id;
+}
+
+function schemaTableForRow(
+    document: Readonly<InstanceDocument>,
+    schemaTables: readonly InstanceTable[],
+    row: TableRow,
+    issues: Issue[],
+): InstanceTable | undefined {
+    const containingTables = schemaTables.filter(
+        (schemaTable) => document.tables[schemaTable.id]?.rows[row.id] !== undefined,
+    );
+    if (containingTables.length === 0) {
+        issues.push({ message: `Row \`${row.id}\` does not exist` });
+        return undefined;
+    }
+    if (containingTables.length > 1) {
+        issues.push({ message: `Row \`${row.id}\` occurs in more than one table` });
+        return undefined;
+    }
+    return containingTables[0];
+}
+
+function encodeFieldsByLabel(
+    schemaTable: InstanceTable,
+    fields: Record<string, LiteralValue | TableRow>,
+    issues: Issue[],
+): Record<string, DocumentTypes.FieldValue> {
+    const encoded: Record<string, DocumentTypes.FieldValue> = {};
+    for (const [label, value] of Object.entries(fields)) {
+        const matching = schemaTable.headers.filter((header) => header.label === label);
+        if (matching.length === 0) {
+            issues.push({
+                message: `Table \`${schemaTable.label}\` has no column labeled \`${label}\``,
+            });
+            continue;
+        }
+        if (matching.length > 1) {
+            issues.push({
+                message: `Column label \`${label}\` is ambiguous in table \`${schemaTable.label}\``,
+            });
+            continue;
+        }
+        const header = matching[0]!;
+        encoded[header.id] = encodeFieldValue(header, value);
+    }
+    return encoded;
+}
+
+/* This function follows the run-time shape of the given value, with the one
+   exception carved out for Int vs Float which we can't determine.*/
+function encodeFieldValue(
+    header: TableHeader,
+    value: LiteralValue | TableRow,
+): DocumentTypes.FieldValue {
+    if (value === null) {
+        return "Null";
+    }
+    if (typeof value === "boolean") {
+        return { Bool: value };
+    }
+    if (typeof value === "string") {
+        return { String: value };
+    }
+    if (typeof value === "number") {
+        return header.type.tag === "Int" ? { Int: value } : { Float: value };
+    }
+    return { RowRef: value.id };
+}
+
+function requireRawRow(
+    document: Readonly<InstanceDocument>,
+    tableId: string,
+    rowId: string,
+): Readonly<DocumentTypes.TableRow> {
+    const row = document.tables[tableId]?.rows[rowId];
+    if (row === undefined) {
+        throw new Error(`Row \`${rowId}\` does not exist in table \`${tableId}\``);
+    }
+    return row;
+}
+
+function makeRow<Handle>(
+    store: DocumentStore<Handle>,
+    handle: Handle,
+    schemaTable: InstanceTable,
+    rowId: string,
+): TableRow {
+    return {
+        id: rowId,
+        get index() {
+            const document = store.getDocumentView(handle) as Readonly<InstanceDocument>;
+            return orderedRowIds(document.tables[schemaTable.id]).indexOf(rowId);
+        },
+        get fields() {
+            const document = store.getDocumentView(handle) as Readonly<InstanceDocument>;
+            const storedRow = requireRawRow(document, schemaTable.id, rowId);
+            return schemaTable.headers.map((header) =>
+                fieldValueFromStored(
+                    [schemaTable.id, "rows", rowId, "fields", header.id],
+                    storedRow.fields[header.id] ?? "Null",
+                ),
+            );
+        },
+    };
+}
+
+/** Read the tables using a validated schema model. */
+export function instanceTablesFromModel<Handle>(
+    shape: InstanceCapableShape,
+    store: DocumentStore<Handle>,
+    handle: Handle,
+    schemaModel: DblModel,
+): readonly InstanceTable[] {
+    const presentation = schemaModel.presentation();
+    const objectsById = new Map(presentation.obGenerators.map((object) => [object.id, object]));
+    const tableObjects = presentation.obGenerators.filter((object) =>
+        shape.supportsInstances.tableObjects.some((type) =>
+            objectTypesEqual(type.obType, object.obType),
+        ),
+    );
+    const tableIds = new Set(tableObjects.map((object) => object.id));
+
+    return tableObjects.map((tableObject) => {
+        const headers: TableHeader[] = [];
+        for (const morphism of presentation.morGenerators) {
+            if (morphism.dom.tag !== "Basic" || morphism.dom.content !== tableObject.id) {
+                continue;
+            }
+            if (morphism.cod.tag !== "Basic") {
+                continue;
+            }
+            const codomainObject = objectsById.get(morphism.cod.content);
+            if (codomainObject === undefined) {
+                continue;
+            }
+
+            const label = displayLabel(morphism);
+            if (tableIds.has(codomainObject.id)) {
+                headers.push({
+                    id: morphism.id,
+                    label,
+                    type: { tag: "RowRef", content: { id: codomainObject.id } },
+                });
+                continue;
+            }
+
+            const attributeType = codomainObject;
+            const literalType = atomicTypeOfAttributeType(attributeType);
+            headers.push({ id: morphism.id, label, type: { tag: literalType } });
+        }
+        const table: InstanceTable = {
+            id: tableObject.id,
+            label: displayLabel(tableObject),
+            headers,
+            get rows() {
+                const document = store.getDocumentView(handle) as Readonly<InstanceDocument>;
+                return orderedRowIds(document.tables[tableObject.id]).map((rowId) =>
+                    makeRow(store, handle, table, rowId),
+                );
+            },
+        };
+        return table;
+    });
+}
+
+function displayLabel(generator: Pick<ObGenerator, "label">): string {
+    return generator.label?.join(".") ?? "";
+}
+
+function fieldValueFromStored(path: FieldPath, value: DocumentTypes.FieldValue): FieldValue {
+    if (value === "Null") {
+        return { tag: "Null", content: { path } };
+    }
+    if ("Bool" in value) {
+        return { tag: "Bool", content: { path, value: value.Bool } };
+    }
+    if ("Int" in value) {
+        return { tag: "Int", content: { path, value: value.Int } };
+    }
+    if ("Float" in value) {
+        return { tag: "Float", content: { path, value: value.Float } };
+    }
+    if ("String" in value) {
+        return { tag: "String", content: { path, value: value.String } };
+    }
+    return { tag: "RowRef", content: { path, id: value.RowRef } };
+}
+
+function orderedRowIds(table: Readonly<DocumentTypes.Table> | undefined): string[] {
+    if (table === undefined) {
+        return [];
+    }
+    const seen = new Set<string>();
+    const ordered: string[] = [];
+    for (const id of table.rowOrder ?? []) {
+        if (table.rows[id] !== undefined && !seen.has(id)) {
+            seen.add(id);
+            ordered.push(id);
+        }
+    }
+    for (const id of Object.keys(table.rows)) {
+        if (!seen.has(id)) {
+            ordered.push(id);
+        }
+    }
+    return ordered;
+}
+
+function pathError(message: string) {
+    return { tag: "Err" as const, content: [{ message }] };
+}


### PR DESCRIPTION
*tests will be included in the last change stacked on this*

This is an absolute grind of a change. There are simply twelve quadrillion things that have to happen to make things like changing rows or adjusting tables work correctly.

The basic pattern is visible in instance-runtime.ts :

```typescript
async function withValidatedSchema<
    Handle,
    S extends Shape,
    T,
    E extends ReadonlyArray<Issue> = ReadonlyArray<Issue>,
>(
    schema: Notebook<S, ModelDocument>,
    operation: (schemaModel: DblModel) => Result<T, E>,
): Promise<Result<T, E>>
```

is used to perform the steps of obtaining a dblmodel (or erroring if the schema doesn't validate), learning about the table structure, and finally running the operation (which might itself fail in a way at least as exciting as ReadonlyArray<Issue>). So this is what is contained in the factory functions that will (in a later change) back the Instance factory: `createTablesMethod`, `createGetMethod`, `createAddRowManyMethod`, etc.

Then there's the elephant: table-methods.ts. The basic premise for all of these is to permissively apply everything that makes sense, and report everything that failed. Thus an `Ok` is only possible if went well. The only kinds of failures that are important here are addressing failures: mentioning a table that doesn't exist, mentioning a row that doesn't exist. Type issues, missing entries, bad links, and so on are all semantic checks that will be caught by validation passes.