### PR TITLE
OBEE-32: integrate instances

### DIFF
--- a/packages/documents/src/binder.ts
+++ b/packages/documents/src/binder.ts
@@ -1,9 +1,11 @@
-import { Model } from "catcolab-document-methods";
+import { Instance as InstanceMethods, Model } from "catcolab-document-methods";
 import type { Document } from "catcolab-document-types";
 import type { DocumentStore } from "./document-store";
-import { createInMemoryStore } from "./document-store/in-memory";
+import { createInMemoryStore } from "./document-store";
+import { instanceFromStore, type Instance } from "./instance/instance";
 import type { ModelDocument } from "./model/document";
 import { modelNotebookFromStore, type Notebook } from "./model/notebook";
+import type { Result } from "./result";
 import type { Shape } from "./shape";
 
 export interface Binder<Handle> {
@@ -13,7 +15,12 @@ export interface Binder<Handle> {
     createNotebook<S extends Shape & { readonly theory: string }>(
         shape: S,
         options: { title: string },
-    ): Promise<Notebook<S, ModelDocument>>;
+    ): Promise<Notebook<S, ModelDocument, Handle>>;
+
+    createInstance<S extends Shape>(
+        schema: Notebook<S, ModelDocument, Handle>,
+        options: { title: string },
+    ): Promise<Result<Instance<Handle, S>>>;
 }
 
 /* Overloads rather than a single signature `createBinder<Handle>(store?:
@@ -47,6 +54,46 @@ function binderFromStore<Handle>(store: DocumentStore<Handle>): Binder<Handle> {
             const handle = await store.createHandle(document);
 
             return modelNotebookFromStore(shape, store, handle);
+        },
+        async createInstance<S extends Shape>(
+            schema: Notebook<S, ModelDocument, Handle>,
+            options: { title: string },
+        ) {
+            const shape = schema.shape;
+            if (shape.supportsInstances === undefined) {
+                return {
+                    tag: "Err",
+                    content: [
+                        {
+                            message: `Shape \`${shape.theory ?? "unnamed"}\` does not support instances`,
+                        },
+                    ],
+                };
+            }
+
+            const schemaResult = await schema.validate();
+            if (schemaResult.tag === "Err") {
+                return schemaResult;
+            }
+
+            const schemaModel = schemaResult.content;
+            try {
+                const schemaRef = store.getDocumentRef(schema.handle);
+                const document = InstanceMethods.newInstanceDocument({
+                    _id: schemaRef.id,
+                    _version: schemaRef.version,
+                    _server: schemaRef.server ?? "",
+                });
+                document.name = options.title;
+
+                const handle = await store.createHandle(document);
+                return {
+                    tag: "Ok",
+                    content: instanceFromStore(shape, schema, store, handle),
+                };
+            } finally {
+                schemaModel.free();
+            }
         },
     };
 }

--- a/packages/documents/src/index.ts
+++ b/packages/documents/src/index.ts
@@ -4,6 +4,18 @@ export type { Binder } from "./binder";
 export type { DocumentStore, DocumentRef } from "./document-store";
 export type { Issue, PathSegment, Result } from "./result";
 export { createInMemoryStore } from "./document-store";
+export { atomicTypeOfAttributeType } from "./instance/validation";
+export type { FieldPath, TableFieldIssue } from "./instance/errors";
+export type { Instance, InstanceDocument } from "./instance/instance";
+export type {
+    FieldValue,
+    InstancePath,
+    InstanceTable,
+    LiteralType,
+    LiteralValue,
+    TableHeader,
+    TableRow,
+} from "./instance/tables";
 export type { CellOf as NotebookCell, MorphismCell, ObjectCell } from "./model/cell";
 export type { ModelDocument } from "./model/document";
 export type { Notebook } from "./model/notebook";

--- a/packages/documents/src/instance/instance-runtime.ts
+++ b/packages/documents/src/instance/instance-runtime.ts
@@ -16,8 +16,8 @@ import {
 import type { FieldValue, InstancePath, InstanceTable, LiteralValue, TableRow } from "./tables";
 import { validateTableFields } from "./validation";
 
-function instanceCapableShape<S extends Shape>(
-    schema: Notebook<S, ModelDocument>,
+function instanceCapableShape<Handle, S extends Shape>(
+    schema: Notebook<S, ModelDocument, Handle>,
 ): InstanceCapableShape {
     const shape = schema.shape;
     if (shape.supportsInstances === undefined) {
@@ -31,11 +31,12 @@ function instanceCapableShape<S extends Shape>(
 `operation` is expected to report its own failures as a `Result`; this does not
 catch exceptions, so an operation that throws lets that exception propagate. */
 async function withValidatedSchema<
+    Handle,
     S extends Shape,
     T,
     E extends ReadonlyArray<Issue> = ReadonlyArray<Issue>,
 >(
-    schema: Notebook<S, ModelDocument>,
+    schema: Notebook<S, ModelDocument, Handle>,
     operation: (schemaModel: DblModel) => Result<T, E>,
 ): Promise<Result<T, E>> {
     const schemaResult = await schema.validate();
@@ -52,24 +53,27 @@ async function withValidatedSchema<
 }
 
 export function createTablesMethod<Handle, S extends Shape>(
-    schema: Notebook<S, ModelDocument>,
+    schema: Notebook<S, ModelDocument, Handle>,
     store: DocumentStore<Handle>,
     handle: Handle,
 ): () => Promise<Result<ReadonlyArray<InstanceTable>>> {
     return () =>
-        withValidatedSchema(schema, (schemaModel) => ({
-            tag: "Ok",
-            content: instanceTablesFromModel(
-                instanceCapableShape(schema),
-                store,
-                handle,
-                schemaModel,
-            ),
-        }));
+        withValidatedSchema(
+            schema,
+            (schemaModel): Result<ReadonlyArray<InstanceTable>> => ({
+                tag: "Ok",
+                content: instanceTablesFromModel(
+                    instanceCapableShape(schema),
+                    store,
+                    handle,
+                    schemaModel,
+                ),
+            }),
+        );
 }
 
 export function createGetMethod<Handle, S extends Shape>(
-    schema: Notebook<S, ModelDocument>,
+    schema: Notebook<S, ModelDocument, Handle>,
     store: DocumentStore<Handle>,
     handle: Handle,
 ): (path: InstancePath) => Promise<Result<InstanceTable | TableRow | FieldValue>> {
@@ -86,7 +90,7 @@ export function createGetMethod<Handle, S extends Shape>(
 }
 
 export function createAddRowsMethod<Handle, S extends Shape>(
-    schema: Notebook<S, ModelDocument>,
+    schema: Notebook<S, ModelDocument, Handle>,
     store: DocumentStore<Handle>,
     handle: Handle,
 ): (
@@ -126,7 +130,7 @@ export function createAddRowMethod(
 }
 
 export function createUpdateRowsMethod<Handle, S extends Shape>(
-    schema: Notebook<S, ModelDocument>,
+    schema: Notebook<S, ModelDocument, Handle>,
     store: DocumentStore<Handle>,
     handle: Handle,
 ): (
@@ -157,7 +161,7 @@ export function createUpdateRowMethod(
 }
 
 export function createSetMethod<Handle, S extends Shape>(
-    schema: Notebook<S, ModelDocument>,
+    schema: Notebook<S, ModelDocument, Handle>,
     store: DocumentStore<Handle>,
     handle: Handle,
 ): (
@@ -182,7 +186,7 @@ export function createSetMethod<Handle, S extends Shape>(
 /** Build a validator that combines schema validation with instance-content
 validation. */
 export function createSchemaResultValidator<Handle, S extends Shape>(
-    schema: Notebook<S, ModelDocument>,
+    schema: Notebook<S, ModelDocument, Handle>,
     store: DocumentStore<Handle>,
     handle: Handle,
 ): (schemaResult: Result<DblModel>) => Result<undefined, ReadonlyArray<Issue | TableFieldIssue>> {

--- a/packages/documents/src/instance/instance.ts
+++ b/packages/documents/src/instance/instance.ts
@@ -1,7 +1,21 @@
 import type { InstanceDocument } from "catcolab-document-methods";
+import type { Document } from "catcolab-document-types";
+import type { DocumentStore } from "../document-store";
+import type { ModelDocument } from "../model/document";
+import type { Notebook } from "../model/notebook";
 import type { Issue, Result } from "../result";
 import type { Shape } from "../shape";
 import type { TableFieldIssue } from "./errors";
+import {
+    createAddRowsMethod,
+    createAddRowMethod,
+    createGetMethod,
+    createSchemaResultValidator,
+    createSetMethod,
+    createTablesMethod,
+    createUpdateRowsMethod,
+    createUpdateRowMethod,
+} from "./instance-runtime";
 import type { FieldValue, InstancePath, InstanceTable, LiteralValue, TableRow } from "./tables";
 
 export type { InstanceDocument } from "catcolab-document-methods";
@@ -57,4 +71,125 @@ export interface Instance<H, S extends Shape> {
     onValidate(
         callback: (result: Result<void, ReadonlyArray<Issue | TableFieldIssue>>) => void,
     ): () => void;
+}
+
+/** Create a store-backed instance. Schema-derived operations validate the schema on demand. */
+export function instanceFromStore<Handle, S extends Shape>(
+    shape: S,
+    schema: Notebook<S, ModelDocument, Handle>,
+    store: DocumentStore<Handle>,
+    handle: Handle,
+): Instance<Handle, S> {
+    function currentDocument(): Readonly<InstanceDocument> {
+        return store.getDocumentView(handle) as Readonly<InstanceDocument>;
+    }
+
+    const tables = createTablesMethod(schema, store, handle);
+    const get = createGetMethod(schema, store, handle);
+    const addRows = createAddRowsMethod(schema, store, handle);
+    const addRow = createAddRowMethod(addRows);
+    const updateRows = createUpdateRowsMethod(schema, store, handle);
+    const updateRow = createUpdateRowMethod(updateRows);
+    const set = createSetMethod(schema, store, handle);
+    const validateSchemaResult = createSchemaResultValidator(schema, store, handle);
+
+    async function validateCurrentDocument(): Promise<
+        Result<undefined, ReadonlyArray<Issue | TableFieldIssue>>
+    > {
+        return validateSchemaResult(await schema.validate());
+    }
+
+    function deleteStoredRows(rows: ReadonlyArray<{ tableId: string; rowId: string }>): void {
+        store.changeDocument(handle, (document: Document): void => {
+            const instanceDocument: InstanceDocument = document as InstanceDocument;
+            for (const { tableId, rowId } of rows) {
+                const table: InstanceDocument["tables"][string] | undefined =
+                    instanceDocument.tables[tableId];
+                if (table === undefined) {
+                    continue;
+                }
+                delete table.rows[rowId];
+                table.rowOrder = table.rowOrder.filter(
+                    (storedRowId: string): boolean => storedRowId !== rowId,
+                );
+            }
+        });
+    }
+
+    const instance: Instance<Handle, S> = {
+        handle,
+        shape,
+        get document(): Readonly<InstanceDocument> {
+            return currentDocument();
+        },
+        get title(): string {
+            return currentDocument().name;
+        },
+        tables,
+        get,
+        update(patch: Partial<{ title: string }>): void {
+            if (patch.title !== undefined) {
+                store.changeDocument(handle, (document: Document): void => {
+                    (document as InstanceDocument).name = patch.title as string;
+                });
+            }
+        },
+        dump(): InstanceDocument {
+            return store.copyValue(handle, currentDocument());
+        },
+        addRow,
+        addRows,
+        updateRow,
+        updateRows,
+        set,
+        deleteRow(tableId: string, rowId: string): void {
+            deleteStoredRows([{ tableId, rowId }]);
+        },
+        deleteRows(rows: ReadonlyArray<{ tableId: string; rowId: string }>): void {
+            deleteStoredRows(rows);
+        },
+        validate(): Promise<Result<undefined, ReadonlyArray<Issue | TableFieldIssue>>> {
+            return validateCurrentDocument();
+        },
+        onChange(callback: () => void): () => void {
+            const unsubscribeInstance: () => void = store.subscribe(handle, callback);
+            const unsubscribeSchema: () => void = schema.onChange(callback);
+            return (): void => {
+                unsubscribeInstance();
+                unsubscribeSchema();
+            };
+        },
+        onValidate(
+            callback: (result: Result<undefined, ReadonlyArray<Issue | TableFieldIssue>>) => void,
+        ): () => void {
+            let active: boolean = true;
+
+            function notify(
+                result: Result<undefined, ReadonlyArray<Issue | TableFieldIssue>>,
+            ): void {
+                if (active) {
+                    callback(result);
+                }
+            }
+
+            async function validateAndNotify(): Promise<void> {
+                notify(await validateCurrentDocument());
+            }
+
+            const unsubscribeInstance: () => void = store.subscribe(handle, (): void => {
+                void validateAndNotify();
+            });
+            const unsubscribeSchema: () => void = schema.onValidate((result): void => {
+                notify(validateSchemaResult(result));
+            });
+
+            return (): void => {
+                active = false;
+                unsubscribeInstance();
+                unsubscribeSchema();
+            };
+        },
+    };
+
+    return instance;
 }

--- a/packages/documents/src/model/notebook.ts
+++ b/packages/documents/src/model/notebook.ts
@@ -162,10 +162,15 @@ function cellMatchesFilter<S extends Shape>(cell: CellOf<S>, filter: AnyCellType
     }
 }
 
-export interface Notebook<S extends Shape, D extends NotebookDocument = NotebookDocument> {
+export interface Notebook<
+    S extends Shape,
+    D extends NotebookDocument = NotebookDocument,
+    H = unknown,
+> {
     readonly shape: S;
     readonly document: Readonly<D>;
     readonly title: string;
+    readonly handle: H;
 
     add<T extends CellTypeOf<S>>(type: T, values: CellValuesOf<S, T>): AddedCellOf<S, T>;
     cells(): readonly CellOf<S>[];
@@ -182,7 +187,7 @@ export function modelNotebookFromStore<Handle, S extends Shape>(
     shape: S,
     store: DocumentStore<Handle>,
     handle: Handle,
-): Notebook<S, ModelDocument> {
+): Notebook<S, ModelDocument, Handle> {
     let coreTheory: Promise<DblTheory> | undefined;
 
     async function validateCurrentDocument(): Promise<Result<DblModel>> {
@@ -232,6 +237,7 @@ export function modelNotebookFromStore<Handle, S extends Shape>(
 
     return {
         shape,
+        handle,
         get document() {
             return store.getDocumentView(handle) as Readonly<ModelDocument>;
         },


### PR DESCRIPTION
*tests will come at the end of this commit stack*

This change exposes store handles on notebooks so that binders can validate schemas and form instance-of links before creating instances. This allows us to make creating instances actually possible for the first time in this stack.

Propagate the notebook handle type through existing consumers.