### PR TITLE
Make frontend test users unique

### DIFF
--- a/packages/frontend/src/api/document_editing.test.ts
+++ b/packages/frontend/src/api/document_editing.test.ts
@@ -3,15 +3,14 @@ import { type DocHandle, isValidDocumentId, Repo } from "@automerge/automerge-re
 import { BrowserWebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket";
 import type { DocInfo, UserState } from "catcolab-api/src/user_state";
 import { type FirebaseOptions, initializeApp } from "firebase/app";
-import { deleteUser, getAuth, signInWithEmailAndPassword } from "firebase/auth";
-import invariant from "tiny-invariant";
+import { deleteUser, getAuth } from "firebase/auth";
 import { v4 } from "uuid";
 import { afterAll, assert, describe, test } from "vitest";
 
 import type { ModelDocument } from "catcolab-document-methods";
 import type { Document } from "catcolab-document-types";
 import { normalizeImmutableStrings } from "../util/immutable_string";
-import { createTestDocument, initTestUserAuth } from "../util/test_util.ts";
+import { createTestDocument, createTestUserAuth } from "../util/test_util.ts";
 import { createFetchWithAuth, createRpcClient, unwrap } from "./rpc.ts";
 
 const serverUrl = import.meta.env.VITE_SERVER_URL;
@@ -43,12 +42,8 @@ const waitFor = async (
 
 describe("Document editing, snapshots, and undo/redo", async () => {
     const auth = getAuth(firebaseApp);
-    const email = "test-doc-editing@catcolab.org";
     const password = "foobar";
-    await initTestUserAuth(auth, email, password);
-
-    const user = auth.currentUser;
-    invariant(user);
+    const { user } = await createTestUserAuth(auth, "test-doc-editing", password);
 
     const createdRefs: string[] = [];
     afterAll(async () => {
@@ -111,8 +106,6 @@ describe("Document editing, snapshots, and undo/redo", async () => {
     // Autosave creates a second snapshot after edits
     // ---------------------------------------------------------------
     test.sequential("should create a new snapshot via autosave after editing", async () => {
-        await signInWithEmailAndPassword(auth, email, password);
-
         const name = `Autosave Test - ${v4()}`;
         const refId = await createDoc(name);
 
@@ -150,8 +143,6 @@ describe("Document editing, snapshots, and undo/redo", async () => {
     // Snapshot chain has correct parent/child structure
     // ---------------------------------------------------------------
     test.sequential("should have correct parent/child snapshot structure", async () => {
-        await signInWithEmailAndPassword(auth, email, password);
-
         const name = `Chain Test - ${v4()}`;
         const refId = await createDoc(name);
 
@@ -194,8 +185,6 @@ describe("Document editing, snapshots, and undo/redo", async () => {
     // load_snapshot reverts the live document content
     // ---------------------------------------------------------------
     test.sequential("should revert live document content when navigating to an older snapshot", async () => {
-        await signInWithEmailAndPassword(auth, email, password);
-
         const originalName = `Revert Original - ${v4()}`;
         const refId = await createDoc(originalName);
 
@@ -242,8 +231,6 @@ describe("Document editing, snapshots, and undo/redo", async () => {
     // load_snapshot updates the database snapshot content
     // ---------------------------------------------------------------
     test.sequential("should update document content after navigating to an older snapshot", async () => {
-        await signInWithEmailAndPassword(auth, email, password);
-
         const originalName = `DB Revert Original - ${v4()}`;
         const refId = await createDoc(originalName);
 
@@ -296,8 +283,6 @@ describe("Document editing, snapshots, and undo/redo", async () => {
     // Multiple edits → multiple snapshots → navigate history
     // ---------------------------------------------------------------
     test.sequential("should navigate through a chain of three snapshots", async () => {
-        await signInWithEmailAndPassword(auth, email, password);
-
         const name1 = `History V1 - ${v4()}`;
         const refId = await createDoc(name1);
 
@@ -376,8 +361,6 @@ describe("Document editing, snapshots, and undo/redo", async () => {
     // Undo (go to parent) and redo (go to child)
     // ---------------------------------------------------------------
     test.sequential("should undo and redo through snapshot history", async () => {
-        await signInWithEmailAndPassword(auth, email, password);
-
         const name1 = `Undo V1 - ${v4()}`;
         const refId = await createDoc(name1);
 
@@ -429,8 +412,6 @@ describe("Document editing, snapshots, and undo/redo", async () => {
     // Editing after undo creates a branch
     // ---------------------------------------------------------------
     test.sequential("should allow editing after navigating to an older snapshot", async () => {
-        await signInWithEmailAndPassword(auth, email, password);
-
         const name1 = `Branch V1 - ${v4()}`;
         const refId = await createDoc(name1);
 
@@ -482,8 +463,6 @@ describe("Document editing, snapshots, and undo/redo", async () => {
     // Content beyond just name is preserved during revert
     // ---------------------------------------------------------------
     test.sequential("should preserve full document structure when reverting snapshots", async () => {
-        await signInWithEmailAndPassword(auth, email, password);
-
         const name = `Structure Test - ${v4()}`;
         const refId = await createDoc(name);
 
@@ -548,8 +527,6 @@ describe("Document editing, snapshots, and undo/redo", async () => {
         "should not create extra snapshots when navigating to a historical snapshot",
         { timeout: 15000 },
         async () => {
-            await signInWithEmailAndPassword(auth, email, password);
-
             const name = `No Spurious Snapshot - ${v4()}`;
             const refId = await createDoc(name);
 
@@ -610,8 +587,6 @@ describe("Document editing, snapshots, and undo/redo", async () => {
         "should preserve rich text marks when navigating to a historical snapshot",
         { timeout: 15000 },
         async () => {
-            await signInWithEmailAndPassword(auth, email, password);
-
             const name = `Rich Text Marks - ${v4()}`;
             const refId = await createDoc(name);
 
@@ -709,8 +684,6 @@ describe("Document editing, snapshots, and undo/redo", async () => {
         "should not copy rich text content to other cells on redo",
         { timeout: 20000 },
         async () => {
-            await signInWithEmailAndPassword(auth, email, password);
-
             const name = `Multi Cell Redo - ${v4()}`;
             const refId = await createDoc(name);
 
@@ -845,8 +818,6 @@ describe("Document editing, snapshots, and undo/redo", async () => {
         "should preserve block markers as structural elements after undo",
         { timeout: 15000 },
         async () => {
-            await signInWithEmailAndPassword(auth, email, password);
-
             const name = `Block Markers - ${v4()}`;
             const refId = await createDoc(name);
 

--- a/packages/frontend/src/api/document_rpc.test.ts
+++ b/packages/frontend/src/api/document_rpc.test.ts
@@ -6,7 +6,7 @@ import * as uuid from "uuid";
 import { afterAll, assert, describe, test } from "vitest";
 
 import type { Document } from "catlog-wasm";
-import { createTestDocument, initTestUserAuth } from "../util/test_util.ts";
+import { createTestDocument, createTestUserAuth } from "../util/test_util.ts";
 import { createFetchWithAuth, createRpcClient, unwrap, unwrapErr } from "./rpc.ts";
 
 const serverUrl = import.meta.env.VITE_SERVER_URL;
@@ -108,12 +108,9 @@ describe("RPC for Automerge documents", async () => {
 
 describe("Authorized RPC", async () => {
     const auth = getAuth(firebaseApp);
-    const email = "test-document-rpc@catcolab.org";
     const password = "foobar";
-    await initTestUserAuth(auth, email, password);
-
-    const user = auth.currentUser;
-    afterAll(async () => user && (await deleteUser(user)));
+    const { user } = await createTestUserAuth(auth, "test-document-rpc", password);
+    afterAll(async () => await deleteUser(user));
 
     unwrap(await rpc.sign_up_or_sign_in.mutate());
 

--- a/packages/frontend/src/api/inference_rpc.test.ts
+++ b/packages/frontend/src/api/inference_rpc.test.ts
@@ -1,9 +1,9 @@
 import { type FirebaseOptions, initializeApp } from "firebase/app";
-import { deleteUser, getAuth, signInWithEmailAndPassword, signOut } from "firebase/auth";
+import { deleteUser, getAuth, signInWithEmailAndPassword, signOut, type User } from "firebase/auth";
 import invariant from "tiny-invariant";
 import { afterAll, assert, beforeAll, describe, test } from "vitest";
 
-import { initTestUserAuth } from "../util/test_util.ts";
+import { createTestUserAuth } from "../util/test_util.ts";
 import { createFetchWithAuth, createRpcClient, unwrap, unwrapErr } from "./rpc.ts";
 
 // These tests exercise the live `get_inference_key` RPC, which creates
@@ -18,18 +18,19 @@ const rpc = createRpcClient(serverUrl, createFetchWithAuth(firebaseApp));
 
 describe("RPC for inference keys", () => {
     const auth = getAuth(firebaseApp);
-    const email = "test-inference-key@catcolab.org";
     const password = "foobar";
+    let email: string;
+    let user: User | undefined;
 
     beforeAll(async () => {
-        await initTestUserAuth(auth, email, password);
+        ({ email, user } = await createTestUserAuth(auth, "test-inference-key", password));
         invariant(auth.currentUser);
         unwrap(await rpc.sign_up_or_sign_in.mutate());
     });
 
     afterAll(async () => {
-        if (auth.currentUser) {
-            await deleteUser(auth.currentUser);
+        if (user) {
+            await deleteUser(user);
         }
     });
 

--- a/packages/frontend/src/api/user_rpc.test.ts
+++ b/packages/frontend/src/api/user_rpc.test.ts
@@ -1,12 +1,11 @@
 import { isValidDocumentId } from "@automerge/automerge-repo";
 import { type FirebaseOptions, initializeApp } from "firebase/app";
 import { deleteUser, getAuth, signInWithEmailAndPassword, signOut } from "firebase/auth";
-import invariant from "tiny-invariant";
 import { v4 } from "uuid";
 import { afterAll, assert, describe, test } from "vitest";
 
 import type { UserProfile } from "catcolab-api";
-import { createTestDocument, initTestUserAuth } from "../util/test_util.ts";
+import { createTestDocument, createTestUserAuth } from "../util/test_util.ts";
 import { createFetchWithAuth, createRpcClient, unwrap, unwrapErr } from "./rpc.ts";
 
 const serverUrl = import.meta.env.VITE_SERVER_URL;
@@ -17,13 +16,10 @@ const rpc = createRpcClient(serverUrl, createFetchWithAuth(firebaseApp));
 
 describe("RPC for user profiles", async () => {
     const auth = getAuth(firebaseApp);
-    const email = "test-user-rpc@catcolab.org";
     const password = "foobar";
-    await initTestUserAuth(auth, email, password);
+    const { email, user } = await createTestUserAuth(auth, "test-user-rpc", password);
 
-    const user = auth.currentUser;
-
-    afterAll(async () => user && (await deleteUser(user)));
+    afterAll(async () => await deleteUser(user));
 
     const signUpResult = await rpc.sign_up_or_sign_in.mutate();
     test.sequential("should allow sign up when authenticated", () => {
@@ -100,12 +96,12 @@ describe("RPC for user profiles", async () => {
 describe("Sharing documents between users", async () => {
     // Set up account for the user to share with (the "sharee").
     const auth = getAuth(firebaseApp);
-    const shareeEmail = "test-user-sharee@catcolab.org";
     const password = "foobar";
-    await initTestUserAuth(auth, shareeEmail, password);
-
-    const shareeUser = auth.currentUser;
-    invariant(shareeUser);
+    const { email: shareeEmail, user: shareeUser } = await createTestUserAuth(
+        auth,
+        "test-user-sharee",
+        password,
+    );
     afterAll(async () => await deleteUser(shareeUser));
 
     unwrap(await rpc.sign_up_or_sign_in.mutate());
@@ -121,11 +117,7 @@ describe("Sharing documents between users", async () => {
     await signOut(auth);
 
     // Set up account for the user who will share the document (the "sharer").
-    const sharerEmail = "test-user-sharer@catcolab.org";
-    await initTestUserAuth(auth, sharerEmail, password);
-
-    const sharerUser = auth.currentUser;
-    invariant(sharerUser);
+    const { user: sharerUser } = await createTestUserAuth(auth, "test-user-sharer", password);
     afterAll(async () => await deleteUser(sharerUser));
 
     unwrap(await rpc.sign_up_or_sign_in.mutate());

--- a/packages/frontend/src/api/user_state.test.ts
+++ b/packages/frontend/src/api/user_state.test.ts
@@ -2,8 +2,7 @@ import { type DocHandle, isValidDocumentId, Repo } from "@automerge/automerge-re
 import { BrowserWebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket";
 import type { DocInfo, UserState } from "catcolab-api/src/user_state";
 import { type FirebaseOptions, initializeApp } from "firebase/app";
-import { deleteUser, getAuth, signInWithEmailAndPassword } from "firebase/auth";
-import invariant from "tiny-invariant";
+import { deleteUser, getAuth } from "firebase/auth";
 import { stringify as uuidStringify, v4 } from "uuid";
 import { afterAll, assert, describe, test } from "vitest";
 
@@ -11,7 +10,7 @@ import { normalizeImmutableStrings } from "../util/immutable_string";
 import {
     createChildTestDocument,
     createTestDocument,
-    initTestUserAuth,
+    createTestUserAuth,
 } from "../util/test_util.ts";
 import { createFetchWithAuth, createRpcClient, unwrap } from "./rpc.ts";
 
@@ -28,12 +27,8 @@ const repo = new Repo({
 
 describe("User state Automerge document", async () => {
     const auth = getAuth(firebaseApp);
-    const email = "test-user-state-doc@catcolab.org";
     const password = "foobar";
-    await initTestUserAuth(auth, email, password);
-
-    const user = auth.currentUser;
-    invariant(user);
+    const { user } = await createTestUserAuth(auth, "test-user-state-doc", password);
 
     const createdRefs: string[] = [];
     afterAll(async () => {
@@ -139,7 +134,6 @@ describe("User state Automerge document", async () => {
         );
 
         // Soft-delete.
-        await signInWithEmailAndPassword(auth, email, password);
         unwrap(await rpc.delete_ref.mutate(refId));
 
         await waitFor(() => {
@@ -223,8 +217,6 @@ describe("User state Automerge document", async () => {
     });
 
     test("should sync document name change via autosave", async () => {
-        await signInWithEmailAndPassword(auth, email, password);
-
         const name = `Test Autosave - ${v4()}`;
         const refId = await createDoc(name);
         await waitFor(
@@ -255,8 +247,6 @@ describe("User state Automerge document", async () => {
     });
 
     test("should switch current snapshot via load_snapshot", async () => {
-        await signInWithEmailAndPassword(auth, email, password);
-
         const name = `Test Snapshot Switch - ${v4()}`;
         const refId = await createDoc(name);
         await waitFor(

--- a/packages/frontend/src/inference/chat.test.ts
+++ b/packages/frontend/src/inference/chat.test.ts
@@ -1,10 +1,10 @@
 import { type FirebaseOptions, initializeApp } from "firebase/app";
-import { deleteUser, getAuth } from "firebase/auth";
+import { deleteUser, getAuth, type User } from "firebase/auth";
 import invariant from "tiny-invariant";
 import { afterAll, assert, beforeAll, describe, test } from "vitest";
 
 import { createFetchWithAuth, createRpcClient } from "../api/rpc.ts";
-import { initTestUserAuth } from "../util/test_util.ts";
+import { createTestUserAuth } from "../util/test_util.ts";
 import { createInferenceClient, runOpenAIChatTurn, type OpenAITranscript } from "./chat.ts";
 
 // When inference is configured, these tests exercise a live `runOpenAIChatTurn`
@@ -23,9 +23,10 @@ const testModel = "openai/gpt-oss-20b:free";
 describe("chat turn over OpenRouter", () => {
     const auth = getAuth(firebaseApp);
     let client: ReturnType<typeof createInferenceClient> | undefined;
+    let user: User | undefined;
 
     beforeAll(async () => {
-        await initTestUserAuth(auth, "test-inference-chat@catcolab.org", "foobar");
+        ({ user } = await createTestUserAuth(auth, "test-inference-chat", "foobar"));
         invariant(auth.currentUser);
 
         await rpc.sign_up_or_sign_in.mutate();
@@ -42,8 +43,8 @@ describe("chat turn over OpenRouter", () => {
     });
 
     afterAll(async () => {
-        if (auth.currentUser) {
-            await deleteUser(auth.currentUser);
+        if (user) {
+            await deleteUser(user);
         }
     });
 

--- a/packages/frontend/src/util/test_util.ts
+++ b/packages/frontend/src/util/test_util.ts
@@ -1,24 +1,14 @@
-import { FirebaseError } from "firebase/app";
-import {
-    type Auth,
-    createUserWithEmailAndPassword,
-    signInWithEmailAndPassword,
-} from "firebase/auth";
+import { type Auth, createUserWithEmailAndPassword } from "firebase/auth";
+import { v4 } from "uuid";
 
 import type { JsonValue } from "catcolab-api";
 import type { Document } from "catlog-wasm";
 
-/** Initialize a test user in Firebase auth. */
-export async function initTestUserAuth(auth: Auth, email: string, password: string) {
-    try {
-        await createUserWithEmailAndPassword(auth, email, password);
-    } catch (err) {
-        if (err instanceof FirebaseError && err.code === "auth/email-already-in-use") {
-            await signInWithEmailAndPassword(auth, email, password);
-        } else {
-            throw err;
-        }
-    }
+/** Create a Firebase user isolated from other local and CI test runs. */
+export async function createTestUserAuth(auth: Auth, label: string, password: string) {
+    const email = `${label}-${v4()}@catcolab.org`;
+    const { user } = await createUserWithEmailAndPassword(auth, email, password);
+    return { email, user };
 }
 
 /** Creates a valid test document with the given name. */


### PR DESCRIPTION
This solves some intermittent failures with frontend tests like [this run](https://github.com/ToposInstitute/CatColab/actions/runs/32509855266/job/96858171510?pr=1411). The LLM analysis of the situation:


> - This job started Vitest at 13:50:23.
> - Another CI run, 32509819873 (https://github.com/ToposInstitute/CatColab/actions/runs/32509819873), started the same integration tests at 13:50:10.
> - Both runs used hard-coded accounts such as test-doc-editing@catcolab.org and deleted them during afterAll.
> - The earlier run deleted accounts while this run was still using them, invalidating its sessions.
>
> That produced the characteristic cascade:
> - auth/user-token-expired
> - auth/invalid-credential
> - auth/too-many-requests after repeated login attempts
> - Not authorized to access ref
