### PR TITLE
Document binder for frontend

### DIFF
--- a/packages/documents/src/instance/table-methods.ts
+++ b/packages/documents/src/instance/table-methods.ts
@@ -100,13 +100,16 @@ export function addInstanceRowsToStore<Handle>(
             for (const rowValues of values) {
                 const fields = encodeFieldsByLabel(schemaTable, rowValues, issues);
                 const id = freshRowId(instanceDocument);
-                let storedTable = instanceDocument.tables[schemaTable.id];
+                const storedTable = instanceDocument.tables[schemaTable.id];
                 if (storedTable === undefined) {
-                    storedTable = { rows: {}, rowOrder: [] };
-                    instanceDocument.tables[schemaTable.id] = storedTable;
+                    instanceDocument.tables[schemaTable.id] = {
+                        rows: { [id]: { fields } },
+                        rowOrder: [id],
+                    };
+                } else {
+                    storedTable.rows[id] = { fields };
+                    storedTable.rowOrder.push(id);
                 }
-                storedTable.rows[id] = { fields };
-                storedTable.rowOrder.push(id);
                 addedRows.push({ schemaTable, id });
             }
         }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -51,6 +51,7 @@
         "catcolab-document-methods": "link:../document-methods",
         "catcolab-document-types": "link:../document-types/pkg",
         "catcolab-documents": "link:../documents",
+        "catcolab-logics": "link:../logics",
         "catcolab-ui-components": "link:../ui-components",
         "catlog-wasm": "link:../catlog-wasm/dist/pkg-browser",
         "echarts": "^6.1.0",

--- a/packages/frontend/pnpm-lock.yaml
+++ b/packages/frontend/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       catcolab-documents:
         specifier: link:../documents
         version: link:../documents
+      catcolab-logics:
+        specifier: link:../logics
+        version: link:../logics
       catcolab-ui-components:
         specifier: link:../ui-components
         version: link:../ui-components

--- a/packages/frontend/pnpm-lock.yaml
+++ b/packages/frontend/pnpm-lock.yaml
@@ -189,9 +189,6 @@ importers:
       '@types/node':
         specifier: ^24.0.0
         version: 24.10.0
-      catcolab-logics:
-        specifier: link:../logics
-        version: link:../logics
       eslint-plugin-solid:
         specifier: ^0.14.5
         version: 0.14.5(eslint@9.39.4)(typescript@6.0.3)

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -10,7 +10,7 @@ import invariant from "tiny-invariant";
 import * as uuid from "uuid";
 
 import { Button } from "catcolab-ui-components";
-import { Api, ApiContext, useApi } from "./api";
+import { Api, ApiContext, BinderContext, createApiBinder, useApi } from "./api";
 import { helpRoutes } from "./help/routes";
 import { createModelLibraryWithApi, ModelLibraryContext } from "./model";
 import { createModel } from "./model/document";
@@ -45,12 +45,14 @@ const Root = (props: RouteSectionProps) => {
 
     const theories = stdTheories;
     const models = createModelLibraryWithApi(api, theories);
+    const binder = createApiBinder(api);
 
     return (
         <FirebaseProvider app={firebaseApp}>
             <MultiProvider
                 values={[
                     [ApiContext, api],
+                    [BinderContext, binder],
                     [TheoryLibraryContext, theories],
                     [ModelLibraryContext, models],
                     UserStateProvider,
@@ -129,9 +131,10 @@ const routes: RouteDefinition[] = [
     {
         path: "/:kind/:ref/:subkind?/:subref?",
         matchFilters: {
-            kind: ["model", "diagram", "analysis"],
+            kind: ["model", "diagram", "analysis", "instance"],
             ref: refIsUUIDFilter.ref,
-            subkind: (v?: string) => !v || v === "analysis" || v === "diagram" || v === "model",
+            subkind: (v?: string) =>
+                !v || v === "analysis" || v === "diagram" || v === "instance" || v === "model",
             subref: (v?: string) => !v || refIsUUIDFilter.ref(v),
         },
         component: lazy(() => import("./page/document_page")),

--- a/packages/frontend/src/api/context.ts
+++ b/packages/frontend/src/api/context.ts
@@ -1,6 +1,7 @@
 import { createContext, useContext } from "solid-js";
 import invariant from "tiny-invariant";
 
+import type { ApiBinder } from "./document_store";
 import type { Api } from "./types";
 
 /** Context for the CatColab API. */
@@ -11,4 +12,14 @@ export function useApi(): Api {
     const api = useContext(ApiContext);
     invariant(api, "CatColab API should be provided as context");
     return api;
+}
+
+/** Context for the binder shared by the application. */
+export const BinderContext = createContext<ApiBinder>();
+
+/** Retrieve the shared binder from application context. */
+export function useBinder(): ApiBinder {
+    const binder = useContext(BinderContext);
+    invariant(binder, "Binder should be provided as context");
+    return binder;
 }

--- a/packages/frontend/src/api/document_store.test.ts
+++ b/packages/frontend/src/api/document_store.test.ts
@@ -1,0 +1,140 @@
+import { Repo } from "@automerge/automerge-repo";
+import { SimpleOlog, Type } from "catcolab-logics/simple-olog";
+import { describe, expect, test } from "vitest";
+
+import { Instance as LegacyInstance, Model } from "catcolab-document-methods";
+import { createBinder, defineShape, type InstanceDocument } from "catcolab-documents";
+import { makeLiveDoc } from "./document";
+import { createApiDocumentStore } from "./document_store";
+import type { Api } from "./types";
+
+const schemaRef = "schema-ref";
+const instanceRef = "instance-ref";
+const server = "test.catcolab.org";
+
+function createFixture() {
+    const repo = new Repo();
+    const schemaAutomergeHandle = repo.create(Model.newModelDocument({ theory: "simple-olog" }));
+    const instanceAutomergeHandle = repo.create(
+        LegacyInstance.newInstanceDocument({
+            _id: schemaRef,
+            _version: null,
+            _server: server,
+        }),
+    );
+    const instanceLiveDoc = makeLiveDoc<InstanceDocument>(instanceAutomergeHandle);
+    const api = {
+        serverHost: server,
+        async getDocHandle(refId: string) {
+            if (refId === schemaRef) {
+                return schemaAutomergeHandle;
+            }
+            if (refId === instanceRef) {
+                return instanceAutomergeHandle;
+            }
+            throw new Error(`Unknown document ref: ${refId}`);
+        },
+    } as unknown as Api;
+    const store = createApiDocumentStore(api);
+
+    return {
+        binder: createBinder(store),
+        instanceLiveDoc,
+        schemaAutomergeHandle,
+        store,
+    };
+}
+
+async function createFixtureWithSchema() {
+    const fixture = createFixture();
+    const schema = await fixture.binder.loadNotebookFromRef(SimpleOlog, {
+        id: schemaRef,
+        version: null,
+        server,
+    });
+    expect(schema.tag).toBe("Ok");
+    if (schema.tag !== "Ok") {
+        throw new Error("expected schema to load");
+    }
+
+    return { ...fixture, schema: schema.content };
+}
+
+describe("API document store", () => {
+    test("binds instance mutations to existing Automerge handles", async () => {
+        const { binder, instanceLiveDoc, schema } = await createFixtureWithSchema();
+        schema.add(Type, { label: "Person" });
+
+        const instance = await binder.loadInstanceFromRef(schema, {
+            id: instanceRef,
+            version: null,
+            server,
+        });
+        expect(instance.tag).toBe("Ok");
+        if (instance.tag !== "Ok") {
+            throw new Error("expected instance to load");
+        }
+
+        const tables = await instance.content.tables();
+        expect(tables.tag).toBe("Ok");
+        if (tables.tag !== "Ok") {
+            throw new Error("expected tables to load");
+        }
+        const table = tables.content.find((table) => table.label === "Person");
+        expect(table).toBeDefined();
+        if (!table) {
+            throw new Error("expected entity table");
+        }
+        const added = await instance.content.addRow(table);
+        expect(added.tag).toBe("Ok");
+        // Tables are stored as a record keyed by the schema entity's UUID,
+        // each with its rows keyed by row UUID alongside an ordering.
+        expect(Object.keys(instanceLiveDoc.doc.tables)).toHaveLength(1);
+        const storedTable = instanceLiveDoc.doc.tables[table.id];
+        expect(storedTable?.rowOrder).toHaveLength(1);
+        expect(Object.keys(storedTable?.rows ?? {})).toHaveLength(1);
+    });
+
+    test("rejects a document with the wrong type", async () => {
+        const { binder, schema } = await createFixtureWithSchema();
+
+        const wrongType = await binder.loadInstanceFromRef(schema, {
+            id: schemaRef,
+            version: null,
+            server,
+        });
+
+        expect(wrongType).toMatchObject({ tag: "Err", content: [{ path: ["type"] }] });
+    });
+
+    test("rejects instances of unsupported schema shapes", async () => {
+        const { binder } = createFixture();
+
+        const unsupportedSchema = await binder.loadNotebookFromRef(
+            defineShape({ theory: "simple-olog" }),
+            { id: schemaRef, version: null, server },
+        );
+        expect(unsupportedSchema.tag).toBe("Ok");
+        if (unsupportedSchema.tag === "Err") {
+            throw new Error("expected unsupported schema to load as a notebook");
+        }
+        const unsupported = await binder.loadInstanceFromRef(unsupportedSchema.content, {
+            id: instanceRef,
+            version: null,
+            server,
+        });
+        expect(unsupported).toMatchObject({ tag: "Err" });
+    });
+
+    test("resolves local refs to canonical cached handles", async () => {
+        const { schemaAutomergeHandle, store } = createFixture();
+
+        const local = await store.getHandle({ id: schemaRef, version: null });
+        expect(local.tag).toBe("Ok");
+        if (local.tag === "Err") {
+            throw new Error("expected local ref to resolve");
+        }
+        expect(local.content.automergeHandle).toBe(schemaAutomergeHandle);
+        expect(local.content.ref.server).toBe(server);
+    });
+});

--- a/packages/frontend/src/api/document_store.ts
+++ b/packages/frontend/src/api/document_store.ts
@@ -1,0 +1,118 @@
+import { getBackend, getObjectId } from "@automerge/automerge";
+import type { DocHandle } from "@automerge/automerge-repo";
+
+import type { Document } from "catcolab-document-types";
+import {
+    type Binder,
+    createBinder,
+    type DocumentRef,
+    type DocumentStore,
+    type Result,
+} from "catcolab-documents";
+import type { Api } from "./types";
+
+export type ApiDocumentHandle = {
+    automergeHandle: DocHandle<Document>;
+    ref: DocumentRef;
+};
+
+export type ApiDocumentStore = DocumentStore<ApiDocumentHandle>;
+
+/** A binder over the API document store. */
+export type ApiBinder = Binder<ApiDocumentHandle>;
+
+/** Create a binder over the document store for an API client.
+
+The binder should be created once per API client and shared across the
+application (via context) so that document handles are cached and deduplicated
+between loads.
+ */
+export function createApiBinder(api: Api): ApiBinder {
+    return createBinder(createApiDocumentStore(api));
+}
+
+/** Adapt frontend Automerge documents to the storage boundary used by catcolab-documents. */
+export function createApiDocumentStore(api: Api): ApiDocumentStore {
+    const handles = new Map<string, ApiDocumentHandle>();
+
+    const cacheHandle = (ref: DocumentRef, automergeHandle: DocHandle<Document>) => {
+        const existing = handles.get(ref.id);
+        if (existing) {
+            existing.ref = ref;
+            return existing;
+        }
+        const handle = { automergeHandle, ref };
+        handles.set(ref.id, handle);
+        return handle;
+    };
+
+    return {
+        async createHandle(initialDoc) {
+            const refId = await api.createDoc(initialDoc);
+            const automergeHandle = await api.getDocHandle(refId);
+            return cacheHandle(
+                { id: refId, version: null, server: api.serverHost },
+                automergeHandle,
+            );
+        },
+        getDocumentView: (handle) => handle.automergeHandle.doc(),
+        changeDocument: (handle, fn) => handle.automergeHandle.change(fn),
+        subscribe: (handle, callback) => {
+            handle.automergeHandle.on("change", callback);
+            return () => handle.automergeHandle.off("change", callback);
+        },
+        copyValue: (handle, value) => {
+            if (typeof value !== "object" || value === null) {
+                return value;
+            }
+            const objectId = getObjectId(value);
+            if (!objectId) {
+                return structuredClone(value);
+            }
+            return getBackend(handle.automergeHandle.doc()).materialize(objectId) as typeof value;
+        },
+        getDocumentRef: (handle) => handle.ref,
+        async getHandle(ref: DocumentRef): Promise<Result<ApiDocumentHandle>> {
+            if (ref.version !== null) {
+                return {
+                    tag: "Err",
+                    content: [
+                        { message: "Pinned document refs are not supported.", path: ["version"] },
+                    ],
+                };
+            }
+            if (ref.server && ref.server !== api.serverHost) {
+                return {
+                    tag: "Err",
+                    content: [
+                        {
+                            message: `Cannot resolve a document on server "${ref.server}".`,
+                            path: ["server"],
+                        },
+                    ],
+                };
+            }
+            const canonicalRef = { ...ref, server: ref.server || api.serverHost };
+
+            const cached = handles.get(ref.id);
+            if (cached) {
+                cached.ref = canonicalRef;
+                return { tag: "Ok", content: cached };
+            }
+            try {
+                const automergeHandle = await api.getDocHandle(ref.id);
+                return { tag: "Ok", content: cacheHandle(canonicalRef, automergeHandle) };
+            } catch (error) {
+                return {
+                    tag: "Err",
+                    content: [
+                        {
+                            message: error instanceof Error ? error.message : String(error),
+                            path: ["id"],
+                        },
+                    ],
+                };
+            }
+        },
+    };
+}

--- a/packages/frontend/src/api/index.ts
+++ b/packages/frontend/src/api/index.ts
@@ -1,4 +1,5 @@
 export * from "./context";
 export * from "./document";
+export * from "./document_store";
 export * from "./rpc";
 export * from "./types";

--- a/packages/frontend/src/instance/instance_editor.module.css
+++ b/packages/frontend/src/instance/instance_editor.module.css
@@ -1,0 +1,3 @@
+.editor {
+    padding: 1rem;
+}

--- a/packages/frontend/src/instance/instance_editor.tsx
+++ b/packages/frontend/src/instance/instance_editor.tsx
@@ -1,0 +1,12 @@
+import type { ApiInstance } from "./live_doc_compatibility";
+
+import styles from "./instance_editor.module.css";
+
+/** Placeholder editor for the data instance of a model. */
+export function InstanceEditor(_props: { instance: ApiInstance }) {
+    return (
+        <div class={styles.editor}>
+            <a href="http://textfiles.com/underconstruction/">🚧 UNDER CONSTRUCTION 🚧</a>
+        </div>
+    );
+}

--- a/packages/frontend/src/instance/instance_info.tsx
+++ b/packages/frontend/src/instance/instance_info.tsx
@@ -1,0 +1,19 @@
+import { A } from "@solidjs/router";
+
+import type { LiveInstanceDoc } from "./live_doc_compatibility";
+
+/** Parent model link shown in an instance document head. */
+export function InstanceInfo(props: { liveInstance: LiveInstanceDoc }) {
+    const modelRefId = () => props.liveInstance.instance.document.instanceOf._id;
+
+    return (
+        <>
+            <div class="name">Data instance of</div>
+            <div class="model">
+                <A href={`/model/${modelRefId()}`}>
+                    {props.liveInstance.modelLiveDoc.doc.name || "Untitled"}
+                </A>
+            </div>
+        </>
+    );
+}

--- a/packages/frontend/src/instance/live_doc_compatibility.ts
+++ b/packages/frontend/src/instance/live_doc_compatibility.ts
@@ -1,0 +1,92 @@
+import { SimpleOlog } from "catcolab-logics/simple-olog";
+import { SimpleSchema } from "catcolab-logics/simple-schema";
+
+import type { Instance, InstanceDocument } from "catcolab-documents";
+import type { Api, ApiBinder, ApiDocumentHandle, DocRef, LiveDoc } from "../api";
+import type { LiveModelDoc, ModelLibrary } from "../model";
+
+/** Shapes whose models can have data instances. */
+const instanceShapes = [SimpleOlog, SimpleSchema] as const;
+type SupportedInstanceShape = (typeof instanceShapes)[number];
+export type ApiInstance = Instance<ApiDocumentHandle, SupportedInstanceShape>;
+
+/** An instance document "live" for compatibility with existing container components.
+
+A facade over the catcolab-documents {@link Instance} API that structurally matches
+the other `Live*Doc` types, so that generic UI (toolbar, sidebar, breadcrumbs,
+document head, permissions) can consume it uniformly. The instance itself
+remains the source of truth: `liveDoc` is derived from its document handle.
+ */
+export type LiveInstanceDoc = {
+    /** Tag for use in tagged unions of document types. */
+    type: "instance";
+
+    /** Live document containing the instance data. */
+    liveDoc: LiveDoc<InstanceDocument>;
+
+    /** The catcolab-documents instance object, consumed by new components. */
+    instance: ApiInstance;
+
+    /** Canonical live schema document used by document chrome. */
+    modelLiveDoc: LiveModelDoc["liveDoc"];
+};
+
+/** Look up the shape for a theory that supports data instances, if any. */
+export function shapeForTheory(theory?: string) {
+    return instanceShapes.find((shape) => shape.theory === theory);
+}
+
+function enlivenInstance(
+    instance: ApiInstance,
+    liveDoc: LiveDoc<InstanceDocument>,
+    modelLiveDoc: LiveModelDoc["liveDoc"],
+): LiveInstanceDoc {
+    return {
+        type: "instance",
+        liveDoc,
+        instance,
+        modelLiveDoc,
+    };
+}
+
+export async function getLiveInstance(
+    refId: string,
+    api: Api,
+    models: ModelLibrary<string>,
+    binder: ApiBinder,
+): Promise<{ liveInstance: LiveInstanceDoc; docRef: DocRef }> {
+    const { liveDoc, docRef } = await api.getLiveDoc<InstanceDocument>(refId, "instance");
+    const modelRef = {
+        id: liveDoc.doc.instanceOf._id,
+        version: liveDoc.doc.instanceOf._version,
+        server: liveDoc.doc.instanceOf._server,
+    };
+    if (modelRef.version !== null || modelRef.server !== api.serverHost) {
+        throw new Error("Data instances require a live model on the current server.");
+    }
+    const liveModel = await models.getLiveModel(liveDoc.doc.instanceOf._id);
+
+    const shape = shapeForTheory(liveModel.liveDoc.doc.theory);
+    if (!shape) {
+        throw new Error(
+            `Data instances are not supported for theory "${liveModel.liveDoc.doc.theory}".`,
+        );
+    }
+    const model = await binder.loadNotebookFromRef(shape, modelRef);
+    if (model.tag === "Err") {
+        throw new Error(model.content.map((issue) => issue.message).join("\n"));
+    }
+    const instance = await binder.loadInstanceFromRef(model.content, {
+        id: refId,
+        version: null,
+        server: api.serverHost,
+    });
+    if (instance.tag === "Err") {
+        throw new Error(instance.content.map((issue) => issue.message).join("\n"));
+    }
+
+    return {
+        liveInstance: enlivenInstance(instance.content, liveDoc, liveModel.liveDoc),
+        docRef,
+    };
+}

--- a/packages/frontend/src/page/document_page.tsx
+++ b/packages/frontend/src/page/document_page.tsx
@@ -32,10 +32,21 @@ import {
 import { getLiveAnalysis, type LiveAnalysisDoc } from "../analysis";
 import { AnalysisNotebookEditor } from "../analysis/analysis_editor";
 import { AnalysisInfo } from "../analysis/analysis_info";
-import { type Api, type DocRef, type DocumentType, documentTypeLabel, useApi } from "../api";
+import {
+    type Api,
+    type ApiBinder,
+    type DocRef,
+    type DocumentType,
+    documentTypeLabel,
+    useApi,
+    useBinder,
+} from "../api";
 import { getLiveDiagram, type LiveDiagramDoc } from "../diagram";
 import { DiagramNotebookEditor } from "../diagram/diagram_editor";
 import { DiagramInfo } from "../diagram/diagram_info";
+import { InstanceEditor } from "../instance/instance_editor";
+import { InstanceInfo } from "../instance/instance_info";
+import { getLiveInstance, type LiveInstanceDoc } from "../instance/live_doc_compatibility";
 import { type LiveModelDoc, type ModelLibrary, ModelLibraryContext } from "../model";
 import { ModelNotebookEditor } from "../model/model_editor";
 import { ModelDocumentHead } from "../model/model_info";
@@ -51,7 +62,7 @@ import { useSnapshotHistory } from "./use_snapshot_history";
 
 import "./document_page.css";
 
-type AnyLiveDoc = LiveModelDoc | LiveDiagramDoc | LiveAnalysisDoc;
+type AnyLiveDoc = LiveModelDoc | LiveDiagramDoc | LiveAnalysisDoc | LiveInstanceDoc;
 
 /** A Live*Document bundled with its backend DocRef.
  *
@@ -68,6 +79,7 @@ const INITIAL_SPLIT_SIZE = 0.5;
 
 export default function DocumentPage() {
     const api = useApi();
+    const binder = useBinder();
     const models = useContext(ModelLibraryContext);
     invariant(models, "Must provide model library as context to page");
 
@@ -85,7 +97,7 @@ export default function DocumentPage() {
 
     const [primaryLiveDoc, { refetch: refetchPrimaryDoc }] = createResource(
         () => params.ref,
-        (refId) => getLiveDocument(refId, api, models, params.kind as DocumentType),
+        (refId) => getLiveDocument(refId, api, models, binder, params.kind as DocumentType),
     );
 
     const [secondaryLiveDoc, { refetch: refetchSecondaryDoc }] = createResource(
@@ -108,7 +120,7 @@ export default function DocumentPage() {
                 return undefined;
             }
 
-            return getLiveDocument(source.ref, api, models, source.kind as DocumentType);
+            return getLiveDocument(source.ref, api, models, binder, source.kind as DocumentType);
         },
     );
 
@@ -512,6 +524,13 @@ export function DocumentPane(props: {
                                     </DocumentHead>
                                 )}
                             </Match>
+                            <Match keyed when={props.doc.type === "instance" && props.doc}>
+                                {(liveInstance) => (
+                                    <DocumentHead liveDoc={liveInstance.liveDoc}>
+                                        <InstanceInfo liveInstance={liveInstance} />
+                                    </DocumentHead>
+                                )}
+                            </Match>
                         </Switch>
                         <Switch>
                             <Match keyed when={props.doc.type === "model" && props.doc}>
@@ -538,6 +557,11 @@ export function DocumentPane(props: {
                                     />
                                 )}
                             </Match>
+                            <Match keyed when={props.doc.type === "instance" && props.doc}>
+                                {(liveInstance) => (
+                                    <InstanceEditor instance={liveInstance.instance} />
+                                )}
+                            </Match>
                         </Switch>
                     </div>
                 </div>
@@ -555,6 +579,7 @@ async function getLiveDocument(
     refId: string,
     api: Api,
     models: ModelLibrary<string>,
+    binder: ApiBinder,
     documentType: DocumentType,
 ): Promise<AnyLiveDocWithRef> {
     switch (documentType) {
@@ -571,8 +596,10 @@ async function getLiveDocument(
             const { liveAnalysis, docRef } = await getLiveAnalysis(refId, api, models);
             return { liveDoc: liveAnalysis, docRef };
         }
-        case "instance":
-            throw new Error("Instance documents are not supported by the frontend");
+        case "instance": {
+            const { liveInstance, docRef } = await getLiveInstance(refId, api, models, binder);
+            return { liveDoc: liveInstance, docRef };
+        }
         case "llmconversation":
             throw new Error("LLM conversation pages are not implemented");
         default:

--- a/packages/frontend/src/page/document_page_sidebar.tsx
+++ b/packages/frontend/src/page/document_page_sidebar.tsx
@@ -51,6 +51,9 @@ async function getDocParent(doc: Document, api: Api): Promise<LiveDocWithRef | u
         case "analysis":
             parentLink = doc.analysisOf;
             break;
+        case "instance":
+            parentLink = doc.instanceOf;
+            break;
         case "llmconversation":
             parentLink = doc.llmConversationOf;
             break;
@@ -124,6 +127,7 @@ function DocumentsTreeNode(props: {
                 .filter(
                     (relation) =>
                         relation.relationType === "diagram-in" ||
+                        relation.relationType === "instance-of" ||
                         relation.relationType === "analysis-of" ||
                         relation.relationType === "llmconversation-of",
                 )


### PR DESCRIPTION
This adds an Automerge+our-backend binder for our frontend and a context for it. This does not yet have a fine-grained reactive view of the document. 

This also wires the instance document type through to everywhere, including some compatibility with the existing `liveDoc` way of doing things.

There was one place that revealed that doing things a normal JS way doesn't necessarily work with the Automerge proxy. 