### PR TITLE
OBEE-41 scaffolding for LLMConversation pages

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -131,10 +131,15 @@ const routes: RouteDefinition[] = [
     {
         path: "/:kind/:ref/:subkind?/:subref?",
         matchFilters: {
-            kind: ["model", "diagram", "analysis", "instance"],
+            kind: ["model", "diagram", "analysis", "instance", "llmconversation"],
             ref: refIsUUIDFilter.ref,
             subkind: (v?: string) =>
-                !v || v === "analysis" || v === "diagram" || v === "instance" || v === "model",
+                !v ||
+                v === "analysis" ||
+                v === "diagram" ||
+                v === "instance" ||
+                v === "model" ||
+                v === "llmconversation",
             subref: (v?: string) => !v || refIsUUIDFilter.ref(v),
         },
         component: lazy(() => import("./page/document_page")),

--- a/packages/frontend/src/instance/live_doc_compatibility.ts
+++ b/packages/frontend/src/instance/live_doc_compatibility.ts
@@ -1,13 +1,11 @@
-import { SimpleOlog } from "catcolab-logics/simple-olog";
-import { SimpleSchema } from "catcolab-logics/simple-schema";
-
 import type { Instance, InstanceDocument } from "catcolab-documents";
 import type { Api, ApiBinder, ApiDocumentHandle, DocRef, LiveDoc } from "../api";
 import type { LiveModelDoc, ModelLibrary } from "../model";
+import { instanceShapes, shapeForTheory as shapeForTheoryIn } from "../model/shapes";
 
-/** Shapes whose models can have data instances. */
-const instanceShapes = [SimpleOlog, SimpleSchema] as const;
 type SupportedInstanceShape = (typeof instanceShapes)[number];
+
+/** An instance loaded through a frontend document binder. */
 export type ApiInstance = Instance<ApiDocumentHandle, SupportedInstanceShape>;
 
 /** An instance document "live" for compatibility with existing container components.
@@ -33,7 +31,7 @@ export type LiveInstanceDoc = {
 
 /** Look up the shape for a theory that supports data instances, if any. */
 export function shapeForTheory(theory?: string) {
-    return instanceShapes.find((shape) => shape.theory === theory);
+    return shapeForTheoryIn(instanceShapes, theory);
 }
 
 function enlivenInstance(

--- a/packages/frontend/src/llm_conversation/conversation_editor_stub.module.css
+++ b/packages/frontend/src/llm_conversation/conversation_editor_stub.module.css
@@ -1,0 +1,3 @@
+.editor {
+    padding: 1rem;
+}

--- a/packages/frontend/src/llm_conversation/conversation_editor_stub.tsx
+++ b/packages/frontend/src/llm_conversation/conversation_editor_stub.tsx
@@ -1,0 +1,10 @@
+import styles from "./conversation_editor_stub.module.css";
+
+/** Placeholder editor for an LLM conversation. */
+export function LLMConversationEditorStub() {
+    return (
+        <div class={styles.editor}>
+            <a href="http://textfiles.com/underconstruction/">🚧 UNDER CONSTRUCTION 🚧</a>
+        </div>
+    );
+}

--- a/packages/frontend/src/llm_conversation/index.ts
+++ b/packages/frontend/src/llm_conversation/index.ts
@@ -1,0 +1,3 @@
+export * from "./conversation_editor_stub";
+export * from "./document";
+export * from "./live_doc_compatibility";

--- a/packages/frontend/src/llm_conversation/live_doc_compatibility.ts
+++ b/packages/frontend/src/llm_conversation/live_doc_compatibility.ts
@@ -1,0 +1,137 @@
+import type { Document } from "catcolab-document-types";
+import type {
+    DocumentRef,
+    LLMConversation as LLMConversationAPI,
+    LLMConversationAttachment,
+    LLMConversationDocument,
+    Shape,
+} from "catcolab-documents";
+import { llmConversationFromStore } from "catcolab-documents";
+import type { Api, ApiBinder, ApiDocumentHandle, ApiDocumentStore, DocRef, LiveDoc } from "../api";
+import type { LiveModelDoc, ModelLibrary } from "../model";
+import { notebookShapes, shapeForTheory } from "../model/shapes";
+
+/**
+ * Live*Doc compatibility and binder loading for LLM conversations, following
+ * `instance/live_doc_compatibility.ts`; see that module for the details of the
+ * pattern. Differences: the attachment may be a model notebook or a data
+ * instance, and the facade carries the conversation object and its backing
+ * store, the seam used by the conversation editor.
+ */
+
+export type ApiLLMConversationAttachment = LLMConversationAttachment<Shape, ApiDocumentHandle>;
+
+export type ApiLLMConversation = LLMConversationAPI<
+    ApiLLMConversationAttachment,
+    ApiDocumentHandle
+>;
+
+export type LiveLLMConversationDoc = {
+    type: "llmconversation";
+    liveDoc: LiveDoc<LLMConversationDocument>;
+    conversation: ApiLLMConversation;
+    attachment: ApiLLMConversationAttachment;
+    store: ApiDocumentStore;
+    modelLiveDoc: LiveModelDoc["liveDoc"];
+};
+
+async function getHandle(binder: ApiBinder, ref: DocumentRef) {
+    const result = await binder.store.getHandle(ref);
+    if (result.tag === "Err") {
+        throw new Error(result.content.map((issue) => issue.message).join("\n"));
+    }
+    return result.content;
+}
+
+async function loadNotebook(api: Api, binder: ApiBinder, modelRefId: string) {
+    const ref = { id: modelRefId, version: null, server: api.serverHost };
+    const handle = await getHandle(binder, ref);
+    const document = binder.store.getDocumentView(handle);
+    if (document.type !== "model") {
+        throw new Error(`Cannot load document of type "${document.type}" as a model notebook.`);
+    }
+    const shape = shapeForTheory(notebookShapes, document.theory);
+    if (!shape) {
+        throw new Error(`LLM conversations are not supported for theory "${document.theory}".`);
+    }
+    const notebook = await binder.loadNotebookFromRef(shape, ref);
+    if (notebook.tag === "Err") {
+        throw new Error(notebook.content.map((issue) => issue.message).join("\n"));
+    }
+    return notebook.content;
+}
+
+async function loadAttachment(
+    api: Api,
+    binder: ApiBinder,
+    attachmentRef: DocumentRef,
+): Promise<{ attachment: ApiLLMConversationAttachment; modelRefId: string }> {
+    const handle = await getHandle(binder, attachmentRef);
+    const document: Document = binder.store.getDocumentView(handle);
+
+    if (document.type === "model") {
+        const attachment = await loadNotebook(api, binder, attachmentRef.id);
+        return { attachment, modelRefId: attachmentRef.id };
+    }
+    if (document.type === "instance") {
+        const modelRefId = document.instanceOf._id;
+        const schema = await loadNotebook(api, binder, modelRefId);
+        const instance = await binder.loadInstanceFromRef(schema, attachmentRef);
+        if (instance.tag === "Err") {
+            throw new Error(instance.content.map((issue) => issue.message).join("\n"));
+        }
+        return { attachment: instance.content, modelRefId };
+    }
+    throw new Error(`Cannot attach an LLM conversation to a "${document.type}" document.`);
+}
+
+export async function getLiveLLMConversation(
+    refId: string,
+    api: Api,
+    models: ModelLibrary<string>,
+    binder: ApiBinder,
+): Promise<{ liveConversation: LiveLLMConversationDoc; docRef: DocRef }> {
+    const { liveDoc, docRef } = await api.getLiveDoc<LLMConversationDocument>(
+        refId,
+        "llmconversation",
+    );
+    const of = liveDoc.doc.llmConversationOf;
+    if (of._version !== null || of._server !== api.serverHost) {
+        throw new Error("LLM conversations require a live attachment on the current server.");
+    }
+    const attachmentRef = { id: of._id, version: null, server: api.serverHost };
+
+    const { attachment, modelRefId } = await loadAttachment(api, binder, attachmentRef);
+    const liveModel = await models.getLiveModel(modelRefId);
+    const conversationHandle = await getHandle(binder, {
+        id: refId,
+        version: null,
+        server: api.serverHost,
+    });
+    const conversation = llmConversationFromStore(binder.store, conversationHandle, attachment);
+
+    return {
+        liveConversation: {
+            type: "llmconversation",
+            liveDoc,
+            conversation,
+            attachment,
+            store: binder.store,
+            modelLiveDoc: liveModel.liveDoc,
+        },
+        docRef,
+    };
+}
+
+export async function createLLMConversation(
+    api: Api,
+    binder: ApiBinder,
+    modelRefId: string,
+    llmModel: string,
+): Promise<string> {
+    const attachment = await loadNotebook(api, binder, modelRefId);
+    const conversation = await binder.createLLMConversation(attachment, llmModel, {
+        title: "",
+    });
+    return conversation.handle.ref.id;
+}

--- a/packages/frontend/src/model/shapes.ts
+++ b/packages/frontend/src/model/shapes.ts
@@ -1,0 +1,29 @@
+import { PetriNet } from "catcolab-logics/petri-net";
+import { SimpleOlog } from "catcolab-logics/simple-olog";
+import { SimpleSchema } from "catcolab-logics/simple-schema";
+
+/**
+ * Which theories the frontend can load through a document binder, and the
+ * shapes it uses to load them.
+ */
+import type { ModelDocument, Notebook, Shape } from "catcolab-documents";
+import type { ApiDocumentHandle } from "../api";
+
+/** Shapes of model notebooks that can be loaded through a document binder. */
+export const notebookShapes = [SimpleOlog, SimpleSchema, PetriNet] as const;
+
+type NotebookShape = (typeof notebookShapes)[number];
+
+/** A model notebook loaded through a frontend document binder. */
+export type ApiNotebook = Notebook<NotebookShape, ModelDocument, ApiDocumentHandle>;
+
+/** Shapes whose models can have data instances. */
+export const instanceShapes = [SimpleOlog, SimpleSchema] as const;
+
+/** Look up the shape for a theory among the given shapes, if any. */
+export function shapeForTheory<ShapeType extends Shape & { theory: string }>(
+    shapes: ReadonlyArray<ShapeType>,
+    theory?: string,
+): ShapeType | undefined {
+    return shapes.find((shape) => shape.theory === theory);
+}

--- a/packages/frontend/src/page/document_menu.tsx
+++ b/packages/frontend/src/page/document_menu.tsx
@@ -6,8 +6,10 @@ import invariant from "tiny-invariant";
 
 import { DocumentTypeIcon, IconButton } from "catcolab-ui-components";
 import { createAnalysis } from "../analysis";
-import { type DocRef, type DocumentType, type LiveDoc, useApi } from "../api";
+import { type DocRef, type DocumentType, type LiveDoc, useApi, useBinder } from "../api";
 import { createDiagram } from "../diagram";
+import { DEFAULT_LLM_MODEL } from "../inference/chat";
+import { createLLMConversation } from "../llm_conversation";
 import {
     CopyJSONMenuItem,
     DeleteMenuItem,
@@ -19,6 +21,7 @@ import {
     RestoreMenuItem,
 } from "../page";
 import { TheoryLibraryContext } from "../theory";
+import { isDocumentVisible, useUserSettings } from "../user/user_settings";
 
 export function DocumentMenu(props: {
     liveDoc: LiveDoc;
@@ -27,6 +30,8 @@ export function DocumentMenu(props: {
     onDocDeleted?: () => void;
 }) {
     const api = useApi();
+    const binder = useBinder();
+    const { settings } = useUserSettings();
 
     const navigate = useNavigate();
     const docType = () => props.liveDoc.doc.type;
@@ -69,6 +74,21 @@ export function DocumentMenu(props: {
         handleDocCreated("analysis", newRef);
     };
 
+    const canCreateLLMConversation = () =>
+        props.liveDoc.doc.type === "model" &&
+        isDocumentVisible({ typeName: "llmconversation" }, settings());
+
+    const onNewLLMConversation = async () => {
+        invariant(canCreateLLMConversation(), "LLM Conversation creation should be enabled");
+        const newRef = await createLLMConversation(
+            api,
+            binder,
+            props.docRef.refId,
+            DEFAULT_LLM_MODEL,
+        );
+        handleDocCreated("llmconversation", newRef);
+    };
+
     const theories = useContext(TheoryLibraryContext);
     invariant(theories, "Library of theories should be provided as context");
 
@@ -79,13 +99,9 @@ export function DocumentMenu(props: {
         },
     );
 
-    const showSeparator = createMemo(() => {
-        return (
-            theory()?.supportsInstances ||
-            docType() === "diagram" ||
-            props.liveDoc.doc.type !== "analysis"
-        );
-    });
+    const showSeparator = createMemo(
+        () => theory()?.supportsInstances || docType() === "model" || docType() === "diagram",
+    );
     const canDelete = () => props.docRef.permissions.user === "Own" && !props.docRef.isDeleted;
 
     const canRestore = () => props.docRef.permissions.user === "Own" && props.docRef.isDeleted;
@@ -121,6 +137,12 @@ export function DocumentMenu(props: {
                         <MenuItem onSelect={() => onNewAnalysis()}>
                             <DocumentTypeIcon documentType="analysis" />
                             <MenuItemLabel>{`New analysis of this ${docType()}`}</MenuItemLabel>
+                        </MenuItem>
+                    </Show>
+                    <Show when={canCreateLLMConversation()}>
+                        <MenuItem onSelect={() => onNewLLMConversation()}>
+                            <DocumentTypeIcon documentType="llmconversation" />
+                            <MenuItemLabel>New LLM Conversation</MenuItemLabel>
                         </MenuItem>
                     </Show>
                     <Show when={showSeparator()}>

--- a/packages/frontend/src/page/document_page.tsx
+++ b/packages/frontend/src/page/document_page.tsx
@@ -47,6 +47,11 @@ import { DiagramInfo } from "../diagram/diagram_info";
 import { InstanceEditor } from "../instance/instance_editor";
 import { InstanceInfo } from "../instance/instance_info";
 import { getLiveInstance, type LiveInstanceDoc } from "../instance/live_doc_compatibility";
+import {
+    getLiveLLMConversation,
+    LLMConversationEditorStub,
+    type LiveLLMConversationDoc,
+} from "../llm_conversation";
 import { type LiveModelDoc, type ModelLibrary, ModelLibraryContext } from "../model";
 import { ModelNotebookEditor } from "../model/model_editor";
 import { ModelDocumentHead } from "../model/model_info";
@@ -54,7 +59,9 @@ import { DocumentBreadcrumbs, DocumentLoadingScreen } from "../page";
 import { DocumentHead } from "../page/document_head";
 import { SidebarLayout } from "../page/sidebar_layout";
 import { PermissionsButton } from "../user";
+import { isDocumentVisible, useUserSettings } from "../user/user_settings";
 import { assertExhaustive } from "../util/assert_exhaustive";
+import NotFoundPage from "./404_page";
 import { DocRefIdContext } from "./context";
 import { DocumentSidebar } from "./document_page_sidebar";
 import { HistorySidebar } from "./history_sidebar";
@@ -62,7 +69,12 @@ import { useSnapshotHistory } from "./use_snapshot_history";
 
 import "./document_page.css";
 
-type AnyLiveDoc = LiveModelDoc | LiveDiagramDoc | LiveAnalysisDoc | LiveInstanceDoc;
+type AnyLiveDoc =
+    | LiveModelDoc
+    | LiveDiagramDoc
+    | LiveAnalysisDoc
+    | LiveInstanceDoc
+    | LiveLLMConversationDoc;
 
 /** A Live*Document bundled with its backend DocRef.
  *
@@ -85,7 +97,11 @@ export default function DocumentPage() {
 
     const params = useParams();
     const navigate = useNavigate();
-    const isSidePanelOpen = () => !!params.subkind && !!params.subref;
+    const { settings } = useUserSettings();
+    const documentIsVisible = (kind: string | undefined) =>
+        kind === undefined || isDocumentVisible({ typeName: kind as DocumentType }, settings());
+    const isSidePanelOpen = () =>
+        !!params.subkind && !!params.subref && documentIsVisible(params.subkind);
     const paneFocus = useChildFocus<"primary" | "secondary">(rootFocus, { default: "primary" });
 
     // Redirect if primary and secondary refs match
@@ -96,7 +112,7 @@ export default function DocumentPage() {
     });
 
     const [primaryLiveDoc, { refetch: refetchPrimaryDoc }] = createResource(
-        () => params.ref,
+        () => (documentIsVisible(params.kind) ? params.ref : undefined),
         (refId) => getLiveDocument(refId, api, models, binder, params.kind as DocumentType),
     );
 
@@ -107,11 +123,12 @@ export default function DocumentPage() {
                 kind: params.subkind || null,
                 ref: params.subref || null,
                 primaryRef: params.ref,
+                visible: documentIsVisible(params.subkind),
             };
         },
         async (source) => {
             // Return undefined to clear resource when there's no secondary in URL
-            if (!source.kind || !source.ref) {
+            if (!source.kind || !source.ref || !source.visible) {
                 return undefined;
             }
 
@@ -171,7 +188,7 @@ export default function DocumentPage() {
     });
 
     return (
-        <>
+        <Show when={documentIsVisible(params.kind)} fallback={<NotFoundPage />}>
             <Title>{documentTitle()}</Title>
             <Show when={primaryLiveDoc()} fallback={<DocumentLoadingScreen />}>
                 {(docWithRef) => (
@@ -230,7 +247,7 @@ export default function DocumentPage() {
                     </SidebarLayout>
                 )}
             </Show>
-        </>
+        </Show>
     );
 }
 
@@ -531,6 +548,11 @@ export function DocumentPane(props: {
                                     </DocumentHead>
                                 )}
                             </Match>
+                            <Match keyed when={props.doc.type === "llmconversation" && props.doc}>
+                                {(liveConversation) => (
+                                    <DocumentHead liveDoc={liveConversation.liveDoc} />
+                                )}
+                            </Match>
                         </Switch>
                         <Switch>
                             <Match keyed when={props.doc.type === "model" && props.doc}>
@@ -561,6 +583,9 @@ export function DocumentPane(props: {
                                 {(liveInstance) => (
                                     <InstanceEditor instance={liveInstance.instance} />
                                 )}
+                            </Match>
+                            <Match when={props.doc.type === "llmconversation"}>
+                                <LLMConversationEditorStub />
                             </Match>
                         </Switch>
                     </div>
@@ -600,8 +625,15 @@ async function getLiveDocument(
             const { liveInstance, docRef } = await getLiveInstance(refId, api, models, binder);
             return { liveDoc: liveInstance, docRef };
         }
-        case "llmconversation":
-            throw new Error("LLM conversation pages are not implemented");
+        case "llmconversation": {
+            const { liveConversation, docRef } = await getLiveLLMConversation(
+                refId,
+                api,
+                models,
+                binder,
+            );
+            return { liveDoc: liveConversation, docRef };
+        }
         default:
             assertExhaustive(documentType);
     }

--- a/packages/logics/src/petri-net.ts
+++ b/packages/logics/src/petri-net.ts
@@ -22,7 +22,7 @@ export const PetriNet = defineShape({
 });
 
 export const petriNetCellTypes = {
-    petri_net_place: Place,
-    petri_net_transition: Transition,
-    petri_net_rich_text: RichText,
+    Place,
+    Transition,
+    RichText,
 };

--- a/packages/logics/src/simple-olog.ts
+++ b/packages/logics/src/simple-olog.ts
@@ -18,6 +18,6 @@ export const SimpleOlog = defineShape({
 });
 
 export const simpleOlogCellTypes = {
-    olog_type: Type,
-    olog_aspect: Aspect,
+    Type,
+    Aspect,
 };

--- a/packages/logics/src/simple-schema.ts
+++ b/packages/logics/src/simple-schema.ts
@@ -24,9 +24,9 @@ export const SimpleSchema = defineShape({
 });
 
 export const simpleSchemaCellTypes = {
-    schema_entity: Entity,
-    schema_attr_type: AttrType,
-    schema_mapping: Mapping,
-    schema_attr: Attr,
-    schema_rich_text: RichText,
+    Entity,
+    AttrType,
+    Mapping,
+    Attr,
+    RichText,
 };


### PR DESCRIPTION
"all-but-ui" for LLMConversation stuff, following closely the work in #1430.

* Route filters in `App.tsx` accept the `llmconversation` kind/subkind.
* `document_page.tsx` loads live LLM conversations and shows a stub editor.
* `llm_conversation/live_doc_compatibility.ts` loads a conversation, its attachment (model notebook or data instance), and its parent model through the frontend document binder, following `instance/live_doc_compatibility`. The facade also exposes the binder-backed store for use by a future editor.
* `document_menu.tsx` creates conversations through the binder.
* `model/shapes.ts` centralises the shape lists and theory lookups shared with the instance module now