### PR TITLE
Add `ElaboratedModel` type that mirrors notebook API

### DIFF
--- a/packages/documents/src/binder.ts
+++ b/packages/documents/src/binder.ts
@@ -141,24 +141,19 @@ function binderFromStore<Handle>(store: DocumentStore<Handle>): Binder<Handle> {
                 return schemaResult;
             }
 
-            const schemaModel = schemaResult.content;
-            try {
-                const schemaRef = store.getDocumentRef(schema.handle);
-                const document = InstanceMethods.newInstanceDocument({
-                    _id: schemaRef.id,
-                    _version: schemaRef.version,
-                    _server: schemaRef.server ?? "",
-                });
-                document.name = options.title;
+            const schemaRef = store.getDocumentRef(schema.handle);
+            const document = InstanceMethods.newInstanceDocument({
+                _id: schemaRef.id,
+                _version: schemaRef.version,
+                _server: schemaRef.server ?? "",
+            });
+            document.name = options.title;
 
-                const handle = await store.createHandle(document);
-                return {
-                    tag: "Ok",
-                    content: instanceFromStore(shape, schema, store, handle),
-                };
-            } finally {
-                schemaModel.free();
-            }
+            const handle = await store.createHandle(document);
+            return {
+                tag: "Ok",
+                content: instanceFromStore(shape, schema, store, handle),
+            };
         },
         async createLLMConversation<Attachment extends LLMConversationAttachment<Shape, Handle>>(
             attachment: Attachment,

--- a/packages/documents/src/index.ts
+++ b/packages/documents/src/index.ts
@@ -27,6 +27,12 @@ export type { CellOf as NotebookCell, MorphismCell, ObjectCell } from "./model/c
 export type { ModelDocument } from "./model/document";
 export { modelNotebookFromStore } from "./model/notebook";
 export type { Notebook } from "./model/notebook";
+export type {
+    JudgmentOf,
+    MorphismJudgment,
+    ObjectJudgment,
+    ElaboratedModel,
+} from "./model/elaborated-model";
 export type { NotebookDocument } from "./notebook-document";
 export type { RichTextCell } from "./rich-text";
 export { defineMorphism, defineObject, defineShape, RichText } from "./shape";

--- a/packages/documents/src/instance/instance-runtime.ts
+++ b/packages/documents/src/instance/instance-runtime.ts
@@ -186,7 +186,7 @@ export function createSchemaResultValidator<Handle, S extends Shape>(
     handle: Handle,
 ): (
     schemaResult: Result<ElaboratedModel<S>>,
-) => Result<undefined, ReadonlyArray<Issue | TableFieldIssue>> {
+) => Result<void, ReadonlyArray<Issue | TableFieldIssue>> {
     return (schemaResult) => {
         if (schemaResult.tag === "Err") {
             return schemaResult;

--- a/packages/documents/src/instance/instance-runtime.ts
+++ b/packages/documents/src/instance/instance-runtime.ts
@@ -1,7 +1,7 @@
 import type { InstanceDocument } from "catcolab-document-methods";
-import type { DblModel } from "catlog-wasm";
 import type { DocumentStore } from "../document-store";
 import type { ModelDocument } from "../model/document";
+import type { ElaboratedModel } from "../model/elaborated-model";
 import type { Notebook } from "../model/notebook";
 import type { Issue, Result } from "../result";
 import type { InstanceCapableShape, Shape } from "../shape";
@@ -26,7 +26,7 @@ function instanceCapableShape<Handle, S extends Shape>(
     return shape as InstanceCapableShape;
 }
 
-/** Validate the schema, run an operation against the resulting model, and free it.
+/** Validate the schema and run an operation against the resulting model.
 
 `operation` is expected to report its own failures as a `Result`; this does not
 catch exceptions, so an operation that throws lets that exception propagate. */
@@ -37,19 +37,14 @@ async function withValidatedSchema<
     E extends ReadonlyArray<Issue> = ReadonlyArray<Issue>,
 >(
     schema: Notebook<S, ModelDocument, Handle>,
-    operation: (schemaModel: DblModel) => Result<T, E>,
+    operation: (schemaModel: ElaboratedModel<S>) => Result<T, E>,
 ): Promise<Result<T, E>> {
     const schemaResult = await schema.validate();
     if (schemaResult.tag === "Err") {
         return schemaResult as Result<T, E>;
     }
 
-    const schemaModel = schemaResult.content;
-    try {
-        return operation(schemaModel);
-    } finally {
-        schemaModel.free();
-    }
+    return operation(schemaResult.content);
 }
 
 export function createTablesMethod<Handle, S extends Shape>(
@@ -189,29 +184,26 @@ export function createSchemaResultValidator<Handle, S extends Shape>(
     schema: Notebook<S, ModelDocument, Handle>,
     store: DocumentStore<Handle>,
     handle: Handle,
-): (schemaResult: Result<DblModel>) => Result<undefined, ReadonlyArray<Issue | TableFieldIssue>> {
+): (
+    schemaResult: Result<ElaboratedModel<S>>,
+) => Result<undefined, ReadonlyArray<Issue | TableFieldIssue>> {
     return (schemaResult) => {
         if (schemaResult.tag === "Err") {
             return schemaResult;
         }
 
-        const schemaModel = schemaResult.content;
-        try {
-            const tables = instanceTablesFromModel(
-                instanceCapableShape(schema),
-                store,
-                handle,
-                schemaModel,
-            );
-            const issues: TableFieldIssue[] = validateTableFields(
-                store.getDocumentView(handle) as Readonly<InstanceDocument>,
-                tables,
-            );
-            return issues.length === 0
-                ? { tag: "Ok", content: undefined }
-                : { tag: "Err", content: issues };
-        } finally {
-            schemaModel.free();
-        }
+        const tables = instanceTablesFromModel(
+            instanceCapableShape(schema),
+            store,
+            handle,
+            schemaResult.content,
+        );
+        const issues: TableFieldIssue[] = validateTableFields(
+            store.getDocumentView(handle) as Readonly<InstanceDocument>,
+            tables,
+        );
+        return issues.length === 0
+            ? { tag: "Ok", content: undefined }
+            : { tag: "Err", content: issues };
     };
 }

--- a/packages/documents/src/instance/instance.ts
+++ b/packages/documents/src/instance/instance.ts
@@ -94,7 +94,7 @@ export function instanceFromStore<Handle, S extends Shape>(
     const validateSchemaResult = createSchemaResultValidator(schema, store, handle);
 
     async function validateCurrentDocument(): Promise<
-        Result<undefined, ReadonlyArray<Issue | TableFieldIssue>>
+        Result<void, ReadonlyArray<Issue | TableFieldIssue>>
     > {
         return validateSchemaResult(await schema.validate());
     }
@@ -148,7 +148,7 @@ export function instanceFromStore<Handle, S extends Shape>(
         deleteRows(rows: ReadonlyArray<{ tableId: string; rowId: string }>): void {
             deleteStoredRows(rows);
         },
-        validate(): Promise<Result<undefined, ReadonlyArray<Issue | TableFieldIssue>>> {
+        validate(): Promise<Result<void, ReadonlyArray<Issue | TableFieldIssue>>> {
             return validateCurrentDocument();
         },
         onChange(callback: () => void): () => void {
@@ -160,13 +160,11 @@ export function instanceFromStore<Handle, S extends Shape>(
             };
         },
         onValidate(
-            callback: (result: Result<undefined, ReadonlyArray<Issue | TableFieldIssue>>) => void,
+            callback: (result: Result<void, ReadonlyArray<Issue | TableFieldIssue>>) => void,
         ): () => void {
             let active: boolean = true;
 
-            function notify(
-                result: Result<undefined, ReadonlyArray<Issue | TableFieldIssue>>,
-            ): void {
+            function notify(result: Result<void, ReadonlyArray<Issue | TableFieldIssue>>): void {
                 if (active) {
                     callback(result);
                 }

--- a/packages/documents/src/instance/table-methods.ts
+++ b/packages/documents/src/instance/table-methods.ts
@@ -2,11 +2,11 @@ import { v7 as uuid } from "uuid";
 
 import type { InstanceDocument } from "catcolab-document-methods";
 import type * as DocumentTypes from "catcolab-document-types";
-import type { DblModel, ObGenerator } from "catlog-wasm";
+import type { QualifiedLabel } from "catlog-wasm";
 import type { DocumentStore } from "../document-store";
-import { objectTypesEqual } from "../model/equality";
+import type { ElaboratedModel, ObjectJudgment } from "../model/elaborated-model";
 import type { Issue, Result } from "../result";
-import type { InstanceCapableShape } from "../shape";
+import type { InstanceCapableShape, ObjectType, Shape } from "../shape";
 import type { FieldPath } from "./errors";
 import type {
     FieldValue,
@@ -25,7 +25,7 @@ export function readInstancePathFromStore<Handle>(
     shape: InstanceCapableShape,
     store: DocumentStore<Handle>,
     handle: Handle,
-    schemaModel: DblModel,
+    schemaModel: ElaboratedModel<Shape>,
     path: InstancePath,
 ): Result<InstanceTable | TableRow | FieldValue> {
     const schemaTables = instanceTablesFromModel(shape, store, handle, schemaModel);
@@ -73,7 +73,7 @@ export function addInstanceRowsToStore<Handle>(
     shape: InstanceCapableShape,
     store: DocumentStore<Handle>,
     handle: Handle,
-    schemaModel: DblModel,
+    schemaModel: ElaboratedModel<Shape>,
     additions: ReadonlyArray<{
         table: InstanceTable;
         values: ReadonlyArray<Record<string, LiteralValue | TableRow>>;
@@ -132,7 +132,7 @@ export function updateInstanceFieldsByLabelInStore<Handle>(
     shape: InstanceCapableShape,
     store: DocumentStore<Handle>,
     handle: Handle,
-    schemaModel: DblModel,
+    schemaModel: ElaboratedModel<Shape>,
     updates: ReadonlyArray<{
         row: TableRow;
         values: ReadonlyArray<Record<string, LiteralValue | TableRow>>;
@@ -172,7 +172,7 @@ export function updateInstanceFieldByIdInStore<Handle>(
     shape: InstanceCapableShape,
     store: DocumentStore<Handle>,
     handle: Handle,
-    schemaModel: DblModel,
+    schemaModel: ElaboratedModel<Shape>,
     row: TableRow,
     field: { id: string },
     value: LiteralValue | TableRow,
@@ -320,48 +320,45 @@ export function instanceTablesFromModel<Handle>(
     shape: InstanceCapableShape,
     store: DocumentStore<Handle>,
     handle: Handle,
-    schemaModel: DblModel,
+    schemaModel: ElaboratedModel<Shape>,
 ): readonly InstanceTable[] {
-    const presentation = schemaModel.presentation();
-    const objectsById = new Map(presentation.obGenerators.map((object) => [object.id, object]));
-    const tableObjects = presentation.obGenerators.filter((object) =>
-        shape.supportsInstances.tableObjects.some((type) =>
-            objectTypesEqual(type.obType, object.obType),
-        ),
-    );
+    const judgments = schemaModel.judgments();
+    const tableObjects = schemaModel
+        .judgmentsOf({ objects: shape.supportsInstances.tableObjects })
+        // This shouldn't be needed once judgmentsOf returns narrower types.
+        .filter((judgment): judgment is ObjectJudgment<ObjectType> => judgment.kind === "object");
     const tableIds = new Set(tableObjects.map((object) => object.id));
 
     return tableObjects.map((tableObject) => {
         const headers: TableHeader[] = [];
-        for (const morphism of presentation.morGenerators) {
-            if (morphism.dom.tag !== "Basic" || morphism.dom.content !== tableObject.id) {
+        for (const morphism of judgments) {
+            if (morphism.kind !== "morphism" || morphism.from?.id !== tableObject.id) {
                 continue;
             }
-            if (morphism.cod.tag !== "Basic") {
-                continue;
-            }
-            const codomainObject = objectsById.get(morphism.cod.content);
-            if (codomainObject === undefined) {
+            const codomain = morphism.to;
+            if (codomain === null) {
                 continue;
             }
 
-            const label = displayLabel(morphism);
-            if (tableIds.has(codomainObject.id)) {
+            if (tableIds.has(codomain.id)) {
                 headers.push({
                     id: morphism.id,
-                    label,
-                    type: { tag: "RowRef", content: { id: codomainObject.id } },
+                    label: displayLabel(morphism.label),
+                    type: { tag: "RowRef", content: { id: codomain.id } },
                 });
                 continue;
             }
 
-            const attributeType = codomainObject;
-            const literalType = atomicTypeOfAttributeType(attributeType);
-            headers.push({ id: morphism.id, label, type: { tag: literalType } });
+            const literalType = atomicTypeOfAttributeType(codomain.label);
+            headers.push({
+                id: morphism.id,
+                label: displayLabel(morphism.label),
+                type: { tag: literalType },
+            });
         }
         const table: InstanceTable = {
             id: tableObject.id,
-            label: displayLabel(tableObject),
+            label: displayLabel(tableObject.label),
             headers,
             get rows() {
                 const document = store.getDocumentView(handle) as Readonly<InstanceDocument>;
@@ -374,8 +371,8 @@ export function instanceTablesFromModel<Handle>(
     });
 }
 
-function displayLabel(generator: Pick<ObGenerator, "label">): string {
-    return generator.label?.join(".") ?? "";
+function displayLabel(label: QualifiedLabel): string {
+    return label.join(".");
 }
 
 function fieldValueFromStored(path: FieldPath, value: DocumentTypes.FieldValue): FieldValue {

--- a/packages/documents/src/instance/validation.ts
+++ b/packages/documents/src/instance/validation.ts
@@ -2,15 +2,16 @@
 
 import type { InstanceDocument } from "catcolab-document-methods";
 import type * as DocumentTypes from "catcolab-document-types";
-import type { ObGenerator } from "catlog-wasm";
+import type { QualifiedLabel } from "catlog-wasm";
 import type { FieldPath, TableFieldIssue } from "./errors";
 import type { InstanceTable, LiteralType, TableHeader } from "./tables";
 
-/** Decide which concrete atomic type an attribute type denotes. This function
-    is intended to be temporary and should be replaced once we have an account
-    of typing with which we are satisfied. */
-export function atomicTypeOfAttributeType(attributeType: Pick<ObGenerator, "label">): LiteralType {
-    const name = attributeType.label?.[0];
+/** Decide which concrete atomic type an attribute type's qualified label
+    denotes. The first label segment decides. This function is intended to be
+    temporary and should be replaced once we have an account of typing with
+    which we are satisfied. */
+export function atomicTypeOfAttributeType(label: QualifiedLabel): LiteralType {
+    const name = label[0];
     switch (name) {
         case "Bool":
         case "Int":

--- a/packages/documents/src/model/elaborated-model.ts
+++ b/packages/documents/src/model/elaborated-model.ts
@@ -1,4 +1,4 @@
-import type { ModelPresentation, MorGenerator, ObGenerator } from "catlog-wasm";
+import type { ModelPresentation, MorGenerator, QualifiedLabel } from "catlog-wasm";
 import {
     findMorphismType,
     findObjectType,
@@ -11,18 +11,17 @@ import {
 } from "../shape";
 import { morphismTypesEqual, objectTypesEqual } from "./equality";
 
-/** An object judgment of an elaborated model. Mirrors [`ObjectCell`], minus mutation. */
+/** An object judgment of an elaborated model. Mirrors [`ObjectCell`], minus
+mutation */
 export interface ObjectJudgment<O extends ObjectType> {
     readonly kind: "object";
     readonly id: string;
     readonly type: O;
-    readonly label: string;
+    readonly label: QualifiedLabel;
 }
 
-/** A morphism judgment of an elaborated model. Mirrors [`MorphismCell`], minus mutation.
-
-The endpoints are resolved to object judgments; an endpoint that is not a basic
-object generator is `null`. */
+/** A morphism judgment of an elaborated model. Mirrors [`MorphismCell`], minus
+mutation display string. */
 export interface MorphismJudgment<
     out S extends Shape,
     M extends MorphismType = MorphismTypesOf<S>,
@@ -30,7 +29,7 @@ export interface MorphismJudgment<
     readonly kind: "morphism";
     readonly id: string;
     readonly type: M;
-    readonly label: string;
+    readonly label: QualifiedLabel;
     readonly from: ObjectJudgment<ObjectTypesOf<S>> | null;
     readonly to: ObjectJudgment<ObjectTypesOf<S>> | null;
 }
@@ -71,7 +70,7 @@ export function elaboratedModelFromPresentation<S extends Shape>(
                 kind: "object",
                 id: generator.id,
                 type,
-                label: displayLabel(generator),
+                label: generator.label ?? [],
             };
             objectsById.set(generator.id, judgment);
             objects.push(judgment);
@@ -87,7 +86,7 @@ export function elaboratedModelFromPresentation<S extends Shape>(
                 kind: "morphism",
                 id: generator.id,
                 type,
-                label: displayLabel(generator),
+                label: generator.label ?? [],
                 from: endpointJudgment(objectsById, generator.dom),
                 to: endpointJudgment(objectsById, generator.cod),
             });
@@ -102,10 +101,6 @@ export function elaboratedModelFromPresentation<S extends Shape>(
             return judgments().filter((judgment) => judgmentMatchesFilter(judgment, typeOrShape));
         },
     };
-}
-
-function displayLabel(generator: Pick<ObGenerator, "label">): string {
-    return generator.label?.join(".") ?? "";
 }
 
 function endpointJudgment<S extends Shape>(

--- a/packages/documents/src/model/elaborated-model.ts
+++ b/packages/documents/src/model/elaborated-model.ts
@@ -1,0 +1,154 @@
+import type { ModelPresentation, MorGenerator, ObGenerator } from "catlog-wasm";
+import {
+    findMorphismType,
+    findObjectType,
+    type AnyCellType,
+    type MorphismType,
+    type MorphismTypesOf,
+    type ObjectType,
+    type ObjectTypesOf,
+    type Shape,
+} from "../shape";
+import { morphismTypesEqual, objectTypesEqual } from "./equality";
+
+/** An object judgment of an elaborated model. Mirrors [`ObjectCell`], minus mutation. */
+export interface ObjectJudgment<O extends ObjectType> {
+    readonly kind: "object";
+    readonly id: string;
+    readonly type: O;
+    readonly label: string;
+}
+
+/** A morphism judgment of an elaborated model. Mirrors [`MorphismCell`], minus mutation.
+
+The endpoints are resolved to object judgments; an endpoint that is not a basic
+object generator is `null`. */
+export interface MorphismJudgment<
+    out S extends Shape,
+    M extends MorphismType = MorphismTypesOf<S>,
+> {
+    readonly kind: "morphism";
+    readonly id: string;
+    readonly type: M;
+    readonly label: string;
+    readonly from: ObjectJudgment<ObjectTypesOf<S>> | null;
+    readonly to: ObjectJudgment<ObjectTypesOf<S>> | null;
+}
+
+/** A judgment of an elaborated model.*/
+export type JudgmentOf<S extends Shape> =
+    | ObjectJudgment<ObjectTypesOf<S>>
+    | MorphismJudgment<S, MorphismTypesOf<S>>;
+
+/** Read-only, shape-typed access to an elaborated model.
+
+The API mirrors the notebook's `cells`/`cellsOf`: judgments are returned in
+presentation order (objects first, then morphisms). */
+export interface ElaboratedModel<out S extends Shape> {
+    judgments(): ReadonlyArray<JudgmentOf<S>>;
+    judgmentsOf(typeOrShape: AnyCellType | Shape): ReadonlyArray<JudgmentOf<S>>;
+}
+
+/** Create an elaborated model over a (possibly changing) model presentation. */
+export function elaboratedModelFromPresentation<S extends Shape>(
+    shape: S,
+    getPresentation: () => Readonly<ModelPresentation> | undefined,
+): ElaboratedModel<S> {
+    function judgments(): ReadonlyArray<JudgmentOf<S>> {
+        const presentation = getPresentation();
+        if (presentation === undefined) {
+            return [];
+        }
+
+        const objectsById = new Map<string, ObjectJudgment<ObjectTypesOf<S>>>();
+        const objects: ObjectJudgment<ObjectTypesOf<S>>[] = [];
+        for (const generator of presentation.obGenerators) {
+            const type = findObjectType(shape, generator.obType);
+            if (type === undefined) {
+                continue;
+            }
+            const judgment: ObjectJudgment<ObjectTypesOf<S>> = {
+                kind: "object",
+                id: generator.id,
+                type,
+                label: displayLabel(generator),
+            };
+            objectsById.set(generator.id, judgment);
+            objects.push(judgment);
+        }
+
+        const morphisms: MorphismJudgment<S, MorphismTypesOf<S>>[] = [];
+        for (const generator of presentation.morGenerators) {
+            const type = findMorphismType(shape, generator.morType);
+            if (type === undefined) {
+                continue;
+            }
+            morphisms.push({
+                kind: "morphism",
+                id: generator.id,
+                type,
+                label: displayLabel(generator),
+                from: endpointJudgment(objectsById, generator.dom),
+                to: endpointJudgment(objectsById, generator.cod),
+            });
+        }
+
+        return [...objects, ...morphisms];
+    }
+
+    return {
+        judgments,
+        judgmentsOf(typeOrShape: AnyCellType | Shape): ReadonlyArray<JudgmentOf<S>> {
+            return judgments().filter((judgment) => judgmentMatchesFilter(judgment, typeOrShape));
+        },
+    };
+}
+
+function displayLabel(generator: Pick<ObGenerator, "label">): string {
+    return generator.label?.join(".") ?? "";
+}
+
+function endpointJudgment<S extends Shape>(
+    objectsById: ReadonlyMap<string, ObjectJudgment<ObjectTypesOf<S>>>,
+    endpoint: MorGenerator["dom"],
+): ObjectJudgment<ObjectTypesOf<S>> | null {
+    if (endpoint.tag !== "Basic") {
+        return null;
+    }
+    return objectsById.get(endpoint.content) ?? null;
+}
+
+function isCellType(value: AnyCellType | Shape): value is AnyCellType {
+    return "kind" in value;
+}
+
+function judgmentMatchesFilter<S extends Shape>(
+    judgment: JudgmentOf<S>,
+    filter: AnyCellType | Shape,
+): boolean {
+    if (isCellType(filter)) {
+        switch (filter.kind) {
+            case "rich-text":
+                return false;
+            case "object":
+                return (
+                    judgment.kind === "object" &&
+                    objectTypesEqual(judgment.type.obType, filter.obType)
+                );
+            case "morphism":
+                return (
+                    judgment.kind === "morphism" &&
+                    morphismTypesEqual(judgment.type.morType, filter.morType)
+                );
+        }
+    }
+
+    if (judgment.kind === "object") {
+        return (filter.objects ?? []).some((type) =>
+            objectTypesEqual(judgment.type.obType, type.obType),
+        );
+    }
+    return (filter.morphisms ?? []).some((type) =>
+        morphismTypesEqual(judgment.type.morType, type.morType),
+    );
+}

--- a/packages/documents/src/model/notebook.ts
+++ b/packages/documents/src/model/notebook.ts
@@ -1,6 +1,6 @@
 import { Model, Nb } from "catcolab-document-methods";
 import type { ModelJudgment } from "catcolab-document-types";
-import type { DblModel, DblTheory } from "catlog-wasm";
+import type { DblTheory, ModelPresentation } from "catlog-wasm";
 import type { DocumentStore } from "../document-store";
 import type { NotebookDocument } from "../notebook-document";
 import type { Result } from "../result";
@@ -27,6 +27,7 @@ import {
     type ObjectCell,
 } from "./cell";
 import type { ModelDocument } from "./document";
+import { elaboratedModelFromPresentation, type ElaboratedModel } from "./elaborated-model";
 import { morphismTypesEqual, objectTypesEqual } from "./equality";
 import { validateModelDocument } from "./validation";
 
@@ -179,8 +180,8 @@ export interface Notebook<
     update(patch: Partial<{ title: string }>): void;
     dump(): D;
     onChange(callback: () => void): () => void;
-    validate(): Promise<Result<DblModel>>;
-    onValidate(callback: (result: Result<DblModel>) => void): () => void;
+    validate(): Promise<Result<ElaboratedModel<S>>>;
+    onValidate(callback: (result: Result<ElaboratedModel<S>>) => void): () => void;
 }
 
 export function modelNotebookFromStore<Handle, S extends Shape>(
@@ -190,8 +191,8 @@ export function modelNotebookFromStore<Handle, S extends Shape>(
 ): Notebook<S, ModelDocument, Handle> {
     let coreTheory: Promise<DblTheory> | undefined;
 
-    async function validateCurrentDocument(): Promise<Result<DblModel>> {
-        let result: Result<DblModel>;
+    async function validateCurrentDocument(): Promise<Result<ElaboratedModel<S>>> {
+        let result: Result<ModelPresentation>;
         if (!shape.getCoreTheory) {
             let shapeName = "unnamed";
             if (shape.theory) {
@@ -224,7 +225,14 @@ export function modelNotebookFromStore<Handle, S extends Shape>(
             }
         }
 
-        return result;
+        if (result.tag === "Err") {
+            return result;
+        }
+        const presentation = result.content;
+        return {
+            tag: "Ok",
+            content: elaboratedModelFromPresentation(shape, () => presentation),
+        };
     }
 
     function appendCell(

--- a/packages/documents/src/model/validation.ts
+++ b/packages/documents/src/model/validation.ts
@@ -1,6 +1,6 @@
 import type { FormalCell, ModelDocument } from "catcolab-document-methods";
 import type { ModelJudgment, Notebook } from "catcolab-document-types";
-import type { DblModel, DblTheory, InvalidDblModel } from "catlog-wasm";
+import type { DblModel, DblTheory, InvalidDblModel, ModelPresentation } from "catlog-wasm";
 import type { Issue, Result } from "../result";
 
 function formalCellForGenerator(
@@ -88,12 +88,14 @@ function invalidModelIssue(notebook: Notebook<ModelJudgment>, error: InvalidDblM
     }
 }
 
-/** Elaborate and validate a model document against its core theory. */
+/** Elaborate and validate a model document against its core theory.
+
+On success, returns the presentation of the validated model. */
 export async function validateModelDocument(
     document: Readonly<ModelDocument>,
     theory: DblTheory,
     refId: string,
-): Promise<Result<DblModel>> {
+): Promise<Result<ModelPresentation>> {
     const { DblModelMap, elaborateModel } = await import("catlog-wasm");
     const instantiatedModels = new DblModelMap();
     let model: DblModel;
@@ -108,12 +110,18 @@ export async function validateModelDocument(
         instantiatedModels.free();
     }
 
-    const validation = model.validate();
-    if (validation.tag === "Err") {
-        return {
-            tag: "Err",
-            content: validation.content.map((error) => invalidModelIssue(document.notebook, error)),
-        };
+    try {
+        const validation = model.validate();
+        if (validation.tag === "Err") {
+            return {
+                tag: "Err",
+                content: validation.content.map((error) =>
+                    invalidModelIssue(document.notebook, error),
+                ),
+            };
+        }
+        return { tag: "Ok", content: model.presentation() };
+    } finally {
+        model.free();
     }
-    return { tag: "Ok", content: model };
 }

--- a/packages/documents/test/instances.test.ts
+++ b/packages/documents/test/instances.test.ts
@@ -497,12 +497,12 @@ describe("tabular instances", () => {
 
 describe("atomic instance column types", () => {
     test("attribute type labels match exact atomic names", () => {
-        expect(atomicTypeOfAttributeType({ label: ["Bool"] })).toBe("Bool");
-        expect(atomicTypeOfAttributeType({ label: ["Int"] })).toBe("Int");
-        expect(atomicTypeOfAttributeType({ label: ["Float"] })).toBe("Float");
-        expect(atomicTypeOfAttributeType({ label: ["String"] })).toBe("String");
-        expect(atomicTypeOfAttributeType({ label: ["namespace", "Bool"] })).toBe("String");
-        expect(atomicTypeOfAttributeType({ label: undefined })).toBe("String");
-        expect(atomicTypeOfAttributeType({ label: ["string"] })).toBe("String");
+        expect(atomicTypeOfAttributeType(["Bool"])).toBe("Bool");
+        expect(atomicTypeOfAttributeType(["Int"])).toBe("Int");
+        expect(atomicTypeOfAttributeType(["Float"])).toBe("Float");
+        expect(atomicTypeOfAttributeType(["String"])).toBe("String");
+        expect(atomicTypeOfAttributeType(["namespace", "Bool"])).toBe("String");
+        expect(atomicTypeOfAttributeType([])).toBe("String");
+        expect(atomicTypeOfAttributeType(["string"])).toBe("String");
     });
 });

--- a/packages/documents/test/validation.test.ts
+++ b/packages/documents/test/validation.test.ts
@@ -3,8 +3,7 @@ import { describe, expect, test } from "vitest";
 
 // RFC-0006 "Model validation": the asynchronous `validate` method, subscribing
 // to validation changes with `onValidate`, and validation failures.
-import { createBinder, Instantiation, type Result } from "catcolab-documents";
-import type { DblModel } from "catlog-wasm";
+import { createBinder, type ElaboratedModel, Instantiation, type Result } from "catcolab-documents";
 
 async function wellFormedOlog() {
     const binder = createBinder();
@@ -20,14 +19,14 @@ async function wellFormedOlog() {
 // the first time tests run we incur the cost of loading the catlog-wasm bundle,
 // so these tests have longer timeouts
 describe("validate", { timeout: 10000 }, () => {
-    test("a well-formed notebook validates to an Ok carrying the model", async () => {
+    test("a well-formed notebook validates to an Ok carrying the elaborated model", async () => {
         const notebook = await wellFormedOlog();
 
-        const result: Result<DblModel> = await notebook.validate();
+        const result: Result<ElaboratedModel<typeof SimpleOlog>> = await notebook.validate();
         expect(result.tag).toBe("Ok");
     });
 
-    test("the validated model is available on the result and can be queried", async () => {
+    test("the elaborated model is available on the result and can be queried", async () => {
         const notebook = await wellFormedOlog();
 
         const result = await notebook.validate();
@@ -35,8 +34,8 @@ describe("validate", { timeout: 10000 }, () => {
         if (result.tag !== "Ok") {
             return;
         }
-        expect(result.content.obGenerators().length).toBe(2);
-        expect(result.content.morGenerators().length).toBe(1);
+        expect(result.content.judgmentsOf(Type).length).toBe(2);
+        expect(result.content.judgmentsOf(Aspect).length).toBe(1);
     });
 });
 
@@ -44,8 +43,8 @@ describe("onValidate", { timeout: 10000 }, () => {
     test("always calls the callback at least once with the current validation", async () => {
         const notebook = await wellFormedOlog();
 
-        const first = await new Promise<Result<DblModel>>((resolve) => {
-            const unsubscribe = notebook.onValidate((result: Result<DblModel>) => {
+        const first = await new Promise<Result<ElaboratedModel<typeof SimpleOlog>>>((resolve) => {
+            const unsubscribe = notebook.onValidate((result) => {
                 resolve(result);
                 unsubscribe();
             });
@@ -57,8 +56,8 @@ describe("onValidate", { timeout: 10000 }, () => {
     test("notifies when changes to the formal content affect the validation result", async () => {
         const notebook = await wellFormedOlog();
 
-        const results: Result<DblModel>[] = [];
-        const unsubscribe = notebook.onValidate((result: Result<DblModel>) => {
+        const results: Result<ElaboratedModel<typeof SimpleOlog>>[] = [];
+        const unsubscribe = notebook.onValidate((result) => {
             results.push(result);
         });
 

--- a/packages/frontend/src/llm_conversation/scoped_document.ts
+++ b/packages/frontend/src/llm_conversation/scoped_document.ts
@@ -1,6 +1,5 @@
 import type { Document } from "catcolab-document-types";
 import { type DocumentStore, type Issue, type Result } from "catcolab-documents";
-import type { DblModel } from "catlog-wasm";
 import { createDocumentTransaction } from "./document_transaction";
 
 export type DocumentBinding<Handle = unknown, E extends Issue = Issue> = {
@@ -74,9 +73,6 @@ async function validateScopedDocument<E extends Issue>(
     const result = await document.validate();
     if (result.tag === "Err") {
         return [`${binding}: ${JSON.stringify(result.content)}`];
-    }
-    if (document.document.type === "model") {
-        (result.content as DblModel).free();
     }
     return [];
 }


### PR DESCRIPTION
This gives the elaborated model an interface with `judgments()` and `judgmentsOf()` that mirror the notebook cell methods.

The reason I am adding this now is that it seems to be the first step in a path to get a non-hacky reactive view of our instance tables.