### PR TITLE
Make elaborated model always available from validation

### DIFF
--- a/packages/documents/src/binder.ts
+++ b/packages/documents/src/binder.ts
@@ -136,9 +136,9 @@ function binderFromStore<Handle>(store: DocumentStore<Handle>): Binder<Handle> {
                 };
             }
 
-            const schemaResult = await schema.validate();
-            if (schemaResult.tag === "Err") {
-                return schemaResult;
+            const schemaValidation = await schema.validate();
+            if (schemaValidation.issues.length > 0) {
+                return { tag: "Err", content: schemaValidation.issues };
             }
 
             const schemaRef = store.getDocumentRef(schema.handle);

--- a/packages/documents/src/index.ts
+++ b/packages/documents/src/index.ts
@@ -32,7 +32,8 @@ export type {
     MorphismJudgment,
     ObjectJudgment,
     ElaboratedModel,
-    ValidationView,
+    ModelValidation,
+    ModelValidationView,
 } from "./model/elaborated-model";
 export type { NotebookDocument } from "./notebook-document";
 export type { RichTextCell } from "./rich-text";

--- a/packages/documents/src/instance/instance-runtime.ts
+++ b/packages/documents/src/instance/instance-runtime.ts
@@ -1,7 +1,7 @@
 import type { InstanceDocument } from "catcolab-document-methods";
 import type { DocumentStore } from "../document-store";
 import type { ModelDocument } from "../model/document";
-import type { ElaboratedModel } from "../model/elaborated-model";
+import type { ElaboratedModel, ModelValidation } from "../model/elaborated-model";
 import type { Notebook } from "../model/notebook";
 import type { Issue, Result } from "../result";
 import type { InstanceCapableShape, Shape } from "../shape";
@@ -39,12 +39,12 @@ async function withValidatedSchema<
     schema: Notebook<S, ModelDocument, Handle>,
     operation: (schemaModel: ElaboratedModel<S>) => Result<T, E>,
 ): Promise<Result<T, E>> {
-    const schemaResult = await schema.validate();
-    if (schemaResult.tag === "Err") {
-        return schemaResult as Result<T, E>;
+    const schemaValidation = await schema.validate();
+    if (schemaValidation.issues.length > 0) {
+        return { tag: "Err", content: schemaValidation.issues as E };
     }
 
-    return operation(schemaResult.content);
+    return operation(schemaValidation.model);
 }
 
 export function createTablesMethod<Handle, S extends Shape>(
@@ -184,19 +184,17 @@ export function createSchemaResultValidator<Handle, S extends Shape>(
     schema: Notebook<S, ModelDocument, Handle>,
     store: DocumentStore<Handle>,
     handle: Handle,
-): (
-    schemaResult: Result<ElaboratedModel<S>>,
-) => Result<void, ReadonlyArray<Issue | TableFieldIssue>> {
-    return (schemaResult) => {
-        if (schemaResult.tag === "Err") {
-            return schemaResult;
+): (schemaValidation: ModelValidation<S>) => Result<void, ReadonlyArray<Issue | TableFieldIssue>> {
+    return (schemaValidation) => {
+        if (schemaValidation.issues.length > 0) {
+            return { tag: "Err", content: schemaValidation.issues };
         }
 
         const tables = instanceTablesFromModel(
             instanceCapableShape(schema),
             store,
             handle,
-            schemaResult.content,
+            schemaValidation.model,
         );
         const issues: TableFieldIssue[] = validateTableFields(
             store.getDocumentView(handle) as Readonly<InstanceDocument>,

--- a/packages/documents/src/model/elaborated-model.ts
+++ b/packages/documents/src/model/elaborated-model.ts
@@ -49,22 +49,27 @@ export interface ElaboratedModel<out S extends Shape> {
     judgmentsOf(typeOrShape: AnyCellType | Shape): ReadonlyArray<JudgmentOf<S>>;
 }
 
-/** A live view of a notebook's validation state.
-
-While the view is active, the notebook revalidates whenever its document
-changes; `model` and `issues` reflect the latest outcome. The caller must
-dispose the view when it is no longer needed.
+/** The result of elaborating and validating a notebook.
 
 Elaboration and validation are separate steps, so `model` is always available:
-it reflects the latest elaboration even when validation fails. It is empty
-only before the first elaboration completes or when elaboration itself fails. 
-
-In the case of an empty model the `model.judgments` and `model.judgementsOf` methods 
-return empty arrays. */
-export interface ValidationView<out S extends Shape> {
+it contains the elaborated judgments even when validation fails. The model is
+empty only when elaboration itself fails. */
+export interface ModelValidation<out S extends Shape> {
     readonly model: ElaboratedModel<S>;
     /** Validation issues; empty when the notebook is valid. */
     readonly issues: ReadonlyArray<Issue>;
+}
+
+/** A live view of a notebook's validation state.
+
+While the view is active, the notebook revalidates whenever its document
+changes; `model` and `issues` reflect the latest outcome. Before the first
+elaboration completes, `model` is empty and `issues` reports that validation is
+pending. The caller must dispose the view when it is no longer needed.
+
+In the case of an empty model the `model.judgments` and `model.judgmentsOf`
+methods return empty arrays. */
+export interface ModelValidationView<out S extends Shape> extends ModelValidation<S> {
     dispose(): void;
 }
 

--- a/packages/documents/src/model/notebook.ts
+++ b/packages/documents/src/model/notebook.ts
@@ -2,7 +2,6 @@ import { Model, Nb } from "catcolab-document-methods";
 import type { ModelJudgment } from "catcolab-document-types";
 import type { DocumentStore } from "../document-store";
 import type { NotebookDocument } from "../notebook-document";
-import type { Result } from "../result";
 import { getRichTextCell, type RichTextCell } from "../rich-text";
 import type {
     AnyCellType,
@@ -26,7 +25,7 @@ import {
     type ObjectCell,
 } from "./cell";
 import type { ModelDocument } from "./document";
-import type { ElaboratedModel, ValidationView } from "./elaborated-model";
+import type { ModelValidation, ModelValidationView } from "./elaborated-model";
 import { morphismTypesEqual, objectTypesEqual } from "./equality";
 import { createNotebookValidator } from "./validation";
 
@@ -179,11 +178,11 @@ export interface Notebook<
     update(patch: Partial<{ title: string }>): void;
     dump(): D;
     onChange(callback: () => void): () => void;
-    validate(): Promise<Result<ElaboratedModel<S>>>;
-    onValidate(callback: (result: Result<ElaboratedModel<S>>) => void): () => void;
+    validate(): Promise<ModelValidation<S>>;
+    onValidate(callback: (result: ModelValidation<S>) => void): () => void;
     /** Create a live, reactive view of the notebook's validation state. The
      * caller must dispose the view when it is no longer needed. */
-    createValidationView(): ValidationView<S>;
+    createValidationView(): ModelValidationView<S>;
 }
 
 export function modelNotebookFromStore<Handle, S extends Shape>(

--- a/packages/documents/src/model/validation.ts
+++ b/packages/documents/src/model/validation.ts
@@ -2,12 +2,12 @@ import type { FormalCell, ModelDocument } from "catcolab-document-methods";
 import type { ModelJudgment, Notebook } from "catcolab-document-types";
 import type { DblModel, DblTheory, InvalidDblModel, ModelPresentation } from "catlog-wasm";
 import { createReactiveView, type DocumentStore } from "../document-store";
-import type { Issue, Result } from "../result";
+import type { Issue } from "../result";
 import type { Shape } from "../shape";
 import {
     elaboratedModelFromPresentation,
-    type ElaboratedModel,
-    type ValidationView,
+    type ModelValidation,
+    type ModelValidationView,
 } from "./elaborated-model";
 
 function formalCellForGenerator(
@@ -99,7 +99,7 @@ function invalidModelIssue(notebook: Notebook<ModelJudgment>, error: InvalidDblM
 
 Elaboration and validation are separate steps: even an invalid model has a
 presentation, so `presentation` is absent only when elaboration itself fails. */
-export interface ModelValidation {
+interface ModelValidationState {
     /** Presentation of the elaborated model; absent if elaboration failed. */
     readonly presentation?: ModelPresentation;
     /** Validation issues; empty when the document is valid. */
@@ -112,7 +112,7 @@ export async function validateModelDocument(
     document: Readonly<ModelDocument>,
     theory: DblTheory,
     refId: string,
-): Promise<ModelValidation> {
+): Promise<ModelValidationState> {
     const { DblModelMap, elaborateModel } = await import("catlog-wasm");
     const instantiatedModels = new DblModelMap();
     let model: DblModel;
@@ -142,13 +142,13 @@ export async function validateModelDocument(
 /** The validation surface of a notebook: one-shot validation, validation
 callbacks, and live validation views. */
 export interface NotebookValidator<S extends Shape> {
-    validate(): Promise<Result<ElaboratedModel<S>>>;
-    onValidate(callback: (result: Result<ElaboratedModel<S>>) => void): () => void;
-    createValidationView(): ValidationView<S>;
+    validate(): Promise<ModelValidation<S>>;
+    onValidate(callback: (result: ModelValidation<S>) => void): () => void;
+    createValidationView(): ModelValidationView<S>;
 }
 
 /** The state shared by all validation consumers of a notebook. */
-type ValidationState = ModelValidation;
+type ValidationState = ModelValidationState;
 
 /** Create the validation machinery for a notebook over a document store.
 
@@ -163,7 +163,7 @@ export function createNotebookValidator<Handle, S extends Shape>(
     let coreTheory: Promise<DblTheory> | undefined;
 
     /** Elaborate and validate the current document. */
-    async function elaborateAndValidate(): Promise<ModelValidation> {
+    async function elaborateAndValidate(): Promise<ModelValidationState> {
         if (!shape.getCoreTheory) {
             let shapeName = "unnamed";
             if (shape.theory) {
@@ -190,18 +190,14 @@ export function createNotebookValidator<Handle, S extends Shape>(
         }
     }
 
-    /** Convert a validation state into the `Result` exposed by `validate` and
-    `onValidate`. Ok only when elaboration succeeded and there are no issues. */
-    function resultFromValidation({
+    /** Convert internal validation state into the public snapshot. */
+    function modelValidationFromState({
         presentation,
         issues,
-    }: ModelValidation): Result<ElaboratedModel<S>> {
-        if (issues.length > 0 || presentation === undefined) {
-            return { tag: "Err", content: issues };
-        }
+    }: ModelValidationState): ModelValidation<S> {
         return {
-            tag: "Ok",
-            content: elaboratedModelFromPresentation(shape, () => presentation),
+            model: elaboratedModelFromPresentation(shape, () => presentation),
+            issues,
         };
     }
 
@@ -222,7 +218,7 @@ export function createNotebookValidator<Handle, S extends Shape>(
     /** Revalidate the document and publish the outcome to listeners. When
     revalidations overlap, only the latest-started one publishes, so listeners
     never observe stale state; every caller still receives its own outcome. */
-    async function revalidate(): Promise<ModelValidation> {
+    async function revalidate(): Promise<ModelValidationState> {
         const ticket = ++revalidationCounter;
         const state = await elaborateAndValidate();
         if (ticket === revalidationCounter) {
@@ -255,14 +251,14 @@ export function createNotebookValidator<Handle, S extends Shape>(
 
     return {
         async validate() {
-            return resultFromValidation(await revalidate());
+            return modelValidationFromState(await revalidate());
         },
         onValidate(callback) {
             return subscribeToValidationState((state) => {
-                callback(resultFromValidation(state));
+                callback(modelValidationFromState(state));
             });
         },
-        createValidationView(): ValidationView<S> {
+        createValidationView(): ModelValidationView<S> {
             const reactiveView = createReactiveView(store, latestValidationState);
             const dispose = subscribeToValidationState((state) => {
                 reactiveView.replace(state);

--- a/packages/documents/test/corpus/model-editing.db-dump-test.ts
+++ b/packages/documents/test/corpus/model-editing.db-dump-test.ts
@@ -129,7 +129,7 @@ describe("editing valid models from a Next database dump", () => {
                 continue;
             }
 
-            if ((await opened.notebook.validate()).tag !== "Ok") {
+            if ((await opened.notebook.validate()).issues.length > 0) {
                 semanticallyInvalid += 1;
                 continue;
             }
@@ -174,7 +174,7 @@ async function checkFixture(
                 for (const edit of edits) {
                     applySemanticPreservingEdit(opened.notebook, edit);
                     assertNotebookStructureIsConsistent(opened.notebook);
-                    expect((await opened.notebook.validate()).tag).toBe("Ok");
+                    expect((await opened.notebook.validate()).issues).toEqual([]);
                 }
             }),
             { numRuns, seed: seedFromRef(fixture.refId) },
@@ -189,7 +189,7 @@ async function checkFixture(
 
                 const { notebook, storeHarness } = opened;
                 assertNotebookStructureIsConsistent(notebook);
-                expect((await notebook.validate()).tag).toBe("Ok");
+                expect((await notebook.validate()).issues).toEqual([]);
 
                 const baseline = structuredClone(notebook.dump());
                 const dependencies = storeHarness.snapshotLoadedExcept(fixture.refId);
@@ -202,12 +202,12 @@ async function checkFixture(
 
                 const commit = transaction.commit();
                 assertNotebookStructureIsConsistent(notebook);
-                expect(["Err", "Ok"]).toContain((await notebook.validate()).tag);
+                expect((await notebook.validate()).model).toBeDefined();
 
                 notebook.revertCommit(commit);
                 assertNotebookStructureIsConsistent(notebook);
                 expect(notebook.dump()).toEqual(baseline);
-                expect((await notebook.validate()).tag).toBe("Ok");
+                expect((await notebook.validate()).issues).toEqual([]);
                 expect(storeHarness.snapshotLoadedExcept(fixture.refId)).toEqual(dependencies);
             }),
             { numRuns, seed: seedFromRef(fixture.refId) },

--- a/packages/documents/test/instantiation.test.ts
+++ b/packages/documents/test/instantiation.test.ts
@@ -30,6 +30,6 @@ describe.skip("instantiation", () => {
 
         // Instantiating a valid notebook keeps this notebook valid.
         const result = await notebook.validate();
-        expect(result.tag).toBe("Ok");
+        expect(result.issues).toEqual([]);
     });
 });

--- a/packages/documents/test/migration.test.ts
+++ b/packages/documents/test/migration.test.ts
@@ -37,6 +37,6 @@ describe.skip("migrating between logics", () => {
                 .map((cell) => cell.label)
                 .join(", "),
         ).toBe("has");
-        expect((await schema.validate()).tag).toBe("Ok");
+        expect((await schema.validate()).issues).toEqual([]);
     });
 });

--- a/packages/documents/test/path-equations.test.ts
+++ b/packages/documents/test/path-equations.test.ts
@@ -32,6 +32,6 @@ describe.skip("path equations", () => {
         expect(notebook.cellsOf(PathEquation).length).toBe(1);
 
         const result = await notebook.validate();
-        expect(result.tag).toBe("Ok");
+        expect(result.issues).toEqual([]);
     });
 });

--- a/packages/documents/test/solid-completions.test.tsx
+++ b/packages/documents/test/solid-completions.test.tsx
@@ -24,11 +24,10 @@ import {
     defineObject,
     defineShape,
     type DocumentStore,
-    type ModelValidationResult,
+    type ModelValidation,
     type Notebook,
     type NotebookCell,
     RichText,
-    type ValidatableNotebook,
 } from "catcolab-documents";
 import type { DblModel, ObType, QualifiedName } from "catlog-wasm";
 import { selfResolving } from "./helpers/self_resolving";
@@ -186,20 +185,16 @@ function MyCellEditor(props: { cell: NotebookCell<typeof MyShape>; text: Accesso
 // Globals for testing
 let testCurrentModel!: () => DblModel | undefined;
 
-function MyNotebookEditor(props: {
-    notebook: MyNotebook & ValidatableNotebook;
-    text: Accessor<string>;
-}) {
+function MyNotebookEditor(props: { notebook: MyNotebook; text: Accessor<string> }) {
     // `onValidate` delivers an initial result and then re-validates whenever
     // anything the validation depends on changes, notifying only when the
     // result actually changed.
-    const [validation, setValidation] = createSignal<ModelValidationResult>();
+    const [validation, setValidation] = createSignal<ModelValidation<typeof MyShape>>();
     const unsubscribe = props.notebook.onValidate(setValidation);
     onCleanup(unsubscribe);
 
     const model = () => {
-        const result = validation();
-        return result?.tag === "Ok" ? result.content : undefined;
+        return validation()?.model;
     };
 
     testCurrentModel = model;

--- a/packages/documents/test/stores/backend-store.test.ts
+++ b/packages/documents/test/stores/backend-store.test.ts
@@ -106,6 +106,6 @@ describe.skip("backend binder", () => {
         notebook.add(Instantiation, { label: "ImportedOlog", model: imported });
 
         const result = await notebook.validate();
-        expect(result.tag).toBe("Ok");
+        expect(result.issues).toEqual([]);
     });
 });

--- a/packages/documents/test/validation.test.ts
+++ b/packages/documents/test/validation.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "vitest";
 
 // RFC-0006 "Model validation": the asynchronous `validate` method, subscribing
 // to validation changes with `onValidate`, and validation failures.
-import { createBinder, type ElaboratedModel, Instantiation, type Result } from "catcolab-documents";
+import { createBinder, Instantiation, type ModelValidation } from "catcolab-documents";
 
 async function wellFormedOlog() {
     const binder = createBinder();
@@ -19,23 +19,32 @@ async function wellFormedOlog() {
 // the first time tests run we incur the cost of loading the catlog-wasm bundle,
 // so these tests have longer timeouts
 describe("validate", { timeout: 10000 }, () => {
-    test("a well-formed notebook validates to an Ok carrying the elaborated model", async () => {
+    test("a well-formed notebook validates without issues", async () => {
         const notebook = await wellFormedOlog();
 
-        const result: Result<ElaboratedModel<typeof SimpleOlog>> = await notebook.validate();
-        expect(result.tag).toBe("Ok");
+        const result: ModelValidation<typeof SimpleOlog> = await notebook.validate();
+        expect(result.issues).toEqual([]);
     });
 
     test("the elaborated model is available on the result and can be queried", async () => {
         const notebook = await wellFormedOlog();
 
         const result = await notebook.validate();
-        expect(result.tag).toBe("Ok");
-        if (result.tag !== "Ok") {
-            return;
-        }
-        expect(result.content.judgmentsOf(Type).length).toBe(2);
-        expect(result.content.judgmentsOf(Aspect).length).toBe(1);
+        expect(result.model.judgmentsOf(Type).length).toBe(2);
+        expect(result.model.judgmentsOf(Aspect).length).toBe(1);
+    });
+
+    test("an invalid notebook still returns its elaborated model", async () => {
+        const notebook = await wellFormedOlog();
+        notebook.add(Aspect, { label: "dangling", from: null, to: null });
+
+        const result = await notebook.validate();
+
+        expect(result.issues.length).toBeGreaterThan(0);
+        expect(result.model.judgmentsOf(Type).length).toBe(2);
+        expect(result.model.judgmentsOf(Aspect).map((judgment) => judgment.label)).toEqual([
+            ["has"],
+        ]);
     });
 });
 
@@ -43,20 +52,20 @@ describe("onValidate", { timeout: 10000 }, () => {
     test("always calls the callback at least once with the current validation", async () => {
         const notebook = await wellFormedOlog();
 
-        const first = await new Promise<Result<ElaboratedModel<typeof SimpleOlog>>>((resolve) => {
+        const first = await new Promise<ModelValidation<typeof SimpleOlog>>((resolve) => {
             const unsubscribe = notebook.onValidate((result) => {
                 resolve(result);
                 unsubscribe();
             });
         });
 
-        expect(first.tag).toBe("Ok");
+        expect(first.issues).toEqual([]);
     });
 
     test("notifies when changes to the formal content affect the validation result", async () => {
         const notebook = await wellFormedOlog();
 
-        const results: Result<ElaboratedModel<typeof SimpleOlog>>[] = [];
+        const results: ModelValidation<typeof SimpleOlog>[] = [];
         const unsubscribe = notebook.onValidate((result) => {
             results.push(result);
         });
@@ -78,7 +87,9 @@ describe("onValidate", { timeout: 10000 }, () => {
         }
         unsubscribe();
 
-        expect(results[results.length - 1]?.tag).toBe("Err");
+        const latest = results[results.length - 1];
+        expect(latest?.issues.length).toBeGreaterThan(0);
+        expect(latest?.model.judgmentsOf(Type).map((judgment) => judgment.label)).toEqual([["B"]]);
     });
 });
 
@@ -97,11 +108,7 @@ describe.skip("validation result", () => {
         second.add(Instantiation, { label: "ImportedFirst", model: first });
 
         const result = await first.validate();
-        expect(result.tag).toBe("Err");
-        if (result.tag !== "Err") {
-            return;
-        }
-        expect(result.content.map((issue) => issue.message).join("; ")).toBe(
+        expect(result.issues.map((issue) => issue.message).join("; ")).toBe(
             'Instantiation cycle detected: "First" → "Second" → "First". ' +
                 "A notebook cannot instantiate itself, directly or indirectly. " +
                 "To fix, remove one of the instantiations in this chain.",

--- a/packages/frontend/src/llm_conversation/scoped_document.ts
+++ b/packages/frontend/src/llm_conversation/scoped_document.ts
@@ -6,7 +6,7 @@ export type DocumentBinding<Handle = unknown, E extends Issue = Issue> = {
     readonly document: Readonly<Document>;
     readonly handle: Handle;
     readonly title: string;
-    validate(): Promise<Result<unknown, ReadonlyArray<E>>>;
+    validate(): Promise<Result<unknown, ReadonlyArray<E>> | { issues: ReadonlyArray<E> }>;
 };
 
 export type ScopedDocumentLink = {
@@ -71,8 +71,9 @@ async function validateScopedDocument<E extends Issue>(
     binding: string,
 ): Promise<ReadonlyArray<string>> {
     const result = await document.validate();
-    if (result.tag === "Err") {
-        return [`${binding}: ${JSON.stringify(result.content)}`];
+    const issues = "issues" in result ? result.issues : result.tag === "Err" ? result.content : [];
+    if (issues.length > 0) {
+        return [`${binding}: ${JSON.stringify(issues)}`];
     }
     return [];
 }

--- a/packages/logics/test/petri-net.test.ts
+++ b/packages/logics/test/petri-net.test.ts
@@ -74,11 +74,8 @@ describe("The petri-net logic", () => {
         });
 
         const result = await notebook.validate();
-        expect(result.tag).toBe("Ok");
-        if (result.tag !== "Ok") {
-            return;
-        }
-        expect(result.content.obGenerators().length).toBe(3);
-        expect(result.content.morGenerators().length).toBe(1);
+        expect(result.issues).toEqual([]);
+        expect(result.model.judgmentsOf(Place).length).toBe(3);
+        expect(result.model.judgmentsOf(Transition).length).toBe(1);
     });
 });

--- a/packages/logics/test/simple-olog-advanced.test.ts
+++ b/packages/logics/test/simple-olog-advanced.test.ts
@@ -16,12 +16,9 @@ describe.skip("the simple-olog logic (advanced)", () => {
         notebook.add(Aspect, { label: "has", from: a, to: b });
 
         const result = await notebook.validate();
-        expect(result.tag).toBe("Ok");
-        if (result.tag !== "Ok") {
-            return;
-        }
-        expect(result.content.obGenerators().length).toBe(2);
-        expect(result.content.morGenerators().length).toBe(1);
+        expect(result.issues).toEqual([]);
+        expect(result.model.judgmentsOf(Type).length).toBe(2);
+        expect(result.model.judgmentsOf(Aspect).length).toBe(1);
     });
 
     test("the shape supports rich text and path equations", async () => {
@@ -79,6 +76,6 @@ describe.skip("the simple-olog logic (advanced)", () => {
             return;
         }
         expect(migration.content.document.theory).toBe("simple-schema");
-        expect((await migration.content.validate()).tag).toBe("Ok");
+        expect((await migration.content.validate()).issues).toEqual([]);
     });
 });

--- a/packages/logics/test/simple-schema.test.ts
+++ b/packages/logics/test/simple-schema.test.ts
@@ -57,12 +57,11 @@ describe("the simple-schema logic", () => {
         notebook.add(Attr, { label: "name", from: person, to: str });
 
         const result = await notebook.validate();
-        expect(result.tag).toBe("Ok");
-        if (result.tag !== "Ok") {
-            return;
-        }
-        expect(result.content.obGenerators().length).toBe(3);
-        expect(result.content.morGenerators().length).toBe(2);
+        expect(result.issues).toEqual([]);
+        expect(result.model.judgmentsOf(Entity).length).toBe(2);
+        expect(result.model.judgmentsOf(AttrType).length).toBe(1);
+        expect(result.model.judgmentsOf(Mapping).length).toBe(1);
+        expect(result.model.judgmentsOf(Attr).length).toBe(1);
     });
 
     test("the shape supports rich text", async () => {
@@ -102,6 +101,6 @@ describe("the simple-schema logic", () => {
             return;
         }
         expect(migration.content.document.theory).toBe("simple-olog");
-        expect((await migration.content.validate()).tag).toBe("Ok");
+        expect((await migration.content.validate()).issues).toEqual([]);
     });
 });


### PR DESCRIPTION
Based on #1435 but didn't want to sit on top of @epatters WIP #1436 on the stack.

This adds `ModelValidation` which is the validation type from #1435 minus the reactivity. It always has the elaborated model and an array of issues. We no longer return a `Result` from validation, instead we always return a `ModelValidation`. 

```diff
-    validate(): Promise<Result<ElaboratedModel<S>>>;
-    onValidate(callback: (result: Result<ElaboratedModel<S>>) => void): () => void;
+    validate(): Promise<ModelValidation<S>>;
+    onValidate(callback: (result: ModelValidation<S>) => void): () => void;
```

```ts
export interface ModelValidation<out S extends Shape> {
    readonly model: ElaboratedModel<S>;
    /** Validation issues; empty when the notebook is valid. */
    readonly issues: ReadonlyArray<Issue>;
}
```