### PR TITLE
Reactive view for instance validation

### DIFF
--- a/packages/documents/src/index.ts
+++ b/packages/documents/src/index.ts
@@ -7,7 +7,12 @@ export { createInMemoryStore } from "./document-store";
 export { atomicTypeOfAttributeType } from "./instance/validation";
 export type { FieldPath, OrphanedTableIssue, TableFieldIssue, TableIssue } from "./instance/errors";
 export { instanceFromStore } from "./instance/instance";
-export type { Instance, InstanceDocument, InstanceValidation } from "./instance/instance";
+export type {
+    Instance,
+    InstanceDocument,
+    InstanceValidation,
+    InstanceValidationView,
+} from "./instance/instance";
 export { llmConversationFromStore } from "./llm-conversation";
 export type {
     LLMConversation,

--- a/packages/documents/src/instance/instance.ts
+++ b/packages/documents/src/instance/instance.ts
@@ -1,8 +1,8 @@
 import type { InstanceDocument } from "catcolab-document-methods";
 import type { Document } from "catcolab-document-types";
-import type { DocumentStore } from "../document-store";
+import { createReactiveView, type DocumentStore } from "../document-store";
 import type { ModelDocument } from "../model/document";
-import type { ModelValidation } from "../model/elaborated-model";
+import type { ModelValidation, ModelValidationView } from "../model/elaborated-model";
 import type { Notebook } from "../model/notebook";
 import type { Result } from "../result";
 import type { Shape } from "../shape";
@@ -66,6 +66,9 @@ export interface Instance<H, S extends Shape> {
     onChange(callback: () => void): () => void;
     /** Revalidate initially and whenever either the instance or its schema changes. */
     onValidate(callback: (validation: InstanceValidation<S>) => void): () => void;
+    /** Create a live, reactive view of the instance's validation state. The
+     * caller must dispose the view when it is no longer needed. */
+    createValidationView(): InstanceValidationView<S>;
 }
 
 /** The result of validating an instance and its schema. */
@@ -78,6 +81,13 @@ export interface InstanceValidation<out S extends Shape> {
     readonly issues: ReadonlyArray<TableIssue>;
     /** Read one table, row, or field from the validated tables. */
     get(path: InstancePath): Result<InstanceTable | TableRow | FieldValue>;
+}
+
+/** A live view of an instance's validation state. */
+export interface InstanceValidationView<out S extends Shape> extends InstanceValidation<S> {
+    /** The live validation view of the instance's schema. */
+    readonly modelValidation: ModelValidationView<S>;
+    dispose(): void;
 }
 
 /** Create a store-backed instance. Schema-derived operations validate the schema on demand. */
@@ -184,6 +194,36 @@ export function instanceFromStore<Handle, S extends Shape>(
                 active = false;
                 unsubscribeInstance();
                 unsubscribeSchema();
+            };
+        },
+        createValidationView(): InstanceValidationView<S> {
+            const modelValidation = schema.createValidationView();
+            let revision = 0;
+            const reactiveRevision = createReactiveView(store, { revision });
+            const unsubscribeInstance = store.subscribe(handle, (): void => {
+                reactiveRevision.replace({ revision: ++revision });
+            });
+
+            function currentValidation(): InstanceValidation<S> {
+                void reactiveRevision.current.revision;
+                return validateInstance(modelValidation);
+            }
+
+            return {
+                modelValidation,
+                get tables(): ReadonlyArray<InstanceTable> {
+                    return currentValidation().tables;
+                },
+                get issues(): ReadonlyArray<TableIssue> {
+                    return currentValidation().issues;
+                },
+                get(path: InstancePath): Result<InstanceTable | TableRow | FieldValue> {
+                    return currentValidation().get(path);
+                },
+                dispose(): void {
+                    unsubscribeInstance();
+                    modelValidation.dispose();
+                },
             };
         },
     };

--- a/packages/documents/test/instances.test.ts
+++ b/packages/documents/test/instances.test.ts
@@ -221,6 +221,41 @@ describe("instance schema validation", () => {
         unsubscribeChanges();
         unsubscribeValidation();
     });
+
+    test("a validation view tracks schema and instance changes", async () => {
+        const binder = createBinder();
+        const schema = await binder.createNotebook(SimpleSchema, { title: "Company schema" });
+        schema.add(Entity, { label: "Person" });
+        const instance = expectOk(
+            await binder.createInstance(schema, { title: "Company instance" }),
+        );
+        const view = instance.createValidationView();
+
+        await expect.poll(() => view.modelValidation.issues).toEqual([]);
+        expect(view.tables.map((table) => table.label)).toEqual(["Person"]);
+
+        schema.add(Entity, { label: "Company" });
+        await expect
+            .poll(() => view.tables.map((table) => table.label))
+            .toEqual(["Person", "Company"]);
+
+        binder.store.changeDocument(instance.handle, (document) => {
+            const stored = document as unknown as StoredInstanceForTest;
+            stored.tables["ghost-table"] = {
+                rows: { "ghost-row": { fields: { mystery: { Int: 3 } } } },
+                rowOrder: ["ghost-row"],
+            };
+        });
+        await expect
+            .poll(() => view.issues.map((issue) => issue.issueType))
+            .toEqual(["OrphanedTable"]);
+        expect(view.get(["ghost-table", "rows", "ghost-row", "fields", "mystery"])).toMatchObject({
+            tag: "Ok",
+            content: { tag: "Int", content: { value: 3 } },
+        });
+
+        view.dispose();
+    });
 });
 
 describe("tabular instances", () => {

--- a/packages/documents/test/stores/solid-validation-view.test.ts
+++ b/packages/documents/test/stores/solid-validation-view.test.ts
@@ -1,4 +1,5 @@
 import { Aspect, SimpleOlog, Type } from "catcolab-logics/simple-olog";
+import { Attr, AttrType, Entity, SimpleSchema } from "catcolab-logics/simple-schema";
 import { createEffect, createRoot } from "solid-js";
 import { describe, expect, test } from "vitest";
 
@@ -44,6 +45,81 @@ describe("reactive validation view", { timeout: 20000 }, () => {
         expect(notebook.handle.listeners.size).toBeGreaterThan(0);
         view.dispose();
         expect(notebook.handle.listeners.size).toBe(0);
+        dispose();
+    });
+
+    test("threads model and instance reactivity through an instance view", async () => {
+        const solidBinder = createBinder(solidStore);
+        const schema = await solidBinder.createNotebook(SimpleSchema, {
+            title: "Company schema",
+        });
+        const person = schema.add(Entity, { label: "Person" });
+        const string = schema.add(AttrType, { label: "String" });
+        schema.add(Attr, { label: "name", from: person, to: string });
+        const instanceResult = await solidBinder.createInstance(schema, {
+            title: "Company instance",
+        });
+        if (instanceResult.tag === "Err") {
+            throw new Error("Expected the instance to be created");
+        }
+        const instance = instanceResult.content;
+        const view = instance.createValidationView();
+
+        let tableLabels: Array<string | null> = [];
+        let headerLabels: Array<string | null> = [];
+        let rowCount = -1;
+        let issueTypes: string[] = [];
+        let schemaIssueCount = -1;
+        const dispose = createRoot((dispose) => {
+            // All observed state comes from one view; no signals are updated manually.
+            createEffect(() => {
+                schemaIssueCount = view.modelValidation.issues.length;
+                const tables = view.tables;
+                tableLabels = tables.map((table) => table.label);
+                headerLabels = tables[0]?.headers.map((header) => header.label) ?? [];
+                rowCount = tables[0]?.rows.length ?? -1;
+                issueTypes = view.issues.map((issue) => issue.issueType);
+            });
+            return dispose;
+        });
+
+        await expect.poll(() => schemaIssueCount, { timeout: 10000 }).toBe(0);
+        expect(tableLabels).toEqual(["Person"]);
+        expect(headerLabels).toEqual(["name"]);
+        expect(rowCount).toBe(0);
+
+        const personTable = view.tables[0];
+        if (personTable === undefined) {
+            throw new Error("Expected the Person table");
+        }
+        // An instance edit updates the row count without refreshing the view.
+        const rowResult = await instance.addRow(personTable, { name: "Alice" });
+        if (rowResult.tag === "Err") {
+            throw new Error("Expected the row to be added");
+        }
+        await expect.poll(() => rowCount).toBe(1);
+
+        // A schema edit updates both the derived headers and instance issues.
+        schema.add(Attr, { label: "role", from: person, to: string });
+        await expect.poll(() => headerLabels).toEqual(["name", "role"]);
+        await expect.poll(() => issueTypes).toEqual(["MissingValue"]);
+
+        const roleHeader = view.tables[0]?.headers.find((header) => header.label === "role");
+        if (roleHeader === undefined) {
+            throw new Error("Expected the role header");
+        }
+        const setResult = await instance.set(rowResult.content, roleHeader, "Engineer");
+        if (setResult.tag === "Err") {
+            throw new Error("Expected the role to be set");
+        }
+        // Repairing the instance clears the issue through the same view.
+        await expect.poll(() => issueTypes).toEqual([]);
+
+        expect(instance.handle.listeners.size).toBeGreaterThan(0);
+        expect(schema.handle.listeners.size).toBeGreaterThan(0);
+        view.dispose();
+        expect(instance.handle.listeners.size).toBe(0);
+        expect(schema.handle.listeners.size).toBe(0);
         dispose();
     });
 });


### PR DESCRIPTION
Adds an `instance.createValidationView` which returns a reactive view of the instance and model validation. The reactivity of the model validation view is threaded through.