### PR TITLE
OBEE-49 Rust names equations in errors, tie equations into TS Judgement

### DIFF
--- a/packages/catlog-wasm/src/model.rs
+++ b/packages/catlog-wasm/src/model.rs
@@ -651,6 +651,18 @@ impl DblModel {
                     },
                     mor_generators: {
                         model.mor_generators().filter_map(|id| self.mor_presentation(id)).collect()
+                    },
+                    equations: match self.discrete() {
+                        Ok(model) => model
+                            .equations()
+                            .map(|(id, lhs, rhs)| EquationGenerator {
+                                id: id.clone(),
+                                label: self.ob_namespace.label(&id),
+                                lhs: Quoter.quote(&lhs),
+                                rhs: Quoter.quote(&rhs),
+                            })
+                            .collect(),
+                        Err(_) => Vec::new(),
                     }
                 }
             }
@@ -934,5 +946,89 @@ pub(crate) mod tests {
         assert_eq!(model.ob_generators().len(), 2);
         assert_eq!(model.mor_generators().len(), 2);
         assert_eq!(model.validate().0, JsResult::Ok(()));
+    }
+
+    #[test]
+    fn model_equation_error_is_named() {
+        use catlog::dbl::model::{InvalidDblModel, InvalidModelEqn};
+        use nonempty::nonempty;
+
+        let th = ThCategory::new().theory();
+        let [a, b, f, g, eqn] = std::array::from_fn(|_| Uuid::now_v7());
+
+        let mut cells = HashMap::new();
+        for (decl, id) in [
+            (
+                ModelJudgment::Object(ObDecl {
+                    name: "A".into(),
+                    id: a,
+                    ob_type: ObType::Basic("Object".into()),
+                }),
+                a,
+            ),
+            (
+                ModelJudgment::Object(ObDecl {
+                    name: "B".into(),
+                    id: b,
+                    ob_type: ObType::Basic("Object".into()),
+                }),
+                b,
+            ),
+        ] {
+            cells.insert(id, NotebookCell::Formal { id, content: decl });
+        }
+        for (decl, id) in [
+            (
+                ModelJudgment::Morphism(MorDecl {
+                    name: "f".into(),
+                    id: f,
+                    mor_type: MorType::Hom(Box::new(ObType::Basic("Object".into()))),
+                    dom: Some(Ob::Basic(a.to_string())),
+                    cod: Some(Ob::Basic(a.to_string())),
+                }),
+                f,
+            ),
+            (
+                ModelJudgment::Morphism(MorDecl {
+                    name: "g".into(),
+                    id: g,
+                    mor_type: MorType::Hom(Box::new(ObType::Basic("Object".into()))),
+                    dom: Some(Ob::Basic(b.to_string())),
+                    cod: Some(Ob::Basic(b.to_string())),
+                }),
+                g,
+            ),
+        ] {
+            cells.insert(id, NotebookCell::Formal { id, content: decl });
+        }
+        cells.insert(
+            eqn,
+            NotebookCell::Formal {
+                id: eqn,
+                content: ModelJudgment::Equation(EqnDecl {
+                    name: "bad".into(),
+                    id: eqn,
+                    lhs: Some(Mor::Basic(f.to_string())),
+                    rhs: Some(Mor::Basic(g.to_string())),
+                }),
+            },
+        );
+        let notebook = ModelNotebook(Notebook {
+            cell_contents: cells,
+            cell_order: vec![a, b, f, g, eqn],
+        });
+
+        let instantiated = DblModelMap::new();
+        let model = elaborate_model(&notebook, &instantiated, &th, "test".into()).unwrap();
+        let JsResult::Err(errors) = model.validate().0 else {
+            panic!("Expected the model to be invalid");
+        };
+        assert_eq!(
+            errors,
+            vec![InvalidDblModel::Eqn(
+                QualifiedName::from(eqn),
+                nonempty![InvalidModelEqn::Src, InvalidModelEqn::Tgt],
+            )]
+        );
     }
 }

--- a/packages/catlog-wasm/src/model_presentation.rs
+++ b/packages/catlog-wasm/src/model_presentation.rs
@@ -8,12 +8,10 @@
 use serde::{Deserialize, Serialize};
 use tsify::Tsify;
 
-use catcolab_document_types::current::{MorType, Ob, ObType};
+use catcolab_document_types::current::{Mor, MorType, Ob, ObType};
 use catlog::zero::{QualifiedLabel, QualifiedName};
 
 /// Presentation of a model of a double theory.
-///
-/// TODO: Include equations between morphisms.
 #[derive(Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub struct ModelPresentation {
@@ -24,6 +22,26 @@ pub struct ModelPresentation {
     /// Generating morphisms.
     #[serde(rename = "morGenerators")]
     pub mor_generators: Vec<MorGenerator>,
+
+    /// Equations between morphisms.
+    pub equations: Vec<EquationGenerator>,
+}
+
+/// Equation in a model of a double theory.
+#[derive(Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct EquationGenerator {
+    /// Unique identifier of equation.
+    pub id: QualifiedName,
+
+    /// Human-readable label for equation.
+    pub label: Option<QualifiedLabel>,
+
+    /// Left-hand side of the equation.
+    pub lhs: Mor,
+
+    /// Right-hand side of the equation.
+    pub rhs: Mor,
 }
 
 /// Object generator in a model of a double theory.

--- a/packages/catlog/src/tt/notebook_elab.rs
+++ b/packages/catlog/src/tt/notebook_elab.rs
@@ -181,7 +181,11 @@ impl<'a> Elaborator<'a> {
                 nb::path::Path::Id(ob) => {
                     let (stx, val, ob_type) = self.ob_syn(ob)?;
                     let mor_type = self.theory().hom_type(ob_type)?;
-                    Some((stx, val.clone(), TyV::morphism(mor_type, val.clone(), val.clone())))
+                    Some((
+                        stx,
+                        TmV::id(val.clone()),
+                        TyV::morphism(mor_type, val.clone(), val.clone()),
+                    ))
                 }
                 nb::path::Path::Seq(ms) => match ms.as_slice() {
                     [] => None,

--- a/packages/documents/src/index.ts
+++ b/packages/documents/src/index.ts
@@ -40,6 +40,8 @@ export type {
     ElaboratedModel,
     ModelValidation,
     ModelValidationView,
+    EquationJudgment,
+    EquationJudgmentSide,
 } from "./model/elaborated-model";
 export type { NotebookDocument } from "./notebook-document";
 export type { RichTextCell } from "./rich-text";

--- a/packages/documents/src/model/elaborated-model.ts
+++ b/packages/documents/src/model/elaborated-model.ts
@@ -1,13 +1,16 @@
+import type { Mor } from "catcolab-document-types";
 import type { ModelPresentation, MorGenerator, QualifiedLabel } from "catlog-wasm";
 import type { Issue } from "../result";
 import {
     findMorphismType,
     findObjectType,
     type AnyCellType,
+    type EquationType,
     type MorphismType,
     type MorphismTypesOf,
     type ObjectType,
     type ObjectTypesOf,
+    type RichTextType,
     type Shape,
 } from "../shape";
 import { morphismTypesEqual, objectTypesEqual } from "./equality";
@@ -36,16 +39,45 @@ export interface MorphismJudgment<
 }
 
 /** A judgment of an elaborated model.*/
+/** One side of an elaborated equation: the identity on an object, or a
+composite of morphism judgments. Morphisms that cannot be resolved are `null`. */
+export type EquationJudgmentSide<S extends Shape> =
+    | ObjectJudgment<ObjectTypesOf<S>>
+    | {
+          readonly kind: "composite";
+          readonly morphisms: ReadonlyArray<MorphismJudgment<S> | null>;
+      };
+
+/** An equation judgment of an elaborated model. Mirrors [`EquationCell`], minus
+mutation. */
+export interface EquationJudgment<S extends Shape> {
+    readonly kind: "path-equation";
+    readonly id: string;
+    readonly label: QualifiedLabel;
+    readonly lhs: EquationJudgmentSide<S>;
+    readonly rhs: EquationJudgmentSide<S>;
+}
+
+/** A judgment of an elaborated model.*/
 export type JudgmentOf<S extends Shape> =
     | ObjectJudgment<ObjectTypesOf<S>>
-    | MorphismJudgment<S, MorphismTypesOf<S>>;
+    | MorphismJudgment<S, MorphismTypesOf<S>>
+    | EquationJudgment<S>;
 
 /** Read-only, shape-typed access to an elaborated model.
 
 The API mirrors the notebook's `cells`/`cellsOf`: judgments are returned in
-presentation order (objects first, then morphisms). */
+presentation order (objects first, then morphisms, then equations). */
 export interface ElaboratedModel<out S extends Shape> {
     judgments(): ReadonlyArray<JudgmentOf<S>>;
+
+    /** Judgments of the given cell type or shape, in presentation order.
+
+    Filtering by a specific cell type narrows the result accordingly. */
+    judgmentsOf(type: RichTextType): ReadonlyArray<never>;
+    judgmentsOf(type: ObjectType): ReadonlyArray<ObjectJudgment<ObjectTypesOf<S>>>;
+    judgmentsOf(type: MorphismType): ReadonlyArray<MorphismJudgment<S>>;
+    judgmentsOf(type: EquationType): ReadonlyArray<EquationJudgment<S>>;
     judgmentsOf(typeOrShape: AnyCellType | Shape): ReadonlyArray<JudgmentOf<S>>;
 }
 
@@ -101,30 +133,48 @@ export function elaboratedModelFromPresentation<S extends Shape>(
             objects.push(judgment);
         }
 
+        const morphismsById = new Map<string, MorphismJudgment<S>>();
         const morphisms: MorphismJudgment<S, MorphismTypesOf<S>>[] = [];
         for (const generator of presentation.morGenerators) {
             const type = findMorphismType(shape, generator.morType);
             if (type === undefined) {
                 continue;
             }
-            morphisms.push({
+            const judgment: MorphismJudgment<S> = {
                 kind: "morphism",
                 id: generator.id,
                 type,
                 label: generator.label ?? [],
                 from: endpointJudgment(objectsById, generator.dom),
                 to: endpointJudgment(objectsById, generator.cod),
+            };
+            morphismsById.set(generator.id, judgment);
+            morphisms.push(judgment);
+        }
+
+        const equations: EquationJudgment<S>[] = [];
+        for (const generator of presentation.equations) {
+            equations.push({
+                kind: "path-equation",
+                id: generator.id,
+                label: generator.label ?? [],
+                lhs: judgmentSideFromMor(objectsById, morphismsById, generator.lhs),
+                rhs: judgmentSideFromMor(objectsById, morphismsById, generator.rhs),
             });
         }
 
-        return [...objects, ...morphisms];
+        return [...objects, ...morphisms, ...equations];
+    }
+
+    function judgmentsOf(typeOrShape: AnyCellType | Shape): ReadonlyArray<JudgmentOf<S>> {
+        return judgments().filter((judgment) => judgmentMatchesFilter(judgment, typeOrShape));
     }
 
     return {
         judgments,
-        judgmentsOf(typeOrShape: AnyCellType | Shape): ReadonlyArray<JudgmentOf<S>> {
-            return judgments().filter((judgment) => judgmentMatchesFilter(judgment, typeOrShape));
-        },
+        // The filter above already narrows per cell type, which TypeScript
+        // cannot see; the cast makes the overloads on `ElaboratedModel` honest.
+        judgmentsOf: judgmentsOf as ElaboratedModel<S>["judgmentsOf"],
     };
 }
 
@@ -136,6 +186,37 @@ function endpointJudgment<S extends Shape>(
         return null;
     }
     return objectsById.get(endpoint.content) ?? null;
+}
+
+function judgmentSideFromMor<S extends Shape>(
+    objectsById: ReadonlyMap<string, ObjectJudgment<ObjectTypesOf<S>>>,
+    morphismsById: ReadonlyMap<string, MorphismJudgment<S>>,
+    side: Mor,
+): EquationJudgmentSide<S> {
+    if (side.tag === "Composite" && side.content.tag === "Id") {
+        if (side.content.content.tag === "Basic") {
+            const judgment = objectsById.get(side.content.content.content);
+            if (judgment !== undefined) {
+                return judgment;
+            }
+        }
+        return { kind: "composite", morphisms: [null] };
+    }
+    let mors: Mor[];
+    if (side.tag === "Composite" && side.content.tag === "Seq") {
+        mors = side.content.content;
+    } else {
+        mors = [side];
+    }
+    return {
+        kind: "composite",
+        morphisms: mors.map((mor) => {
+            if (mor.tag !== "Basic") {
+                return null;
+            }
+            return morphismsById.get(mor.content) ?? null;
+        }),
+    };
 }
 
 function isCellType(value: AnyCellType | Shape): value is AnyCellType {
@@ -161,7 +242,7 @@ function judgmentMatchesFilter<S extends Shape>(
                     morphismTypesEqual(judgment.type.morType, filter.morType)
                 );
             case "path-equation":
-                return false;
+                return judgment.kind === "path-equation";
         }
     }
 
@@ -170,7 +251,10 @@ function judgmentMatchesFilter<S extends Shape>(
             objectTypesEqual(judgment.type.obType, type.obType),
         );
     }
-    return (filter.morphisms ?? []).some((type) =>
-        morphismTypesEqual(judgment.type.morType, type.morType),
-    );
+    if (judgment.kind === "morphism") {
+        return (filter.morphisms ?? []).some((type) =>
+            morphismTypesEqual(judgment.type.morType, type.morType),
+        );
+    }
+    return filter.supportsEquations === true;
 }

--- a/packages/documents/src/model/validation.ts
+++ b/packages/documents/src/model/validation.ts
@@ -102,9 +102,12 @@ function invalidModelIssue(notebook: Notebook<ModelJudgment>, error: InvalidDblM
                 path: generatorPath(notebook, error.content, "cod"),
             };
         case "Eqn": {
-            const errors = error.content[1] ?? [];
-            const details = errors.map(eqnErrorMessage).join("; ");
-            return { message: `An equation in the model is invalid: ${details}` };
+            const [name, errors] = error.content;
+            const details = (errors ?? []).map(eqnErrorMessage).join("; ");
+            return {
+                message: `Equation \`${generatorName(notebook, name)}\` is invalid: ${details}`,
+                path: generatorPath(notebook, name),
+            };
         }
         case "UnsupportedFeature": {
             if (error.content.tag === "PartialEquation") {

--- a/packages/documents/test/path-equations.test.ts
+++ b/packages/documents/test/path-equations.test.ts
@@ -18,7 +18,9 @@ function compositeLabels(side: EquationSide<typeof SimpleOlog>): Array<string | 
     return side.map((mor) => mor?.label);
 }
 
-describe("path equations", { timeout: 10000 }, () => {
+// The first test run pays the cost of loading the catlog-wasm bundle, so these
+// tests have a longer timeout (as in validation.test.ts).
+describe("path equations", { timeout: 30000 }, () => {
     test("a path equation cell relates two paths of morphisms", async () => {
         const binder = createBinder();
         const notebook = await binder.createNotebook(SimpleSchema, { title: "Example schema" });
@@ -163,5 +165,38 @@ describe("path equations", { timeout: 10000 }, () => {
 
         const result = await notebook.validate();
         expect(result.issues[0]?.message).toContain("sources of the sides don't coincide");
+    });
+
+    test("validated models expose equation judgments", async () => {
+        const binder = createBinder();
+        const notebook = await binder.createNotebook(SimpleOlog, { title: "An Olog" });
+
+        const a = notebook.add(Type, { label: "A" });
+        const f = notebook.add(Aspect, { label: "f", from: a, to: a });
+        const equation = notebook.add(PathEquation, { label: "inverse", lhs: [f], rhs: a });
+
+        const result = await notebook.validate();
+        expect(result.issues).toEqual([]);
+        const judgments = result.model.judgmentsOf(PathEquation);
+        expect(judgments.length).toBe(1);
+        const judgment = judgments[0];
+        if (!judgment || judgment.kind !== "path-equation") {
+            throw new Error("Expected an equation judgment.");
+        }
+        const cell = notebook.document.notebook.cellContents[equation.id];
+        if (!cell || cell.tag !== "formal" || cell.content.tag !== "equation") {
+            throw new Error("Expected an equation cell.");
+        }
+        expect(judgment.id).toBe(cell.content.id);
+        expect(judgment.label).toEqual(["inverse"]);
+        if (judgment.lhs.kind !== "composite") {
+            throw new Error("Expected the left-hand side to be a composite.");
+        }
+        expect(judgment.lhs.morphisms.map((mor) => mor?.label)).toEqual([["f"]]);
+        const rhs = judgment.rhs;
+        if (rhs.kind !== "object") {
+            throw new Error("Expected the right-hand side to be an identity.");
+        }
+        expect(rhs.label).toEqual(["A"]);
     });
 });

--- a/packages/documents/test/stores/solid-completions-view.test.tsx
+++ b/packages/documents/test/stores/solid-completions-view.test.tsx
@@ -78,7 +78,7 @@ describe("SolidJS completions from a validation view", { timeout: 20000 }, () =>
 
         // Completions appear once the view's first validation completes.
         await expect
-            .poll(completionLabels, { timeout: 10000 })
+            .poll(completionLabels, { timeout: 20000 })
             .toEqual(["String", "Integer", "Boolean"]);
         expect(selectedLabel()).toBe("String");
 

--- a/packages/documents/test/stores/solid-validation-view.test.ts
+++ b/packages/documents/test/stores/solid-validation-view.test.ts
@@ -28,7 +28,7 @@ describe("reactive validation view", { timeout: 20000 }, () => {
             return dispose;
         });
 
-        await expect.poll(() => issueCount, { timeout: 10000 }).toBe(0);
+        await expect.poll(() => issueCount, { timeout: 20000 }).toBe(0);
         expect(labels).toEqual(["A", "B", "has"]);
 
         // Adding an object updates the judgments through the reactive view.
@@ -83,7 +83,7 @@ describe("reactive validation view", { timeout: 20000 }, () => {
             return dispose;
         });
 
-        await expect.poll(() => schemaIssueCount, { timeout: 10000 }).toBe(0);
+        await expect.poll(() => schemaIssueCount, { timeout: 20000 }).toBe(0);
         expect(tableLabels).toEqual(["Person"]);
         expect(headerLabels).toEqual(["name"]);
         expect(rowCount).toBe(0);

--- a/packages/documents/test/validation-view.test.ts
+++ b/packages/documents/test/validation-view.test.ts
@@ -28,7 +28,7 @@ describe("createValidationView", { timeout: 20000 }, () => {
         expect(view.issues.length).toBeGreaterThan(0);
         expect(view.model.judgments()).toHaveLength(0);
 
-        await expect.poll(() => view.issues, { timeout: 10000 }).toEqual([]);
+        await expect.poll(() => view.issues, { timeout: 20000 }).toEqual([]);
         const model = view.model;
 
         expect(model.judgments().map((judgment) => [judgment.kind, judgment.label])).toEqual([
@@ -52,7 +52,7 @@ describe("createValidationView", { timeout: 20000 }, () => {
         const notebook = await wellFormedOlog();
         const view = notebook.createValidationView();
 
-        await expect.poll(() => view.issues, { timeout: 10000 }).toEqual([]);
+        await expect.poll(() => view.issues, { timeout: 20000 }).toEqual([]);
         const model = view.model;
 
         notebook.add(Type, { label: "C" });

--- a/packages/documents/test/validation.test.ts
+++ b/packages/documents/test/validation.test.ts
@@ -18,7 +18,7 @@ async function wellFormedOlog() {
 
 // the first time tests run we incur the cost of loading the catlog-wasm bundle,
 // so these tests have longer timeouts
-describe("validate", { timeout: 10000 }, () => {
+describe("validate", { timeout: 20000 }, () => {
     test("a well-formed notebook validates without issues", async () => {
         const notebook = await wellFormedOlog();
 
@@ -60,7 +60,7 @@ describe("validate", { timeout: 10000 }, () => {
     });
 });
 
-describe("onValidate", { timeout: 10000 }, () => {
+describe("onValidate", { timeout: 20000 }, () => {
     test("always calls the callback at least once with the current validation", async () => {
         const notebook = await wellFormedOlog();
 


### PR DESCRIPTION
~This is a bit of a judgement call given that it's a new feature in catlog, but the place that seemed most reasonable to insert names for equations was directly into PathEq. I'm prepared to defend this mathematically (after all, equations are data and the only part of f.p. category data that are not presently named, not to mention the HoTT perspective ...) but i'd also like to draw attention to the pragmatic perspective: tracking what certain generators are called in a layer above the data of the generators themselves is bound to cause issuse.~

~It's worth being clear that these names are **not** in practice the *labels* that the notebook supplies, they're the QualifiedName (so some UUID) of the cell in the notebook. It's up to the typescript to figure out whether the cell has a label.~

~The rest of this change tries to be surgical in having catlog report names of equations that are causing errors at the typescript interface, where we are sure that we received UUIDs to begin with.~

See #1464 

On the typescript side it's more of the same that we've seen it the mirror universe, tying this into the judgement structure so that future code can figure use validated models as a source of truth for equations.