### PR TITLE
OBEE-50 check instances satisfy equations

### DIFF
--- a/packages/documents/src/index.ts
+++ b/packages/documents/src/index.ts
@@ -5,7 +5,13 @@ export type { DocumentChange, DocumentRef, DocumentStore, ReactiveView } from ".
 export type { Issue, PathSegment, Result } from "./result";
 export { createInMemoryStore } from "./document-store";
 export { atomicTypeOfAttributeType } from "./instance/validation";
-export type { FieldPath, OrphanedTableIssue, TableFieldIssue, TableIssue } from "./instance/errors";
+export type {
+    FieldPath,
+    OrphanedTableIssue,
+    EquationViolationIssue,
+    TableFieldIssue,
+    TableIssue,
+} from "./instance/errors";
 export { instanceFromStore } from "./instance/instance";
 export type {
     Instance,

--- a/packages/documents/src/instance/equation-validation.ts
+++ b/packages/documents/src/instance/equation-validation.ts
@@ -1,0 +1,174 @@
+/* Check that an instance's data upholds the equations of its schema.
+
+This code is expected to be replaced by catlog implementations in the future
+once a commitment to the mathematical account of instances has been made. */
+
+import type { ElaboratedModel, EquationJudgmentSide } from "../model/elaborated-model";
+import { PathEquation, type Shape } from "../shape";
+import type { EquationViolationIssue } from "./errors";
+import type { LiteralFieldValue, InstanceTable, TableRow } from "./tables";
+import { isLiteralField } from "./tables";
+
+/** Maximum number of counterexamples reported per equation; any further
+violations are summarized in a single issue. */
+const MAX_COUNTEREXAMPLES_PER_EQUATION = 10;
+
+/** The value of one side of an equation at a row of the source table: a row
+of a table, or a literal. */
+type SideValue =
+    | { readonly kind: "row"; readonly table: InstanceTable; readonly row: TableRow }
+    | { readonly kind: "literal"; readonly field: LiteralFieldValue };
+
+/** Check that the instance's stored data upholds the equations of its schema.
+
+Walk the equations literally morphism by morphism and check equality of rows or
+literals at the end. This is computationally expensive.
+
+Evaluation is deliberately trusting: the schema is elaborated, so paths are
+composable and well typed, and each morphism judgment says which table its
+header lives in. Anything that fails to resolve during evaluation---an
+unresolvable side, a missing header, or a null, mistyped, or dangling field
+along the way---simply yields no result, and neither the equation at that row
+nor the row is checked. In particular, problems already reported by
+`validateInstanceTables` are never reported here. */
+export function validatePathEquations<S extends Shape>(
+    tables: ReadonlyArray<InstanceTable>,
+    schemaModel: ElaboratedModel<S>,
+): EquationViolationIssue[] {
+    const tableById = new Map(tables.map((table) => [table.id, table]));
+    const issues: EquationViolationIssue[] = [];
+
+    for (const judgment of schemaModel.judgmentsOf(PathEquation)) {
+        const sourceId = sideSource(judgment.lhs);
+        if (sourceId === null || sourceId !== sideSource(judgment.rhs)) {
+            continue;
+        }
+        const sourceTable = tableById.get(sourceId);
+        if (sourceTable === undefined) {
+            continue; // the source object has no table
+        }
+        const tableLabel = sourceTable.label ?? sourceId;
+        const equationName = judgment.label.join(".") || judgment.id;
+
+        let violations = 0;
+        for (const row of sourceTable.rows) {
+            const source = { table: sourceTable, row };
+            const left = evaluateSide(tableById, judgment.lhs, source);
+            const right = evaluateSide(tableById, judgment.rhs, source);
+            if (left === undefined || right === undefined || sideValuesEqual(left, right)) {
+                continue;
+            }
+            violations += 1;
+            if (violations <= MAX_COUNTEREXAMPLES_PER_EQUATION) {
+                issues.push({
+                    message:
+                        `Equation \`${equationName}\` is violated by a row of table \`${tableLabel}\`: ` +
+                        `left-hand side yields ${describeSideValue(left)}, ` +
+                        `right-hand side yields ${describeSideValue(right)}`,
+                    path: [sourceId, "rows", row.id],
+                    issueType: "EquationViolation",
+                    equationId: judgment.id,
+                });
+            }
+        }
+        if (violations > MAX_COUNTEREXAMPLES_PER_EQUATION) {
+            issues.push({
+                message:
+                    `Equation \`${equationName}\` is violated by ` +
+                    `${violations - MAX_COUNTEREXAMPLES_PER_EQUATION} more rows of table ` +
+                    `\`${tableLabel}\``,
+                path: [sourceId],
+                issueType: "EquationViolation",
+                equationId: judgment.id,
+            });
+        }
+    }
+    return issues;
+}
+
+function sideSource<S extends Shape>(side: EquationJudgmentSide<S>): string | null {
+    switch (side.kind) {
+        case "object":
+            return side.id;
+        case "composite":
+            return side.morphisms[0]?.from?.id ?? null;
+    }
+}
+
+function evaluateSide<S extends Shape>(
+    tableById: ReadonlyMap<string, InstanceTable>,
+    side: EquationJudgmentSide<S>,
+    source: { table: InstanceTable; row: TableRow },
+): SideValue | undefined {
+    switch (side.kind) {
+        case "object":
+            // The identity on an object.
+            return { kind: "row", table: source.table, row: source.row };
+        case "composite": {
+            let current = source;
+            for (const [i, morphism] of side.morphisms.entries()) {
+                if (
+                    morphism === null ||
+                    morphism.from === null ||
+                    current.table.id !== morphism.from.id
+                ) {
+                    return undefined; // unresolvable, or not composable
+                }
+                const headerIndex = current.table.headers.findIndex(
+                    (header) => header.id === morphism.id,
+                );
+                if (headerIndex < 0) {
+                    return undefined; // no such column
+                }
+                const header = current.table.headers[headerIndex]!;
+                const field = current.row.fields[headerIndex];
+                if (field === undefined || field.tag === "Null") {
+                    return undefined;
+                }
+                const isLast = i === side.morphisms.length - 1;
+                if (header.type.tag === "RowRef") {
+                    if (field.tag !== "RowRef") {
+                        return undefined; // mistyped, reported elsewhere
+                    }
+                    const target = tableById.get(header.type.content.id);
+                    const row = target?.rows.find((row) => row.id === field.content.id);
+                    if (target === undefined || row === undefined) {
+                        return undefined; // dangling or mistyped, reported elsewhere
+                    }
+                    if (isLast) {
+                        return { kind: "row", table: target, row };
+                    }
+                    current = { table: target, row };
+                } else {
+                    // A literal header ends the path, as elaboration ensures.
+                    if (!isLast || !isLiteralField(field) || field.tag !== header.type.tag) {
+                        return undefined; // mistyped literal, reported elsewhere
+                    }
+                    return { kind: "literal", field };
+                }
+            }
+            return undefined; // the side is empty, hence unspecified
+        }
+    }
+}
+
+function sideValuesEqual(left: SideValue, right: SideValue): boolean {
+    if (left.kind === "row" && right.kind === "row") {
+        return left.table.id === right.table.id && left.row.id === right.row.id;
+    }
+    if (left.kind === "literal" && right.kind === "literal") {
+        return (
+            left.field.tag === right.field.tag &&
+            left.field.content.value === right.field.content.value
+        );
+    }
+    return false;
+}
+
+function describeSideValue(value: SideValue): string {
+    if (value.kind === "row") {
+        const label = value.table.label ?? value.table.id;
+        return `row \`${value.row.id}\` of table \`${label}\``;
+    }
+    return JSON.stringify(value.field.content.value);
+}

--- a/packages/documents/src/instance/errors.ts
+++ b/packages/documents/src/instance/errors.ts
@@ -28,5 +28,15 @@ export interface OrphanedTableIssue extends Issue {
     readonly issueType: "OrphanedTable";
 }
 
+/** A violation of a path equation in the schema by a row of an instance
+ * table, or a summary of further such violations. */
+export interface EquationViolationIssue extends Issue {
+    /** Path to the violating row, or to its table for a summary issue. */
+    readonly path: [string] | [string, "rows", string];
+    readonly issueType: "EquationViolation";
+    /** Id of the violated equation in the schema. */
+    readonly equationId: string;
+}
+
 /** A problem found while validating an instance's tables. */
-export type TableIssue = TableFieldIssue | OrphanedTableIssue;
+export type TableIssue = TableFieldIssue | OrphanedTableIssue | EquationViolationIssue;

--- a/packages/documents/src/instance/instance-runtime.ts
+++ b/packages/documents/src/instance/instance-runtime.ts
@@ -5,6 +5,7 @@ import type { ElaboratedModel, ModelValidation } from "../model/elaborated-model
 import type { Notebook } from "../model/notebook";
 import type { Result } from "../result";
 import type { InstanceCapableShape, Shape } from "../shape";
+import { validatePathEquations } from "./equation-validation";
 import type { InstanceValidation } from "./instance";
 import {
     addInstanceRowsToStore,
@@ -148,11 +149,12 @@ export function createInstanceValidator<Handle, S extends Shape, Version>(
             handle,
             schemaValidation.model,
         );
-        const issues = validateInstanceTables(
-            store.getDocumentView(handle) as Readonly<InstanceDocument>,
-            schemaTables,
-        );
+        const document = store.getDocumentView(handle) as Readonly<InstanceDocument>;
         const tables = tablesWithOrphanedData(store, handle, schemaTables);
+        const issues = [
+            ...validateInstanceTables(document, schemaTables),
+            ...validatePathEquations(tables, schemaValidation.model),
+        ];
         return {
             modelValidation: schemaValidation,
             tables,

--- a/packages/documents/src/instance/tables.ts
+++ b/packages/documents/src/instance/tables.ts
@@ -63,3 +63,9 @@ export type FieldValue =
           readonly tag: "RowRef";
           readonly content: { readonly path: FieldPath; readonly id: string };
       };
+
+export type LiteralFieldValue = Extract<FieldValue, { readonly tag: LiteralType }>;
+
+export function isLiteralField(field: FieldValue): field is LiteralFieldValue {
+    return field.tag !== "Null" && field.tag !== "RowRef";
+}

--- a/packages/documents/test/instance-equations.test.ts
+++ b/packages/documents/test/instance-equations.test.ts
@@ -1,0 +1,237 @@
+import { Aspect, SimpleOlog, Type } from "catcolab-logics/simple-olog";
+import { Attr, AttrType, Entity, Mapping, SimpleSchema } from "catcolab-logics/simple-schema";
+import { describe, expect, test } from "vitest";
+
+import {
+    createBinder,
+    PathEquation,
+    type EquationViolationIssue,
+    type ModelDocument,
+    type Notebook,
+    type Result,
+    type Shape,
+    type TableIssue,
+} from "catcolab-documents";
+
+function expectOk<T, E>(result: Result<T, E>): T {
+    expect(result.tag).toBe("Ok");
+    if (result.tag === "Err") {
+        throw new Error(`Expected Ok result: ${String(result.content)}`);
+    }
+    return result.content;
+}
+
+function equationViolations(issues: ReadonlyArray<TableIssue>): EquationViolationIssue[] {
+    return issues.filter(
+        (issue): issue is EquationViolationIssue => issue.issueType === "EquationViolation",
+    );
+}
+
+function equationDeclId<S extends Shape>(notebook: Notebook<S, ModelDocument>, cellId: string) {
+    const cell = notebook.document.notebook.cellContents[cellId];
+    if (cell?.tag !== "formal" || cell.content.tag !== "equation") {
+        throw new Error("Expected an equation cell.");
+    }
+    return cell.content.id;
+}
+
+describe("instance validation of path equations", { timeout: 30000 }, () => {
+    test("a row violating a schema equation is reported as a counterexample", async () => {
+        const binder = createBinder();
+        const schema = await binder.createNotebook(SimpleSchema, { title: "Schema" });
+        const a = schema.add(Entity, { label: "A" });
+        const b = schema.add(Entity, { label: "B" });
+        const f = schema.add(Mapping, { label: "f", from: a, to: b });
+        const g = schema.add(Mapping, { label: "g", from: a, to: b });
+        const equation = schema.add(PathEquation, { label: "agree", lhs: [f], rhs: [g] });
+        const equationId = equationDeclId(schema, equation.id);
+
+        const instance = expectOk(await binder.createInstance(schema, { title: "Instance" }));
+        const validation = await instance.validate();
+        expect(validation.modelValidation.issues).toEqual([]);
+        expect(validation.issues).toEqual([]);
+
+        const tableA = validation.tables.find((table) => table.label === "A");
+        const tableB = validation.tables.find((table) => table.label === "B");
+        if (tableA === undefined || tableB === undefined) {
+            throw new Error("Expected tables for both entities.");
+        }
+        const b1 = expectOk(await instance.addRow(tableB));
+        const b2 = expectOk(await instance.addRow(tableB));
+        const a1 = expectOk(await instance.addRow(tableA, { f: b1, g: b2 }));
+
+        const revalidation = await instance.validate();
+        const violations = equationViolations(revalidation.issues);
+        expect(violations).toEqual([
+            {
+                message:
+                    "Equation `agree` is violated by a row of table `A`: left-hand side yields " +
+                    `row \`${b1.id}\` of table \`B\`, right-hand side yields row \`${b2.id}\` of table \`B\``,
+                path: [tableA.id, "rows", a1.id],
+                issueType: "EquationViolation",
+                equationId,
+            },
+        ]);
+
+        // Repairing the row by making both sides agree resolves the issue.
+        const gHeader = tableA.headers.find((header) => header.label === "g");
+        if (gHeader === undefined) {
+            throw new Error("Expected a header for the morphism.");
+        }
+        expectOk(await instance.set(a1, gHeader, b1));
+        expect(equationViolations((await instance.validate()).issues)).toEqual([]);
+    });
+
+    test("an equation with an identity side can hold", async () => {
+        const binder = createBinder();
+        const schema = await binder.createNotebook(SimpleOlog, { title: "Schema" });
+        const a = schema.add(Type, { label: "A" });
+        const f = schema.add(Aspect, { label: "loop", from: a, to: a });
+        schema.add(PathEquation, { label: "identity", lhs: [f], rhs: a });
+
+        const instance = expectOk(await binder.createInstance(schema, { title: "Instance" }));
+        const validation = await instance.validate();
+        const tableA = validation.tables.find((table) => table.label === "A");
+        if (tableA === undefined) {
+            throw new Error("Expected a table for the type.");
+        }
+        const r1 = expectOk(await instance.addRow(tableA));
+        const r2 = expectOk(await instance.addRow(tableA));
+        const loopHeader = tableA.headers.find((header) => header.label === "loop");
+        if (loopHeader === undefined) {
+            throw new Error("Expected a header for the aspect.");
+        }
+
+        expectOk(await instance.set(r1, loopHeader, r2));
+        const violations = equationViolations((await instance.validate()).issues);
+        expect(violations.length).toBe(1);
+        expect(violations[0]?.path).toEqual([tableA.id, "rows", r1.id]);
+        expect(violations[0]?.message).toContain("left-hand side yields");
+        expect(violations[0]?.message).toContain(`row \`${r2.id}\``);
+        expect(violations[0]?.message).toContain(`row \`${r1.id}\``);
+
+        expectOk(await instance.set(r1, loopHeader, r1));
+        expect(equationViolations((await instance.validate()).issues)).toEqual([]);
+    });
+
+    test("an equation between attributes compares literal values", async () => {
+        const binder = createBinder();
+        const schema = await binder.createNotebook(SimpleSchema, { title: "Schema" });
+        const person = schema.add(Entity, { label: "Person" });
+        const string = schema.add(AttrType, { label: "String" });
+        const first = schema.add(Attr, { label: "first", from: person, to: string });
+        const second = schema.add(Attr, { label: "second", from: person, to: string });
+        schema.add(PathEquation, { label: "agreement", lhs: [first], rhs: [second] });
+
+        const instance = expectOk(await binder.createInstance(schema, { title: "Instance" }));
+        const personTable = (await instance.validate()).tables.find(
+            (table) => table.label === "Person",
+        );
+        if (personTable === undefined) {
+            throw new Error("Expected a table for the entity.");
+        }
+        const secondHeader = personTable.headers.find((header) => header.label === "second");
+        if (secondHeader === undefined) {
+            throw new Error("Expected a header for the attribute.");
+        }
+
+        const alice = expectOk(
+            await instance.addRow(personTable, { first: "Alice", second: "Bob" }),
+        );
+        const violations = equationViolations((await instance.validate()).issues);
+        expect(violations.length).toBe(1);
+        expect(violations[0]?.path).toEqual([personTable.id, "rows", alice.id]);
+        expect(violations[0]?.message).toContain(`left-hand side yields "Alice"`);
+        expect(violations[0]?.message).toContain(`right-hand side yields "Bob"`);
+
+        expectOk(await instance.set(alice, secondHeader, "Alice"));
+        expect(equationViolations((await instance.validate()).issues)).toEqual([]);
+    });
+
+    test("a row where an equation cannot be evaluated is not a counterexample", async () => {
+        const binder = createBinder();
+        const schema = await binder.createNotebook(SimpleSchema, { title: "Schema" });
+        const a = schema.add(Entity, { label: "A" });
+        const b = schema.add(Entity, { label: "B" });
+        const f = schema.add(Mapping, { label: "f", from: a, to: b });
+        const g = schema.add(Mapping, { label: "g", from: a, to: b });
+        schema.add(PathEquation, { label: "agree", lhs: [f], rhs: [g] });
+
+        const instance = expectOk(await binder.createInstance(schema, { title: "Instance" }));
+        const validation = await instance.validate();
+        const tableA = validation.tables.find((table) => table.label === "A");
+        const tableB = validation.tables.find((table) => table.label === "B");
+        if (tableA === undefined || tableB === undefined) {
+            throw new Error("Expected tables for both entities.");
+        }
+        const b1 = expectOk(await instance.addRow(tableB));
+        expectOk(await instance.addRow(tableA, { f: b1 }));
+
+        // The missing `g` value is reported, but yields no equation violation.
+        const revalidation = await instance.validate();
+        expect(revalidation.issues.some((issue) => issue.issueType === "MissingValue")).toBe(true);
+        expect(equationViolations(revalidation.issues)).toEqual([]);
+    });
+
+    test("an equation whose source is not a table is not checked", async () => {
+        const binder = createBinder();
+        const schema = await binder.createNotebook(SimpleSchema, { title: "Schema" });
+        const person = schema.add(Entity, { label: "Person" });
+        const string = schema.add(AttrType, { label: "String" });
+        schema.add(Attr, { label: "name", from: person, to: string });
+        schema.add(PathEquation, { label: "trivial", lhs: string, rhs: string });
+
+        const instance = expectOk(await binder.createInstance(schema, { title: "Instance" }));
+        const validation = await instance.validate();
+        expect(validation.modelValidation.issues).toEqual([]);
+
+        // The equation elaborates, but its source is an attribute type, which is
+        // not a table, so there is nothing to check.
+        const equations = validation.modelValidation.model.judgmentsOf(PathEquation);
+        expect(equations.length).toBe(1);
+        const personTable = validation.tables.find((table) => table.label === "Person");
+        if (personTable === undefined) {
+            throw new Error("Expected a table for the entity.");
+        }
+        expectOk(await instance.addRow(personTable, { name: "Alice" }));
+        expect(equationViolations((await instance.validate()).issues)).toEqual([]);
+    });
+
+    test("violations beyond the counterexample cap are summarized", async () => {
+        const binder = createBinder();
+        const schema = await binder.createNotebook(SimpleSchema, { title: "Schema" });
+        const a = schema.add(Entity, { label: "A" });
+        const b = schema.add(Entity, { label: "B" });
+        const f = schema.add(Mapping, { label: "f", from: a, to: b });
+        const g = schema.add(Mapping, { label: "g", from: a, to: b });
+        schema.add(PathEquation, { label: "agree", lhs: [f], rhs: [g] });
+
+        const instance = expectOk(await binder.createInstance(schema, { title: "Instance" }));
+        const validation = await instance.validate();
+        const tableA = validation.tables.find((table) => table.label === "A");
+        const tableB = validation.tables.find((table) => table.label === "B");
+        if (tableA === undefined || tableB === undefined) {
+            throw new Error("Expected tables for both entities.");
+        }
+        const b1 = expectOk(await instance.addRow(tableB));
+        const b2 = expectOk(await instance.addRow(tableB));
+        expectOk(
+            await instance.addRows([
+                { table: tableA, values: Array.from({ length: 12 }, () => ({ f: b1, g: b2 })) },
+            ]),
+        );
+
+        const revalidation = await instance.validate();
+        const violations = equationViolations(revalidation.issues);
+        const counterexamples = violations.filter((issue) => issue.path.length === 3);
+        const summaries = violations.filter((issue) => issue.path.length === 1);
+        expect(counterexamples.length).toBe(10);
+        expect(summaries).toEqual([
+            expect.objectContaining({
+                message: "Equation `agree` is violated by 2 more rows of table `A`",
+                path: [tableA.id],
+                issueType: "EquationViolation",
+            }),
+        ]);
+    });
+});


### PR DESCRIPTION
This is a temporary implementation which is intended to be replaced once instances are internalised into catlog. For now we apply the obvious and inefficient algorithm: for every equation, for both sides, for every row, check. We produce no more than `MAX_COUNTEREXAMPLES_PER_EQUATION` explicit counter-examples of equation failures and if there are more than that we summarise them in a final error about the table.