### PR TITLE
Name equations in f.p. categories and models

### DIFF
--- a/packages/catlog/examples/tt/text/test_equality.dbltt.snapshot
+++ b/packages/catlog/examples/tt/text/test_equality.dbltt.snapshot
@@ -24,7 +24,7 @@ generate CommutativeSquare
 #/ l : NW -> SW : Hom Entity
 #/ r : NE -> SE : Hom Entity
 #/ b : SW -> SE : Hom Entity
-#/ t ⋅ r = l ⋅ b : (Hom Entity)[NW, SE]
+#/ comm : t ⋅ r = l ⋅ b : (Hom Entity)[NW, SE]
 
 syn [S : CommutativeSquare] S.comm
 #/ result: S.comm : S.t · S.r == S.l · S.b

--- a/packages/catlog/src/dbl/discrete/model.rs
+++ b/packages/catlog/src/dbl/discrete/model.rs
@@ -207,10 +207,10 @@ impl FpDblModel for DiscreteDblModel {
         self.mor_types.preimage(typ)
     }
 
-    fn equations(&self) -> impl Iterator<Item = (Self::Mor, Self::Mor)> {
+    fn equations(&self) -> impl Iterator<Item = (QualifiedName, Self::Mor, Self::Mor)> {
         self.category
             .equations()
-            .map(|(_, PathEq { lhs, rhs })| (lhs.clone(), rhs.clone()))
+            .map(|(name, PathEq { lhs, rhs })| (name, lhs.clone(), rhs.clone()))
     }
 }
 

--- a/packages/catlog/src/dbl/discrete/model.rs
+++ b/packages/catlog/src/dbl/discrete/model.rs
@@ -208,7 +208,9 @@ impl FpDblModel for DiscreteDblModel {
     }
 
     fn equations(&self) -> impl Iterator<Item = (Self::Mor, Self::Mor)> {
-        self.category.equations().map(|PathEq { lhs, rhs }| (lhs.clone(), rhs.clone()))
+        self.category
+            .equations()
+            .map(|(_, PathEq { lhs, rhs })| (lhs.clone(), rhs.clone()))
     }
 }
 

--- a/packages/catlog/src/dbl/discrete/model.rs
+++ b/packages/catlog/src/dbl/discrete/model.rs
@@ -48,8 +48,8 @@ impl DiscreteDblModel {
     }
 
     /// Adds a path equation to the model.
-    pub fn add_equation(&mut self, eq: PathEq<QualifiedName, QualifiedName>) {
-        self.category.add_equation(eq);
+    pub fn add_equation(&mut self, name: QualifiedName, eq: QualifiedPathEq) {
+        self.category.add_equation(name, eq);
     }
 
     /// Iterates over failures of model to be well defined.
@@ -58,7 +58,7 @@ impl DiscreteDblModel {
         let category_errors = self.category.iter_invalid().map(|err| match err {
             InvalidFpCategory::Dom(e) => Invalid::Dom(e),
             InvalidFpCategory::Cod(e) => Invalid::Cod(e),
-            InvalidFpCategory::Eqn(eq, errs) => Invalid::Eqn(Some(eq), errs.map(|e| e.into())),
+            InvalidFpCategory::Eqn(eq, errs) => Invalid::Eqn(eq, errs.map(|e| e.into())),
         });
         let ob_type_errors = self.category.ob_generators().filter_map(|x| {
             if self.theory.has_ob_type(&self.ob_type(&x)) {

--- a/packages/catlog/src/dbl/discrete/model.rs
+++ b/packages/catlog/src/dbl/discrete/model.rs
@@ -6,10 +6,9 @@ use derivative::Derivative;
 
 use super::theory::DiscreteDblTheory;
 use crate::dbl::{category::*, model::*, theory::DblTheory};
-use crate::one::{fp_category::QualifiedFpCategory, *};
 use crate::tt::util::pretty::*;
 use crate::validate::{self, Validate};
-use crate::zero::*;
+use crate::{one::*, zero::*};
 
 /// A finitely presented model of a discrete double theory.
 ///
@@ -22,7 +21,7 @@ use crate::zero::*;
 pub struct DiscreteDblModel {
     #[derivative(PartialEq(compare_with = "Rc::ptr_eq"))]
     theory: Rc<DiscreteDblTheory>,
-    pub(crate) category: QualifiedFpCategory,
+    pub(crate) category: FpCategory,
     ob_types: IndexedHashColumn<QualifiedName, QualifiedName>,
     mor_types: IndexedHashColumn<QualifiedName, QualifiedPath>,
 }

--- a/packages/catlog/src/dbl/discrete/model_diagram.rs
+++ b/packages/catlog/src/dbl/discrete/model_diagram.rs
@@ -9,7 +9,7 @@ use tsify::declare;
 use crate::dbl::{model::*, model_diagram::*, model_morphism::*};
 use crate::one::{Category, FgCategory, GraphMapping};
 use crate::validate;
-use crate::zero::{Mapping, QualifiedName};
+use crate::zero::Mapping;
 
 /// A diagram in a model of a discrete double theory.
 pub type DiscreteDblModelDiagram = DblModelDiagram<DiscreteDblModelMapping, DiscreteDblModel>;
@@ -17,7 +17,7 @@ pub type DiscreteDblModelDiagram = DblModelDiagram<DiscreteDblModelMapping, Disc
 /// A failure to be valid in a diagram in a model of a discrete double theory.
 #[cfg_attr(feature = "serde-wasm", declare)]
 pub type InvalidDiscreteDblModelDiagram =
-    InvalidDblModelDiagram<InvalidDblModel, InvalidDblModelMorphism<QualifiedName, QualifiedName>>;
+    InvalidDblModelDiagram<InvalidDblModel, InvalidDblModelMorphism>;
 
 impl DiscreteDblModelDiagram {
     /// Validates that the diagram is well-defined in the given model.

--- a/packages/catlog/src/dbl/discrete/model_morphism.rs
+++ b/packages/catlog/src/dbl/discrete/model_morphism.rs
@@ -85,10 +85,7 @@ pub type DiscreteDblModelMorphism<'a> =
 
 impl<'a> DiscreteDblModelMorphism<'a> {
     /// Iterates over failures of the mapping to be a model morphism.
-    pub fn iter_invalid(
-        &self,
-    ) -> impl Iterator<Item = InvalidDblModelMorphism<QualifiedName, QualifiedName>> + 'a + use<'a>
-    {
+    pub fn iter_invalid(&self) -> impl Iterator<Item = InvalidDblModelMorphism> + 'a + use<'a> {
         let DblModelMorphism(DiscreteDblModelMapping(mapping), dom, cod) = *self;
         let category_errors: Vec<_> = mapping
             .functor_into(&cod.category)
@@ -193,7 +190,7 @@ impl<'a> DiscreteDblModelMorphism<'a> {
 }
 
 impl Validate for DiscreteDblModelMorphism<'_> {
-    type ValidationError = InvalidDblModelMorphism<QualifiedName, QualifiedName>;
+    type ValidationError = InvalidDblModelMorphism;
 
     fn validate(&self) -> Result<(), NonEmpty<Self::ValidationError>> {
         validate::wrap_errors(self.iter_invalid())

--- a/packages/catlog/src/dbl/discrete/model_morphism.rs
+++ b/packages/catlog/src/dbl/discrete/model_morphism.rs
@@ -59,7 +59,7 @@ impl DiscreteDblModelMapping {
     pub fn functor_into<'a>(
         &'a self,
         cod: &'a DiscreteDblModel,
-    ) -> FpFunctor<'a, DiscreteDblModelMappingData, QualifiedFpCategory> {
+    ) -> FpFunctor<'a, DiscreteDblModelMappingData, FpCategory> {
         self.0.functor_into(&cod.category)
     }
 

--- a/packages/catlog/src/dbl/discrete/theory.rs
+++ b/packages/catlog/src/dbl/discrete/theory.rs
@@ -119,7 +119,7 @@ mod tests {
         let mut sgn = FpCategory::new();
         sgn.add_ob_generator(name("*"));
         sgn.add_mor_generator(name("n"), name("*"), name("*"));
-        sgn.equate(Path::pair(name("n"), name("n")), Path::Id(name("*")));
+        sgn.equate(name("involutivity"), Path::pair(name("n"), name("n")), Path::Id(name("*")));
 
         let th = DiscreteDblTheory::from(sgn);
         assert!(th.has_ob_type(&name("*")));

--- a/packages/catlog/src/dbl/discrete/theory.rs
+++ b/packages/catlog/src/dbl/discrete/theory.rs
@@ -20,7 +20,7 @@ use crate::zero::QualifiedName;
 /// - a double category whose underlying categories are both discrete categories
 #[derive(From, RefCast, Debug)]
 #[repr(transparent)]
-pub struct DiscreteDblTheory(pub QualifiedFpCategory);
+pub struct DiscreteDblTheory(pub FpCategory);
 
 impl VDblCategory for DiscreteDblTheory {
     type Ob = QualifiedName;

--- a/packages/catlog/src/dbl/discrete_tabulator/model.rs
+++ b/packages/catlog/src/dbl/discrete_tabulator/model.rs
@@ -315,7 +315,7 @@ impl FpDblModel for DiscreteTabModel {
         self.mor_types.preimage(mortype)
     }
 
-    fn equations(&self) -> impl Iterator<Item = (Self::Mor, Self::Mor)> {
+    fn equations(&self) -> impl Iterator<Item = (QualifiedName, Self::Mor, Self::Mor)> {
         self.equations.iter().map(|()| unreachable!())
     }
 }

--- a/packages/catlog/src/dbl/modal/model.rs
+++ b/packages/catlog/src/dbl/modal/model.rs
@@ -251,7 +251,7 @@ impl<Kind: DblTheoryKind> FpDblModel for ModalDblModel<Kind> {
     fn mor_generators_with_type(&self, typ: &Self::MorType) -> impl Iterator<Item = Self::MorGen> {
         self.mor_types.preimage(typ)
     }
-    fn equations(&self) -> impl Iterator<Item = (Self::Mor, Self::Mor)> {
+    fn equations(&self) -> impl Iterator<Item = (QualifiedName, Self::Mor, Self::Mor)> {
         self.equations.iter().map(|()| unreachable!())
     }
 }

--- a/packages/catlog/src/dbl/modal/theory.rs
+++ b/packages/catlog/src/dbl/modal/theory.rs
@@ -670,7 +670,7 @@ impl<Kind: DblTheoryKind> Validate for ModalDblTheory<Kind> {
             self.pro_composites.iter().enumerate().filter_map(|(id, ((fst, snd), comp))| {
                 let eq = PathEq::new(Path::pair(fst.clone(), snd.clone()), comp.clone().into());
                 let errs = eq.validate_in(graph).err()?;
-                Some(InvalidDblTheory::MorTypeEq(id, errs))
+                Some(InvalidDblTheory::MorTypeComposite(id, errs))
             });
 
         validate::wrap_errors(arr_errors.chain(pro_errors))

--- a/packages/catlog/src/dbl/model.rs
+++ b/packages/catlog/src/dbl/model.rs
@@ -145,7 +145,7 @@ pub trait FpDblModel: DblModel + FgCategory {
     }
 
     /// Iterates over equations between morphisms.
-    fn equations(&self) -> impl Iterator<Item = (Self::Mor, Self::Mor)>;
+    fn equations(&self) -> impl Iterator<Item = (QualifiedName, Self::Mor, Self::Mor)>;
 }
 
 /// A mutable, finitely generated model of a double theory.
@@ -251,13 +251,17 @@ impl DblModelPrinter {
                 + Model::mor_type_to_doc(&model.mor_generator_type(&name))
         });
 
-        let eqn_entries = model.equations().map(|(lhs, rhs)| {
+        let eqn_entries = model.equations().map(|(name, lhs, rhs)| {
             let mor_type = Model::mor_type_to_doc(&model.mor_type(&lhs));
-            let src = model.ob_to_doc(&model.dom(&lhs), ob_ns, mor_ns);
-            let tgt = model.ob_to_doc(&model.cod(&lhs), ob_ns, mor_ns);
+            let dom = model.ob_to_doc(&model.dom(&lhs), ob_ns, mor_ns);
+            let cod = model.ob_to_doc(&model.cod(&lhs), ob_ns, mor_ns);
             let lhs = model.mor_to_doc(&lhs, ob_ns, mor_ns);
             let rhs = model.mor_to_doc(&rhs, ob_ns, mor_ns);
-            lhs + t(" = ") + rhs + t(" : ") + mor_type.parens() + tuple([src, tgt])
+            let eqn = lhs + t(" = ") + rhs + t(" : ") + mor_type.parens() + tuple([dom, cod]);
+            match mor_ns.label(&name) {
+                Some(label) => t(label.to_string()) + t(" : ") + eqn,
+                None => eqn,
+            }
         });
 
         let entries = ob_entries.chain(mor_entries).chain(eqn_entries);

--- a/packages/catlog/src/dbl/model.rs
+++ b/packages/catlog/src/dbl/model.rs
@@ -299,9 +299,7 @@ pub enum InvalidDblModel {
     CodType(QualifiedName),
 
     /// Equation between morphisms has one or more errors.
-    ///
-    /// FIXME: should not really be an Option, fix after issue 1017 is resolved..
-    Eqn(Option<usize>, NonEmpty<InvalidModelEqn>),
+    Eqn(QualifiedName, NonEmpty<InvalidModelEqn>),
 
     /// Tried to us a feature not yet supported by the elaborator.
     UnsupportedFeature(Feature),

--- a/packages/catlog/src/dbl/model_morphism.rs
+++ b/packages/catlog/src/dbl/model_morphism.rs
@@ -26,6 +26,8 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "serde-wasm")]
 use tsify::Tsify;
 
+use crate::zero::QualifiedName;
+
 pub use super::discrete::model_morphism::*;
 
 /// An invalid assignment in a morphism between models of a double theory.
@@ -34,32 +36,32 @@ pub use super::discrete::model_morphism::*;
 #[cfg_attr(feature = "serde", serde(tag = "tag", content = "content"))]
 #[cfg_attr(feature = "serde-wasm", derive(Tsify))]
 #[cfg_attr(feature = "serde-wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub enum InvalidDblModelMorphism<ObGen, MorGen> {
+pub enum InvalidDblModelMorphism {
     /// An object generator not mapped to an object in the codomain model.
     #[error("Object generator `{0}` is not mapped to an object in the codomain")]
-    Ob(ObGen),
+    Ob(QualifiedName),
 
     /// A morphism generator not mapped to a morphism in the codomain model.
     #[error("Morphism generator `{0}` is not mapped to a morphism in the codomain")]
-    Mor(MorGen),
+    Mor(QualifiedName),
 
     /// A morphism generator whose domain is not preserved.
     #[error("Domain of morphism generator `{0}` is not preserved")]
-    Dom(MorGen),
+    Dom(QualifiedName),
 
     /// A morphism generator whose codomain is not preserved.
     #[error("Codomain of morphism generator `{0}` is not preserved")]
-    Cod(MorGen),
+    Cod(QualifiedName),
 
     /// An object generator whose type is not preserved.
     #[error("Object `{0}` is not mapped to an object of the same type in the codomain")]
-    ObType(ObGen),
+    ObType(QualifiedName),
 
     /// A morphism generator whose type is not preserved.
     #[error("Morphism `{0}` is not mapped to a morphism of the same type in the codomain")]
-    MorType(MorGen),
+    MorType(QualifiedName),
 
     /// A path equation in domain presentation that is not respected.
     #[error("Path equation `{0}` is not respected")]
-    Eq(usize),
+    Eq(QualifiedName),
 }

--- a/packages/catlog/src/dbl/theory.rs
+++ b/packages/catlog/src/dbl/theory.rs
@@ -402,7 +402,10 @@ pub enum InvalidDblTheory {
     MorOpBoundary(QualifiedName),
 
     /// Equation between morphism types with one or more errors.
-    MorTypeEq(usize, NonEmpty<InvalidPathEq>),
+    MorTypeEq(QualifiedName, NonEmpty<InvalidPathEq>),
+
+    /// Declared composite of morphism types with one or more errors.
+    MorTypeComposite(usize, NonEmpty<InvalidPathEq>),
 
     /// Equation between object operations with one or more errors.
     ObOpEq(usize, NonEmpty<InvalidPathEq>),

--- a/packages/catlog/src/one/fp_category.rs
+++ b/packages/catlog/src/one/fp_category.rs
@@ -59,8 +59,8 @@ impl FpCategory {
     }
 
     /// Gets the path equations of the category presentation.
-    pub fn equations(&self) -> impl Iterator<Item = &QualifiedPathEq> {
-        self.equations.values()
+    pub fn equations(&self) -> impl Iterator<Item = (QualifiedName, &QualifiedPathEq)> {
+        self.equations.iter()
     }
 
     /// Is the category freely generated?

--- a/packages/catlog/src/one/fp_category.rs
+++ b/packages/catlog/src/one/fp_category.rs
@@ -25,7 +25,7 @@ use thiserror::Error;
 use super::{category::*, graph::*, path::*};
 use crate::egglog_util::EGraphUtils;
 use crate::validate::{self, Validate};
-use crate::zero::QualifiedName;
+use crate::zero::{Column, HashColumn, MutMapping, QualifiedName};
 
 /// A finitely presented category backed by an e-graph.
 ///
@@ -47,7 +47,7 @@ use crate::zero::QualifiedName;
 #[derivative(Debug, Default(new = "true"), PartialEq, Eq)]
 pub struct FpCategory {
     generators: HashGraph<QualifiedName, QualifiedName>,
-    equations: Vec<QualifiedPathEq>,
+    equations: HashColumn<QualifiedName, QualifiedPathEq>,
     #[derivative(Debug = "ignore", PartialEq = "ignore")]
     state: RefCell<CategoryEGraph>,
 }
@@ -60,7 +60,7 @@ impl FpCategory {
 
     /// Gets the path equations of the category presentation.
     pub fn equations(&self) -> impl Iterator<Item = &QualifiedPathEq> {
-        self.equations.iter()
+        self.equations.values()
     }
 
     /// Is the category freely generated?
@@ -143,16 +143,19 @@ impl FpCategory {
     }
 
     /// Adds a path equation to the presentation.
-    pub fn add_equation(&mut self, eq: QualifiedPathEq) {
-        self.equations.push(eq.clone());
+    pub fn add_equation(&mut self, name: QualifiedName, eq: QualifiedPathEq) {
+        assert!(
+            self.equations.set(name, eq.clone()).is_none(),
+            "Equation with given name already exists"
+        );
         let (lhs, rhs) = (self.path_expr(eq.lhs), self.path_expr(eq.rhs));
         let action = action!((union (unquote lhs) (unquote rhs)));
         self.state.get_mut().egraph.run_action(action).unwrap();
     }
 
     /// Equates two path in the presentation.
-    pub fn equate(&mut self, lhs: QualifiedPath, rhs: QualifiedPath) {
-        self.add_equation(PathEq::new(lhs, rhs));
+    pub fn equate(&mut self, name: QualifiedName, lhs: QualifiedPath, rhs: QualifiedPath) {
+        self.add_equation(name, PathEq::new(lhs, rhs));
     }
 
     fn path_expr(&self, path: QualifiedPath) -> Expr {
@@ -172,8 +175,8 @@ impl FpCategory {
             InvalidGraph::Src(e) => InvalidFpCategory::Dom(e),
             InvalidGraph::Tgt(e) => InvalidFpCategory::Cod(e),
         });
-        let equation_errors = self.equations.iter().enumerate().filter_map(|(i, eq)| {
-            Some(InvalidFpCategory::Eqn(i, eq.validate_in(&self.generators).err()?))
+        let equation_errors = self.equations.iter().filter_map(|(name, eq)| {
+            Some(InvalidFpCategory::Eqn(name, eq.validate_in(&self.generators).err()?))
         });
         generator_errors.chain(equation_errors)
     }
@@ -250,7 +253,7 @@ pub enum InvalidFpCategory {
 
     /// Path equation with one or more errors.
     #[error("Path equation `{0}` is not valid: `{1:?}`")]
-    Eqn(usize, NonEmpty<InvalidPathEq>),
+    Eqn(QualifiedName, NonEmpty<InvalidPathEq>),
 }
 
 /// E-graph state for computing with categories in egglog.
@@ -449,9 +452,13 @@ pub fn sch_sgraph() -> FpCategory {
     cat.add_mor_generator(name("src"), name("E"), name("V"));
     cat.add_mor_generator(name("tgt"), name("E"), name("V"));
     cat.add_mor_generator(name("inv"), name("E"), name("E"));
-    cat.equate(Path::pair(name("inv"), name("inv")), Path::empty(name("E")));
-    cat.equate(Path::pair(name("inv"), name("src")), Path::single(name("tgt")));
-    cat.equate(Path::pair(name("inv"), name("tgt")), Path::single(name("src")));
+    cat.equate(
+        name("involutivity"),
+        Path::pair(name("inv"), name("inv")),
+        Path::empty(name("E")),
+    );
+    cat.equate(name("inv_src"), Path::pair(name("inv"), name("src")), Path::single(name("tgt")));
+    cat.equate(name("inv_tgt"), Path::pair(name("inv"), name("tgt")), Path::single(name("src")));
     cat
 }
 
@@ -462,7 +469,11 @@ pub fn sch_hgraph() -> FpCategory {
     cat.add_ob_generators([name("V"), name("H")]);
     cat.add_mor_generator(name("vert"), name("H"), name("V"));
     cat.add_mor_generator(name("inv"), name("H"), name("H"));
-    cat.equate(Path::pair(name("inv"), name("inv")), Path::empty(name("H")));
+    cat.equate(
+        name("involutivity"),
+        Path::pair(name("inv"), name("inv")),
+        Path::empty(name("H")),
+    );
     cat
 }
 

--- a/packages/catlog/src/one/fp_category.rs
+++ b/packages/catlog/src/one/fp_category.rs
@@ -14,8 +14,7 @@
 //! to check for equivalence of paths under the congruence.
 
 use std::cell::RefCell;
-use std::fmt::Debug;
-use std::{collections::HashMap, hash::Hash};
+use std::collections::HashMap;
 
 use derivative::Derivative;
 use egglog::ast::{Command, Expr, RunConfig, Schedule, Schema};
@@ -45,32 +44,22 @@ use crate::zero::QualifiedName;
 /// pattern to encapsulate the mutability of the e-graph and perform borrow checking
 /// at runtime. The current implementation allows only *single-threaded* usage.
 #[derive(Clone, Derivative)]
-#[derivative(Debug(bound = "V: Debug, E: Debug"))]
-#[derivative(Default(bound = "", new = "true"))]
-#[derivative(PartialEq(bound = "V: Eq + Hash, E: Eq + Hash"))]
-#[derivative(Eq(bound = "V: Eq + Hash, E: Eq + Hash"))]
-pub struct FpCategory<V, E> {
-    generators: HashGraph<V, E>,
-    equations: Vec<PathEq<V, E>>,
+#[derivative(Debug, Default(new = "true"), PartialEq, Eq)]
+pub struct FpCategory {
+    generators: HashGraph<QualifiedName, QualifiedName>,
+    equations: Vec<QualifiedPathEq>,
     #[derivative(Debug = "ignore", PartialEq = "ignore")]
-    state: RefCell<CategoryEGraph<V, E>>,
+    state: RefCell<CategoryEGraph>,
 }
 
-/// A finitely presented category whose generators have qualified names.
-pub type QualifiedFpCategory = FpCategory<QualifiedName, QualifiedName>;
-
-impl<V, E> FpCategory<V, E>
-where
-    V: Eq + Clone + Hash,
-    E: Eq + Clone + Hash,
-{
+impl FpCategory {
     /// Gets the generating graph of the category presentation.
-    pub fn generators(&self) -> &(impl FinGraph<V = V, E = E> + use<V, E>) {
+    pub fn generators(&self) -> &impl FinGraph<V = QualifiedName, E = QualifiedName> {
         &self.generators
     }
 
     /// Gets the path equations of the category presentation.
-    pub fn equations(&self) -> impl Iterator<Item = &PathEq<V, E>> {
+    pub fn equations(&self) -> impl Iterator<Item = &QualifiedPathEq> {
         self.equations.iter()
     }
 
@@ -80,7 +69,7 @@ where
     }
 
     /// Adds an object generator.
-    pub fn add_ob_generator(&mut self, v: V) {
+    pub fn add_ob_generator(&mut self, v: QualifiedName) {
         assert!(self.generators.add_vertex(v.clone()), "Object generator already exists");
         let state = self.state.get_mut();
         let expr = state.ob_generator(v);
@@ -88,14 +77,14 @@ where
     }
 
     /// Adds several object generators at once.
-    pub fn add_ob_generators(&mut self, iter: impl IntoIterator<Item = V>) {
+    pub fn add_ob_generators(&mut self, iter: impl IntoIterator<Item = QualifiedName>) {
         for v in iter {
             self.add_ob_generator(v)
         }
     }
 
     /// Adds a morphism generator.
-    pub fn add_mor_generator(&mut self, e: E, dom: V, cod: V) {
+    pub fn add_mor_generator(&mut self, e: QualifiedName, dom: QualifiedName, cod: QualifiedName) {
         assert!(
             self.generators.add_edge(e.clone(), dom.clone(), cod.clone()),
             "Morphism generator already exists"
@@ -112,7 +101,7 @@ where
     }
 
     /// Adds a morphism generator without declaring its (co)domain.
-    pub fn make_mor_generator(&mut self, e: E) {
+    pub fn make_mor_generator(&mut self, e: QualifiedName) {
         assert!(self.generators.make_edge(e.clone()), "Morphism generator already exists");
         let state = self.state.get_mut();
         let expr = state.mor_generator(e);
@@ -120,17 +109,17 @@ where
     }
 
     /// Gets the domain of a morphism generator.
-    pub fn get_dom(&self, e: &E) -> Option<&V> {
+    pub fn get_dom(&self, e: &QualifiedName) -> Option<&QualifiedName> {
         self.generators.get_src(e)
     }
 
     /// Gets the codomain of a morphism generator.
-    pub fn get_cod(&self, e: &E) -> Option<&V> {
+    pub fn get_cod(&self, e: &QualifiedName) -> Option<&QualifiedName> {
         self.generators.get_tgt(e)
     }
 
     /// Sets the domain of a morphism generator.
-    pub fn set_dom(&mut self, e: E, v: V) {
+    pub fn set_dom(&mut self, e: QualifiedName, v: QualifiedName) {
         assert!(
             self.generators.set_src(e.clone(), v.clone()).is_none(),
             "Domain of morphism generator should not already be set"
@@ -142,7 +131,7 @@ where
     }
 
     /// Sets the codomain of a morphism generator.
-    pub fn set_cod(&mut self, e: E, v: V) {
+    pub fn set_cod(&mut self, e: QualifiedName, v: QualifiedName) {
         assert!(
             self.generators.set_tgt(e.clone(), v.clone()).is_none(),
             "Codomain of morphism generator should not already be set"
@@ -154,7 +143,7 @@ where
     }
 
     /// Adds a path equation to the presentation.
-    pub fn add_equation(&mut self, eq: PathEq<V, E>) {
+    pub fn add_equation(&mut self, eq: QualifiedPathEq) {
         self.equations.push(eq.clone());
         let (lhs, rhs) = (self.path_expr(eq.lhs), self.path_expr(eq.rhs));
         let action = action!((union (unquote lhs) (unquote rhs)));
@@ -162,11 +151,11 @@ where
     }
 
     /// Equates two path in the presentation.
-    pub fn equate(&mut self, lhs: Path<V, E>, rhs: Path<V, E>) {
+    pub fn equate(&mut self, lhs: QualifiedPath, rhs: QualifiedPath) {
         self.add_equation(PathEq::new(lhs, rhs));
     }
 
-    fn path_expr(&self, path: Path<V, E>) -> Expr {
+    fn path_expr(&self, path: QualifiedPath) -> Expr {
         path.map_reduce(
             |v| {
                 let ob = self.state.borrow_mut().ob_generator(v);
@@ -178,7 +167,7 @@ where
     }
 
     /// Iterates over failures to be a well-defined presentation of a category.
-    pub fn iter_invalid(&self) -> impl Iterator<Item = InvalidFpCategory<E>> + '_ {
+    pub fn iter_invalid(&self) -> impl Iterator<Item = InvalidFpCategory> + '_ {
         let generator_errors = self.generators.iter_invalid().map(|err| match err {
             InvalidGraph::Src(e) => InvalidFpCategory::Dom(e),
             InvalidGraph::Tgt(e) => InvalidFpCategory::Cod(e),
@@ -190,13 +179,9 @@ where
     }
 }
 
-impl<V, E> Category for FpCategory<V, E>
-where
-    V: Eq + Clone + Hash,
-    E: Eq + Clone + Hash,
-{
-    type Ob = V;
-    type Mor = Path<V, E>;
+impl Category for FpCategory {
+    type Ob = QualifiedName;
+    type Mor = QualifiedPath;
 
     fn has_ob(&self, x: &Self::Ob) -> bool {
         self.generators.has_vertex(x)
@@ -226,13 +211,9 @@ where
     }
 }
 
-impl<V, E> FgCategory for FpCategory<V, E>
-where
-    V: Eq + Clone + Hash,
-    E: Eq + Clone + Hash,
-{
-    type ObGen = V;
-    type MorGen = E;
+impl FgCategory for FpCategory {
+    type ObGen = QualifiedName;
+    type MorGen = QualifiedName;
 
     fn ob_generators(&self) -> impl Iterator<Item = Self::ObGen> {
         self.generators.vertices()
@@ -248,12 +229,8 @@ where
     }
 }
 
-impl<V, E> Validate for FpCategory<V, E>
-where
-    V: Eq + Clone + Hash,
-    E: Eq + Clone + Hash,
-{
-    type ValidationError = InvalidFpCategory<E>;
+impl Validate for FpCategory {
+    type ValidationError = InvalidFpCategory;
 
     fn validate(&self) -> Result<(), NonEmpty<Self::ValidationError>> {
         validate::wrap_errors(self.iter_invalid())
@@ -262,14 +239,14 @@ where
 
 /// A failure of a finite presentation of a category to be well defined.
 #[derive(Debug, Error)]
-pub enum InvalidFpCategory<E> {
+pub enum InvalidFpCategory {
     /// Morphism generator with an invalid domain.
     #[error("Domain of morphism generator `{0}` is not in the category")]
-    Dom(E),
+    Dom(QualifiedName),
 
     /// Morphism generator with an invalid codomain.
     #[error("Codomain of morphism generator `{0}` is not in the category")]
-    Cod(E),
+    Cod(QualifiedName),
 
     /// Path equation with one or more errors.
     #[error("Path equation `{0}` is not valid: `{1:?}`")]
@@ -282,19 +259,15 @@ pub enum InvalidFpCategory<E> {
 /// mappings from vertices and edges in the category's generating graph to numeric
 /// IDs for generator terms in egglog.
 #[derive(Clone)]
-struct CategoryEGraph<V, E> {
+struct CategoryEGraph {
     egraph: EGraph,
-    ob_generators: HashMap<V, usize>,
-    mor_generators: HashMap<E, usize>,
+    ob_generators: HashMap<QualifiedName, usize>,
+    mor_generators: HashMap<QualifiedName, usize>,
 }
 
-impl<V, E> CategoryEGraph<V, E>
-where
-    V: Eq + Hash,
-    E: Eq + Hash,
-{
+impl CategoryEGraph {
     /// Constructs an object generator expression, assigning an ID if needed.
-    fn ob_generator(&mut self, v: V) -> Expr {
+    fn ob_generator(&mut self, v: QualifiedName) -> Expr {
         let n = self.ob_generators.len();
         let id: i64 = (*self.ob_generators.entry(v).or_insert(n))
             .try_into()
@@ -303,7 +276,7 @@ where
     }
 
     /// Constructs a morphism generator expression, assigning an ID if needed.
-    fn mor_generator(&mut self, e: E) -> Expr {
+    fn mor_generator(&mut self, e: QualifiedName) -> Expr {
         let n = self.mor_generators.len();
         let id: i64 = (*self.mor_generators.entry(e).or_insert(n))
             .try_into()
@@ -312,7 +285,7 @@ where
     }
 }
 
-impl<V, E> CategoryEGraph<V, E> {
+impl CategoryEGraph {
     /// Checks whether two morphism expressions are equal.
     ///
     /// The category axioms are saturated before performing the check.
@@ -334,7 +307,7 @@ impl<V, E> CategoryEGraph<V, E> {
     }
 }
 
-impl<V, E> Default for CategoryEGraph<V, E> {
+impl Default for CategoryEGraph {
     fn default() -> Self {
         let mut egraph = EGraph::default();
         init_category_egraph(&mut egraph).expect("Unexpected egglog error");
@@ -460,7 +433,7 @@ use crate::zero::name;
 
 /// The schema for graphs, an f.p. category.
 #[cfg(test)]
-pub fn sch_graph() -> QualifiedFpCategory {
+pub fn sch_graph() -> FpCategory {
     let mut cat = FpCategory::new();
     cat.add_ob_generators([name("V"), name("E")]);
     cat.add_mor_generator(name("src"), name("E"), name("V"));
@@ -470,7 +443,7 @@ pub fn sch_graph() -> QualifiedFpCategory {
 
 /// The schema for symmetric graphs, an f.p. category.
 #[cfg(test)]
-pub fn sch_sgraph() -> QualifiedFpCategory {
+pub fn sch_sgraph() -> FpCategory {
     let mut cat = FpCategory::new();
     cat.add_ob_generators([name("V"), name("E")]);
     cat.add_mor_generator(name("src"), name("E"), name("V"));
@@ -484,7 +457,7 @@ pub fn sch_sgraph() -> QualifiedFpCategory {
 
 /// The schema for half-edge graphs, an f.p. category.
 #[cfg(test)]
-pub fn sch_hgraph() -> QualifiedFpCategory {
+pub fn sch_hgraph() -> FpCategory {
     let mut cat = FpCategory::new();
     cat.add_ob_generators([name("V"), name("H")]);
     cat.add_mor_generator(name("vert"), name("H"), name("V"));

--- a/packages/catlog/src/one/functor.rs
+++ b/packages/catlog/src/one/functor.rs
@@ -19,7 +19,8 @@ use ref_cast::RefCast;
 use thiserror::Error;
 
 use super::{
-    Category, FpCategory, GraphMapping, GraphMorphism, InvalidGraphMorphism, Path, UnderlyingGraph,
+    Category, FpCategory, GraphMapping, GraphMorphism, InvalidGraphMorphism, Path, QualifiedPath,
+    UnderlyingGraph,
 };
 use crate::zero::{Column, Mapping, QualifiedName};
 
@@ -169,11 +170,11 @@ impl<'a, Ob, Mor, Map, Cod> CategoryMap for FpFunctor<'a, Map, Cod>
 where
     Ob: Eq + Clone,
     Mor: Eq + Clone,
-    Map: GraphMapping<CodV = Ob, CodE = Mor>,
+    Map: GraphMapping<DomV = QualifiedName, DomE = QualifiedName, CodV = Ob, CodE = Mor>,
     Cod: Category<Ob = Ob, Mor = Mor>,
 {
-    type DomOb = Map::DomV;
-    type DomMor = Path<Map::DomV, Map::DomE>;
+    type DomOb = QualifiedName;
+    type DomMor = QualifiedPath;
     type CodOb = Ob;
     type CodMor = Mor;
     type ObMap = Map::VertexMap;
@@ -191,13 +192,13 @@ impl<'a, Ob, Mor, Map, Cod> FgCategoryMap for FpFunctor<'a, Map, Cod>
 where
     Ob: Eq + Clone,
     Mor: Eq + Clone,
-    Map: GraphMapping<CodV = Ob, CodE = Mor>,
+    Map: GraphMapping<DomV = QualifiedName, DomE = QualifiedName, CodV = Ob, CodE = Mor>,
     Map::VertexMap: Column,
     Map::EdgeMap: Column,
     Cod: Category<Ob = Ob, Mor = Mor>,
 {
-    type ObGen = Map::DomV;
-    type MorGen = Map::DomE;
+    type ObGen = QualifiedName;
+    type MorGen = QualifiedName;
     type ObGenMap = Map::VertexMap;
     type MorGenMap = Map::EdgeMap;
 
@@ -214,23 +215,21 @@ where
 #[repr(transparent)]
 pub struct FpFunctorMorMap<'a, Map, Cod>(FpFunctor<'a, Map, Cod>);
 
-impl<'a, V, E, Ob, Mor, Map, Cod> Mapping for FpFunctorMorMap<'a, Map, Cod>
+impl<'a, Ob, Mor, Map, Cod> Mapping for FpFunctorMorMap<'a, Map, Cod>
 where
-    V: Eq + Clone,
-    E: Eq + Clone,
     Mor: Eq + Clone,
-    Map: GraphMapping<DomV = V, DomE = E, CodV = Ob, CodE = Mor>,
+    Map: GraphMapping<DomV = QualifiedName, DomE = QualifiedName, CodV = Ob, CodE = Mor>,
     Cod: Category<Ob = Ob, Mor = Mor>,
 {
-    type Dom = Path<V, E>;
+    type Dom = QualifiedPath;
     type Cod = Mor;
 
-    fn apply(&self, path: Path<V, E>) -> Option<Mor> {
+    fn apply(&self, path: QualifiedPath) -> Option<Mor> {
         path.partial_map(|v| self.0.map.apply_vertex(v), |e| self.0.map.apply_edge(e))
             .map(|path| self.0.cod.compose(path))
     }
 
-    fn is_set(&self, path: &Path<V, E>) -> bool {
+    fn is_set(&self, path: &QualifiedPath) -> bool {
         match path {
             Path::Id(v) => self.0.map.is_vertex_assigned(v),
             Path::Seq(edges) => edges.iter().all(|e| self.0.map.is_edge_assigned(e)),
@@ -246,10 +245,7 @@ where
     Cod: Category<Ob = Ob, Mor = Mor>,
 {
     /// Validates that the functor is well-defined on the given f.p. category.
-    pub fn validate_on(
-        &self,
-        dom: &FpCategory,
-    ) -> Result<(), NonEmpty<InvalidFpFunctor<QualifiedName, QualifiedName>>> {
+    pub fn validate_on(&self, dom: &FpCategory) -> Result<(), NonEmpty<InvalidFpFunctor>> {
         crate::validate::wrap_errors(self.iter_invalid_on(dom))
     }
 
@@ -257,7 +253,7 @@ where
     pub fn iter_invalid_on<'b>(
         &'b self,
         dom: &'b FpCategory,
-    ) -> impl Iterator<Item = InvalidFpFunctor<QualifiedName, QualifiedName>> + 'b {
+    ) -> impl Iterator<Item = InvalidFpFunctor> + 'b {
         let generator_errors =
             GraphMorphism(self.map, dom.generators(), UnderlyingGraph::ref_cast(self.cod))
                 .iter_invalid()
@@ -267,12 +263,12 @@ where
                     InvalidGraphMorphism::Src(e) => InvalidFpFunctor::Dom(e),
                     InvalidGraphMorphism::Tgt(e) => InvalidFpFunctor::Cod(e),
                 });
-        let equation_errors = dom.equations().enumerate().filter_map(|(id, eq)| {
+        let equation_errors = dom.equations().filter_map(|(name, eq)| {
             let map = self.mor_map();
             if let (Some(lhs), Some(rhs)) = (map.apply_to_ref(&eq.lhs), map.apply_to_ref(&eq.rhs))
                 && !self.cod.morphisms_are_equal(lhs, rhs)
             {
-                Some(InvalidFpFunctor::Eq(id))
+                Some(InvalidFpFunctor::Eq(name))
             } else {
                 None
             }
@@ -283,26 +279,26 @@ where
 
 /// A failure of a map out of an f.p. category to be functorial.
 #[derive(Debug, Error, PartialEq, Eq)]
-pub enum InvalidFpFunctor<V, E> {
+pub enum InvalidFpFunctor {
     /// An object generator not mapped to an object in the codomain category.
     #[error("Object generator `{0}` is not mapped to an object in the codomain")]
-    ObGen(V),
+    ObGen(QualifiedName),
 
     /// A morphism generator not mapped to a morphism in the codomain category.
     #[error("Morphism generator `{0}` is not mapped to a morphism in the codomain")]
-    MorGen(E),
+    MorGen(QualifiedName),
 
     /// A morphism generator whose domain is not preserved.
     #[error("Domain of morphism generator `{0}` is not preserved")]
-    Dom(E),
+    Dom(QualifiedName),
 
     /// A morphism generator whose codomain is not preserved.
     #[error("Codomain of morphism generator `{0}` is not preserved")]
-    Cod(E),
+    Cod(QualifiedName),
 
     /// A path equation in domain presentation that is not respected.
     #[error("Path equation `{0}` is not respected")]
-    Eq(usize),
+    Eq(QualifiedName),
 }
 
 #[cfg(test)]
@@ -310,6 +306,7 @@ mod tests {
     use super::*;
     use crate::one::fp_category::{sch_graph, sch_hgraph, sch_sgraph};
     use crate::zero::{HashColumn, name};
+    use nonempty::nonempty;
 
     /// Isomorphism b/w the schemas for half-edge graphs and symmetric graphs.
     ///
@@ -345,7 +342,12 @@ mod tests {
         ]);
         let data = FpFunctorData::new(ob_map, mor_map);
         let functor = data.functor_into(&sch_graph);
-        // Two equations fail, namely that `inv` swaps `src` and `tgt`.
-        assert_eq!(functor.validate_on(&sch_sgraph).map_err(|errs| errs.len()), Err(2));
+        assert_eq!(
+            functor.validate_on(&sch_sgraph),
+            Err(nonempty![
+                InvalidFpFunctor::Eq(name("inv_src")),
+                InvalidFpFunctor::Eq(name("inv_tgt")),
+            ])
+        );
     }
 }

--- a/packages/catlog/src/one/functor.rs
+++ b/packages/catlog/src/one/functor.rs
@@ -13,8 +13,6 @@
 //! you must carry around (references to) more data to evaluate functors than to
 //! evaluate functions or graph morphisms.
 
-use std::hash::Hash;
-
 use derive_more::Constructor;
 use nonempty::NonEmpty;
 use ref_cast::RefCast;
@@ -23,7 +21,7 @@ use thiserror::Error;
 use super::{
     Category, FpCategory, GraphMapping, GraphMorphism, InvalidGraphMorphism, Path, UnderlyingGraph,
 };
-use crate::zero::{Column, Mapping};
+use crate::zero::{Column, Mapping, QualifiedName};
 
 /// A mapping between categories.
 ///
@@ -240,28 +238,26 @@ where
     }
 }
 
-impl<'a, V, E, Ob, Mor, Map, Cod> FpFunctor<'a, Map, Cod>
+impl<'a, Ob, Mor, Map, Cod> FpFunctor<'a, Map, Cod>
 where
-    V: Eq + Clone + Hash,
-    E: Eq + Clone + Hash,
     Ob: Eq + Clone,
     Mor: Eq + Clone,
-    Map: GraphMapping<DomV = V, DomE = E, CodV = Ob, CodE = Mor>,
+    Map: GraphMapping<DomV = QualifiedName, DomE = QualifiedName, CodV = Ob, CodE = Mor>,
     Cod: Category<Ob = Ob, Mor = Mor>,
 {
     /// Validates that the functor is well-defined on the given f.p. category.
     pub fn validate_on(
         &self,
-        dom: &FpCategory<V, E>,
-    ) -> Result<(), NonEmpty<InvalidFpFunctor<V, E>>> {
+        dom: &FpCategory,
+    ) -> Result<(), NonEmpty<InvalidFpFunctor<QualifiedName, QualifiedName>>> {
         crate::validate::wrap_errors(self.iter_invalid_on(dom))
     }
 
     /// Iterates over failures to be functorial on the given f.p. category.
     pub fn iter_invalid_on<'b>(
         &'b self,
-        dom: &'b FpCategory<V, E>,
-    ) -> impl Iterator<Item = InvalidFpFunctor<V, E>> + 'b {
+        dom: &'b FpCategory,
+    ) -> impl Iterator<Item = InvalidFpFunctor<QualifiedName, QualifiedName>> + 'b {
         let generator_errors =
             GraphMorphism(self.map, dom.generators(), UnderlyingGraph::ref_cast(self.cod))
                 .iter_invalid()

--- a/packages/catlog/src/one/path.rs
+++ b/packages/catlog/src/one/path.rs
@@ -546,6 +546,9 @@ pub struct PathEq<V, E> {
     pub rhs: Path<V, E>,
 }
 
+/// An equation between paths whose vertices and edges are qualified names.
+pub type QualifiedPathEq = PathEq<QualifiedName, QualifiedName>;
+
 impl<V, E> PathEq<V, E> {
     /// Source of the path equation in the given graph.
     ///

--- a/packages/catlog/src/stdlib/theories.rs
+++ b/packages/catlog/src/stdlib/theories.rs
@@ -40,7 +40,11 @@ pub fn th_signed_category() -> DiscreteDblTheory {
     let mut sgn = FpCategory::new();
     sgn.add_ob_generator(name("Object"));
     sgn.add_mor_generator(name("Negative"), name("Object"), name("Object"));
-    sgn.equate(Path::pair(name("Negative"), name("Negative")), Path::empty(name("Object")));
+    sgn.equate(
+        name("negative_involution"),
+        Path::pair(name("Negative"), name("Negative")),
+        Path::empty(name("Object")),
+    );
     sgn.into()
 }
 
@@ -53,20 +57,33 @@ pub fn th_delayable_signed_category() -> DiscreteDblTheory {
     cat.add_ob_generator(name("Object"));
     cat.add_mor_generator(name("Negative"), name("Object"), name("Object"));
     cat.add_mor_generator(name("Slow"), name("Object"), name("Object"));
-    cat.equate(Path::pair(name("Negative"), name("Negative")), Path::empty(name("Object")));
-    cat.equate(Path::pair(name("Slow"), name("Slow")), name("Slow").into());
     cat.equate(
+        name("negative_involution"),
+        Path::pair(name("Negative"), name("Negative")),
+        Path::empty(name("Object")),
+    );
+    cat.equate(
+        name("slow_idempotent"),
+        Path::pair(name("Slow"), name("Slow")),
+        name("Slow").into(),
+    );
+    cat.equate(
+        name("negative_slow_commute"),
         Path::pair(name("Negative"), name("Slow")),
         Path::pair(name("Slow"), name("Negative")),
     );
 
     // NOTE: These aliases are superfluous but are included for backwards
-    // compatibility with the previous version of the theory, defined by an
-    // explicit multiplication table.
+    // compatibility with the old version of the theory, defined by an explicit
+    // multiplication table.
     cat.add_mor_generator(name("PositiveSlow"), name("Object"), name("Object"));
     cat.add_mor_generator(name("NegativeSlow"), name("Object"), name("Object"));
-    cat.equate(name("PositiveSlow").into(), name("Slow").into());
-    cat.equate(name("NegativeSlow").into(), Path::pair(name("Negative"), name("Slow")));
+    cat.equate(name("positive_slow_alias"), name("PositiveSlow").into(), name("Slow").into());
+    cat.equate(
+        name("negative_slow_alias"),
+        name("NegativeSlow").into(),
+        Path::pair(name("Negative"), name("Slow")),
+    );
 
     cat.into()
 }
@@ -80,10 +97,27 @@ pub fn th_nullable_signed_category() -> DiscreteDblTheory {
     sgn.add_ob_generator(name("Object"));
     sgn.add_mor_generator(name("Negative"), name("Object"), name("Object"));
     sgn.add_mor_generator(name("Zero"), name("Object"), name("Object"));
-    sgn.equate(Path::pair(name("Negative"), name("Negative")), Path::empty(name("Object")));
-    sgn.equate(Path::pair(name("Negative"), name("Zero")), name("Zero").into());
-    sgn.equate(Path::pair(name("Zero"), name("Negative")), name("Zero").into());
-    sgn.equate(Path::pair(name("Zero"), name("Zero")), name("Zero").into());
+    sgn.equate(
+        name("negative_involution"),
+        Path::pair(name("Negative"), name("Negative")),
+        Path::empty(name("Object")),
+    );
+    // Make `Zero` be absorbing.
+    sgn.equate(
+        name("zero_absorbs_negative_left"),
+        Path::pair(name("Negative"), name("Zero")),
+        name("Zero").into(),
+    );
+    sgn.equate(
+        name("zero_absorbs_negative_right"),
+        Path::pair(name("Zero"), name("Negative")),
+        name("Zero").into(),
+    );
+    sgn.equate(
+        name("zero_idempotent"),
+        Path::pair(name("Zero"), name("Zero")),
+        name("Zero").into(),
+    );
     sgn.into()
 }
 
@@ -100,7 +134,11 @@ pub fn th_category_with_scalars() -> DiscreteDblTheory {
     let mut idem = FpCategory::new();
     idem.add_ob_generator(name("Object"));
     idem.add_mor_generator(name("Nonscalar"), name("Object"), name("Object"));
-    idem.equate(Path::pair(name("Nonscalar"), name("Nonscalar")), name("Nonscalar").into());
+    idem.equate(
+        name("nonscalar_idempotent"),
+        Path::pair(name("Nonscalar"), name("Nonscalar")),
+        name("Nonscalar").into(),
+    );
     idem.into()
 }
 
@@ -307,15 +345,32 @@ pub fn th_power_system() -> DiscreteDblTheory {
     cat.add_ob_generator(name("Bus"));
     cat.add_mor_generator(name("Passive"), name("Bus"), name("Bus"));
     cat.add_mor_generator(name("Branch"), name("Bus"), name("Bus"));
-    cat.equate(Path::pair(name("Passive"), name("Passive")), name("Passive").into());
-    cat.equate(Path::pair(name("Passive"), name("Branch")), name("Branch").into());
-    cat.equate(Path::pair(name("Branch"), name("Passive")), name("Branch").into());
-    cat.equate(Path::pair(name("Branch"), name("Branch")), name("Branch").into());
+    cat.equate(
+        name("passive_idempotent"),
+        Path::pair(name("Passive"), name("Passive")),
+        name("Passive").into(),
+    );
+    // Make `Branch` be absorbing.
+    cat.equate(
+        name("branch_absorbs_passive_left"),
+        Path::pair(name("Passive"), name("Branch")),
+        name("Branch").into(),
+    );
+    cat.equate(
+        name("branch_absorbs_passive_right"),
+        Path::pair(name("Branch"), name("Passive")),
+        name("Branch").into(),
+    );
+    cat.equate(
+        name("branch_idempotent"),
+        Path::pair(name("Branch"), name("Branch")),
+        name("Branch").into(),
+    );
     cat.into()
 }
 
-// Not yet using a modal theory since instantiation is currently only supported in
-// models of discrete theories.
+// TODO: Switch to this modal theory since instantiation is now supported for
+// models of modal theories, where previously it was not.
 #[allow(dead_code)]
 fn modal_th_power_system() -> ModalDblTheory<Unital> {
     let mut th = ModalDblTheory::new();

--- a/packages/catlog/src/tt/modelgen.rs
+++ b/packages/catlog/src/tt/modelgen.rs
@@ -172,10 +172,11 @@ impl Model {
     }
 
     /// Adds an equation between two morphisms to the model.
-    fn add_equation(&mut self, lhs: Mor, rhs: Mor) {
+    fn add_equation(&mut self, name: QualifiedName, lhs: Mor, rhs: Mor) {
         match self {
             Model::Discrete(model) => {
-                model.add_equation(PathEq::new(lhs.try_into().unwrap(), rhs.try_into().unwrap()));
+                let eq = PathEq::new(lhs.try_into().unwrap(), rhs.try_into().unwrap());
+                model.add_equation(name, eq);
             }
             Model::DiscreteTab(_) => {
                 // Discrete tabulator models currently do not support equations, so we ignore them.
@@ -392,7 +393,7 @@ impl<'a> ModelGenerator<'a> {
                     return None;
                 };
                 if let (Some(lhs), Some(rhs)) = (self.make_mor(lhs, mt), self.make_mor(rhs, mt)) {
-                    self.model.add_equation(lhs, rhs);
+                    self.model.add_equation(prefix.into(), lhs, rhs);
                 }
                 None
             }

--- a/packages/catlog/src/tt/notebook_elab.rs
+++ b/packages/catlog/src/tt/notebook_elab.rs
@@ -576,7 +576,7 @@ mod test {
     #[test]
     fn commutative_square() {
         let th_schema = Theory::new(name("ThSchema"), TheoryDef::discrete(th_schema()));
-        let model = elab_example(
+        elab_example(
             &th_schema,
             "commutative_square",
             expect![[r#"
@@ -589,10 +589,7 @@ mod test {
                 l : NW -> SW : Hom Entity
                 r : NE -> SE : Hom Entity
                 b : SW -> SE : Hom Entity
-                t ⋅ r = l ⋅ b : (Hom Entity)[NW, SE]"#]],
+                comm : t ⋅ r = l ⋅ b : (Hom Entity)[NW, SE]"#]],
         );
-        let model = model.as_discrete().unwrap();
-        let eqns: Vec<_> = model.category.equations().collect();
-        assert_eq!(eqns.len(), 1);
     }
 }

--- a/packages/catlog/src/tt/notebook_elab.rs
+++ b/packages/catlog/src/tt/notebook_elab.rs
@@ -336,19 +336,13 @@ impl<'a> Elaborator<'a> {
                 (ty_s, ty_v)
             }
             (Some(errors), _, _) => {
-                // FIXME: The assumption in InvalidDblModel that we should already have the vector of equations
-                // built up, so as to give the index in the first argument here, doesn't hold in this case.
-                // It would be best not to use InvalidDblModel here before we've begun
-                // to build a DblModel.
-                self.ty_error(InvalidDblModel::Eqn(None, errors))
+                self.ty_error(InvalidDblModel::Eqn(QualifiedName::from(eqn_decl.id), errors))
             }
             _ => unreachable!(),
         }
     }
 
     fn equation_cell(&mut self, eqn_decl: &nb::EqnDecl) -> (NameSegment, LabelSegment, TyS, TyV) {
-        // Kind of funny that the decl's id produces the cell's name
-        // but the decl's name produces the cell's label.
         let name = NameSegment::Uuid(eqn_decl.id);
         let label = LabelSegment::Text(ustr(&eqn_decl.name));
         let (ty_s, ty_v) = self.equation_cell_ty(eqn_decl);

--- a/packages/catlog/src/tt/text_elab.rs
+++ b/packages/catlog/src/tt/text_elab.rs
@@ -782,6 +782,7 @@ mod tests {
 
     use crate::stdlib;
     use crate::tt::modelgen::Model;
+    use crate::zero::name;
 
     #[test]
     fn generate_model_from_text() {
@@ -795,7 +796,6 @@ mod tests {
         assert_eq!(model, stdlib::models::negative_loop(th));
     }
 
-    /// Check that a commutative square really produces a model with exactly one equation.
     #[test]
     fn generate_model_with_eqn() {
         let th = Rc::new(stdlib::th_schema()).into();
@@ -811,8 +811,8 @@ mod tests {
             comm : (t * r == l * b)
         ]";
         let model = Model::from_text(&th, source).unwrap().as_discrete().unwrap();
-        let eqns: Vec<_> = model.category.equations().collect();
-        assert_eq!(eqns.len(), 1);
+        let eqns: Vec<_> = model.category.equations().map(|(id, _)| id).collect();
+        assert_eq!(eqns, vec![name("comm")]);
     }
 
     #[test]


### PR DESCRIPTION
Previously the equations were identified only by numerical index. This change affects both discrete theories and models of discrete theories.

It was convenient to eliminate the type parameters `V` and `E` from `FpCategory`, `FpFunctor`, and related types, so I took the opportunity to do so.

This PR closes a gap in the functionality for equations in models, where all the key components (core data structures, DoubleTT, frontend) had been upgraded to include equations, but a handoff was missing, namely the model generation (`modelgen`) in DoubleTT wasn't inserting the equation name (because there wasn't a place to put it).