### PR TITLE
Show/hide tables and list them in sidebar

### DIFF
--- a/packages/frontend/src/instance/instance_editor.tsx
+++ b/packages/frontend/src/instance/instance_editor.tsx
@@ -1,13 +1,18 @@
-import { createMemo, createResource, Index, onCleanup, Show } from "solid-js";
+import { createEffect, createMemo, createResource, Index, onCleanup, Show } from "solid-js";
 
 import type { Result, TableIssue } from "catcolab-documents";
 import { type FocusHandle, Spinner, TableEditor, useChildFocus } from "catcolab-ui-components";
 import type { ApiInstance } from "./live_doc_compatibility";
+import { useTableList } from "./table_list";
 
 import styles from "./instance_editor.module.css";
 
 /** Editor for the data instance of a model. */
-export function InstanceEditor(props: { instance: ApiInstance; focus: FocusHandle }) {
+export function InstanceEditor(props: {
+    instance: ApiInstance;
+    refId: string;
+    focus: FocusHandle;
+}) {
     // oxlint-disable-next-line solid/reactivity -- The editor is keyed on the instance.
     const view = props.instance.createValidationView();
     onCleanup(() => view.dispose());
@@ -18,6 +23,22 @@ export function InstanceEditor(props: { instance: ApiInstance; focus: FocusHandl
 
     const issues = createMemo(() => view.issues);
     const tables = createMemo(() => view.tables);
+
+    const tableList = useTableList();
+    createEffect(() => {
+        if (ready()) {
+            const refId = props.refId;
+            tableList.setTables(
+                refId,
+                tables().map(({ id, label }) => ({ id, label })),
+            );
+            onCleanup(() => tableList.setTables(refId, undefined));
+        }
+    });
+
+    const visibleTables = createMemo(() =>
+        tables().filter((table) => tableList.isVisible(props.refId, table.id)),
+    );
 
     const issuesForTable = (tableId: string): TableIssue[] =>
         issues().filter((issue) => issue.path[0] === tableId && issue.issueType !== "MissingValue");
@@ -38,31 +59,41 @@ export function InstanceEditor(props: { instance: ApiInstance; focus: FocusHandl
                     when={tables().length > 0}
                     fallback={<p class={styles.empty}>This model has no tables.</p>}
                 >
-                    <div class={styles.tables}>
-                        <Index each={tables()}>
-                            {(table) => (
-                                <TableEditor
-                                    table={table()}
-                                    tables={tables()}
-                                    issues={issuesForTable(table().id)}
-                                    focus={focus.childFocus(table().id)}
-                                    onSetField={(row, header, value) =>
-                                        void props.instance
-                                            .set(row, header, value)
-                                            .then(logError("set field"))
-                                    }
-                                    onAddRow={() =>
-                                        void props.instance
-                                            .addRow(table())
-                                            .then(logError("add row"))
-                                    }
-                                    onDeleteRow={(row) =>
-                                        props.instance.deleteRow(table().id, row.id)
-                                    }
-                                />
-                            )}
-                        </Index>
-                    </div>
+                    <Show
+                        when={visibleTables().length > 0}
+                        fallback={
+                            <p class={styles.empty}>
+                                All tables are hidden. Select a table in the sidebar to show it.
+                            </p>
+                        }
+                    >
+                        <div class={styles.tables}>
+                            <Index each={visibleTables()}>
+                                {(table) => (
+                                    <TableEditor
+                                        table={table()}
+                                        tables={tables()}
+                                        issues={issuesForTable(table().id)}
+                                        focus={focus.childFocus(table().id)}
+                                        onHide={() => tableList.hide(props.refId, table().id)}
+                                        onSetField={(row, header, value) =>
+                                            void props.instance
+                                                .set(row, header, value)
+                                                .then(logError("set field"))
+                                        }
+                                        onAddRow={() =>
+                                            void props.instance
+                                                .addRow(table())
+                                                .then(logError("add row"))
+                                        }
+                                        onDeleteRow={(row) =>
+                                            props.instance.deleteRow(table().id, row.id)
+                                        }
+                                    />
+                                )}
+                            </Index>
+                        </div>
+                    </Show>
                 </Show>
             </Show>
         </div>

--- a/packages/frontend/src/instance/table_list.ts
+++ b/packages/frontend/src/instance/table_list.ts
@@ -1,0 +1,76 @@
+import { createContext, useContext } from "solid-js";
+import { createStore, produce, reconcile } from "solid-js/store";
+import invariant from "tiny-invariant";
+
+/** Minimal description of an instance table, for listing outside the editor. */
+export type TableSummary = {
+    id: string;
+    label: string | null;
+};
+
+/** Page-level UI state for the tables of open instance documents.
+
+Mounted instance editors register their tables here so that the sidebar can list
+them, and both sides share which tables are hidden. Keyed by document ref ID.
+ */
+export type TableList = {
+    /** Tables registered for a document. Empty if none is mounted. */
+    tables: (refId: string) => ReadonlyArray<TableSummary>;
+
+    /** Register (or, with `undefined`, unregister) the tables of a document. */
+    setTables: (refId: string, tables: ReadonlyArray<TableSummary> | undefined) => void;
+
+    isVisible: (refId: string, tableId: string) => boolean;
+    show: (refId: string, tableId: string) => void;
+    hide: (refId: string, tableId: string) => void;
+};
+
+export const TableListContext = createContext<TableList>();
+
+export function useTableList(): TableList {
+    const tableList = useContext(TableListContext);
+    invariant(tableList, "Table list must be provided as context");
+    return tableList;
+}
+
+export function createTableList(): TableList {
+    // Stable empty array so unmounted documents don't produce a fresh array
+    // (and hence spurious re-rendering) on each reactive read.
+    const noTables: ReadonlyArray<TableSummary> = [];
+
+    const [state, setState] = createStore<{
+        tables: Record<string, TableSummary[]>;
+        hidden: Record<string, Record<string, true>>;
+    }>({ tables: {}, hidden: {} });
+
+    return {
+        tables: (refId) => state.tables[refId] ?? noTables,
+        setTables: (refId, tables) => {
+            if (tables) {
+                setState("tables", refId, reconcile([...tables], { key: "id" }));
+            } else {
+                setState(
+                    "tables",
+                    produce((all) => {
+                        delete all[refId];
+                    }),
+                );
+            }
+        },
+        isVisible: (refId, tableId) => !state.hidden[refId]?.[tableId],
+        show: (refId, tableId) =>
+            setState(
+                "hidden",
+                produce((hidden) => {
+                    delete hidden[refId]?.[tableId];
+                }),
+            ),
+        hide: (refId, tableId) =>
+            setState(
+                "hidden",
+                produce((hidden) => {
+                    (hidden[refId] ??= {})[tableId] = true;
+                }),
+            ),
+    };
+}

--- a/packages/frontend/src/page/document_page.tsx
+++ b/packages/frontend/src/page/document_page.tsx
@@ -47,6 +47,7 @@ import { DiagramInfo } from "../diagram/diagram_info";
 import { InstanceEditor } from "../instance/instance_editor";
 import { InstanceInfo } from "../instance/instance_info";
 import { getLiveInstance, type LiveInstanceDoc } from "../instance/live_doc_compatibility";
+import { createTableList, TableListContext } from "../instance/table_list";
 import {
     getLiveLLMConversation,
     LLMConversationEditor,
@@ -104,6 +105,7 @@ export default function DocumentPage() {
     const isSidePanelOpen = () =>
         !!params.subkind && !!params.subref && documentIsVisible(params.subkind);
     const paneFocus = useChildFocus<"primary" | "secondary">(rootFocus, { default: "primary" });
+    const tableList = createTableList();
 
     // Redirect if primary and secondary refs match
     createEffect(() => {
@@ -193,59 +195,61 @@ export default function DocumentPage() {
             <Title>{documentTitle()}</Title>
             <Show when={primaryLiveDoc()} fallback={<DocumentLoadingScreen />}>
                 {(docWithRef) => (
-                    <SidebarLayout
-                        toolbarContents={
-                            <SplitPaneToolbar
-                                doc={docWithRef().liveDoc}
-                                docRef={docWithRef().docRef}
-                                secondaryDoc={secondaryLiveDoc()?.liveDoc}
-                                secondaryDocRef={secondaryLiveDoc()?.docRef}
-                                panelSizes={resizableContext()?.sizes()}
-                                maximizeSidePanel={maximizeSidePanel}
+                    <TableListContext.Provider value={tableList}>
+                        <SidebarLayout
+                            toolbarContents={
+                                <SplitPaneToolbar
+                                    doc={docWithRef().liveDoc}
+                                    docRef={docWithRef().docRef}
+                                    secondaryDoc={secondaryLiveDoc()?.liveDoc}
+                                    secondaryDocRef={secondaryLiveDoc()?.docRef}
+                                    panelSizes={resizableContext()?.sizes()}
+                                    maximizeSidePanel={maximizeSidePanel}
+                                    closeSidePanel={closeSidePanel}
+                                    togglePrimaryHistorySidebar={togglePrimaryHistorySidebar}
+                                    toggleSecondaryHistorySidebar={toggleSecondaryHistorySidebar}
+                                    primaryPaneFocus={paneFocus.childFocus("primary")}
+                                    secondaryPaneFocus={paneFocus.childFocus("secondary")}
+                                />
+                            }
+                            sidebarContents={
+                                <DocumentSidebar
+                                    primaryDoc={{
+                                        liveDoc: docWithRef().liveDoc.liveDoc,
+                                        docRef: docWithRef().docRef,
+                                    }}
+                                    secondaryDoc={(() => {
+                                        const secondary = secondaryLiveDoc();
+                                        return secondary
+                                            ? {
+                                                  liveDoc: secondary.liveDoc.liveDoc,
+                                                  docRef: secondary.docRef,
+                                              }
+                                            : undefined;
+                                    })()}
+                                    primaryPaneFocus={paneFocus.childFocus("primary")}
+                                    secondaryPaneFocus={paneFocus.childFocus("secondary")}
+                                    refetchPrimaryDoc={refetchPrimaryDoc}
+                                    refetchSecondaryDoc={refetchSecondaryDoc}
+                                />
+                            }
+                        >
+                            <ResizablePanels
+                                primaryDoc={docWithRef().liveDoc}
+                                primaryDocRef={docWithRef().docRef}
+                                secondaryDoc={secondaryLiveDoc()}
+                                isSidePanelOpen={isSidePanelOpen()}
                                 closeSidePanel={closeSidePanel}
-                                togglePrimaryHistorySidebar={togglePrimaryHistorySidebar}
-                                toggleSecondaryHistorySidebar={toggleSecondaryHistorySidebar}
-                                primaryPaneFocus={paneFocus.childFocus("primary")}
-                                secondaryPaneFocus={paneFocus.childFocus("secondary")}
-                            />
-                        }
-                        sidebarContents={
-                            <DocumentSidebar
-                                primaryDoc={{
-                                    liveDoc: docWithRef().liveDoc.liveDoc,
-                                    docRef: docWithRef().docRef,
-                                }}
-                                secondaryDoc={(() => {
-                                    const secondary = secondaryLiveDoc();
-                                    return secondary
-                                        ? {
-                                              liveDoc: secondary.liveDoc.liveDoc,
-                                              docRef: secondary.docRef,
-                                          }
-                                        : undefined;
-                                })()}
-                                primaryPaneFocus={paneFocus.childFocus("primary")}
-                                secondaryPaneFocus={paneFocus.childFocus("secondary")}
                                 refetchPrimaryDoc={refetchPrimaryDoc}
                                 refetchSecondaryDoc={refetchSecondaryDoc}
+                                setResizableContext={setResizableContext}
+                                primaryHistoryOpen={primaryHistoryOpen()}
+                                secondaryHistoryOpen={secondaryHistoryOpen()}
+                                primaryPaneFocus={paneFocus.childFocus("primary")}
+                                secondaryPaneFocus={paneFocus.childFocus("secondary")}
                             />
-                        }
-                    >
-                        <ResizablePanels
-                            primaryDoc={docWithRef().liveDoc}
-                            primaryDocRef={docWithRef().docRef}
-                            secondaryDoc={secondaryLiveDoc()}
-                            isSidePanelOpen={isSidePanelOpen()}
-                            closeSidePanel={closeSidePanel}
-                            refetchPrimaryDoc={refetchPrimaryDoc}
-                            refetchSecondaryDoc={refetchSecondaryDoc}
-                            setResizableContext={setResizableContext}
-                            primaryHistoryOpen={primaryHistoryOpen()}
-                            secondaryHistoryOpen={secondaryHistoryOpen()}
-                            primaryPaneFocus={paneFocus.childFocus("primary")}
-                            secondaryPaneFocus={paneFocus.childFocus("secondary")}
-                        />
-                    </SidebarLayout>
+                        </SidebarLayout>
+                    </TableListContext.Provider>
                 )}
             </Show>
         </Show>
@@ -591,6 +595,7 @@ export function DocumentPane(props: {
                             {(liveInstance) => (
                                 <InstanceEditor
                                     instance={liveInstance.instance}
+                                    refId={props.docRef.refId}
                                     focus={props.focus}
                                 />
                             )}

--- a/packages/frontend/src/page/document_page_sidebar.tsx
+++ b/packages/frontend/src/page/document_page_sidebar.tsx
@@ -1,10 +1,12 @@
 import { useNavigate } from "@solidjs/router";
+import Table from "lucide-solid/icons/table";
 import { createMemo, createResource, For, Show, useContext } from "solid-js";
 import { stringify as uuidStringify } from "uuid";
 
 import { DocumentTypeIcon, type FocusHandle } from "catcolab-ui-components";
 import type { Document, Link } from "catlog-wasm";
 import { type Api, type LiveDocWithRef, useApi } from "../api";
+import { useTableList } from "../instance/table_list";
 import { TheoryLibraryContext } from "../theory";
 import { isDocumentVisible, useUserSettings } from "../user/user_settings";
 import { useUserState } from "../user/user_state_context";
@@ -198,6 +200,18 @@ function DocumentsTreeNode(props: {
                 refetchPrimaryDoc={props.refetchPrimaryDoc}
                 refetchSecondaryDoc={props.refetchSecondaryDoc}
             />
+            <Show when={props.doc.liveDoc.doc.type === "instance" && props.doc.docRef.refId}>
+                {(refId) => (
+                    <InstanceTableList
+                        refId={refId()}
+                        indent={props.indent + 1}
+                        isOpen={
+                            refId() === props.primaryDoc.docRef.refId ||
+                            refId() === props.secondaryDoc?.docRef.refId
+                        }
+                    />
+                )}
+            </Show>
             <For each={visibleChildDocs()}>
                 {(child) => (
                     <DocumentsTreeNode
@@ -323,6 +337,35 @@ function DocumentsTreeLeaf(props: {
                 />
             </div>
         </div>
+    );
+}
+
+/** Tables of an open instance document. Clicking a row shows the table. */
+function InstanceTableList(props: { refId: string; indent: number; isOpen: boolean }) {
+    const tableList = useTableList();
+
+    return (
+        <Show when={props.isOpen}>
+            <For each={tableList.tables(props.refId)}>
+                {(table) => {
+                    const isVisible = () => tableList.isVisible(props.refId, table.id);
+                    return (
+                        <div
+                            class="related-table"
+                            classList={{
+                                active: isVisible(),
+                                unnamed: !table.label,
+                            }}
+                            style={{ "padding-left": `${props.indent * 16}px` }}
+                            onClick={() => tableList.show(props.refId, table.id)}
+                        >
+                            <Table />
+                            <div class="document-name">{table.label || "Unnamed table"}</div>
+                        </div>
+                    );
+                }}
+            </For>
+        </Show>
     );
 }
 

--- a/packages/frontend/src/page/sidebar_layout.css
+++ b/packages/frontend/src/page/sidebar_layout.css
@@ -179,6 +179,41 @@
     }
 }
 
+.related-table {
+    display: flex;
+    align-items: center;
+    box-sizing: border-box;
+    height: 30px;
+    padding: 5px 8px;
+    border-left: 3px solid transparent;
+    transition: background 20ms;
+
+    .document-name {
+        flex: 1;
+        overflow: hidden;
+        text-wrap-mode: nowrap;
+        text-overflow: ellipsis;
+        padding-left: 5px;
+    }
+
+    &.unnamed .document-name {
+        font-style: italic;
+    }
+
+    &:hover {
+        background: var(--color-hover-bg);
+        cursor: pointer;
+    }
+
+    &.active {
+        background: var(--color-gray-150);
+
+        &:hover {
+            background: var(--color-hover-bg-dark);
+        }
+    }
+}
+
 .resizeable-handle {
     background: none;
     border: none;

--- a/packages/ui-components/src/document_type_icon.tsx
+++ b/packages/ui-components/src/document_type_icon.tsx
@@ -3,7 +3,7 @@ import File from "lucide-solid/icons/file";
 import FileX from "lucide-solid/icons/file-x";
 import MessageSquare from "lucide-solid/icons/message-square";
 import Network from "lucide-solid/icons/network";
-import Table from "lucide-solid/icons/table";
+import Table2 from "lucide-solid/icons/table-2";
 import { Match, Switch } from "solid-js";
 
 import { ModelFileIcon } from "./model_file_icon";
@@ -33,7 +33,7 @@ export function DocumentTypeIcon(props: {
                 <ChartSpline />
             </Match>
             <Match when={props.documentType === "instance"}>
-                <Table />
+                <Table2 />
             </Match>
             <Match when={props.documentType === "llmconversation"}>
                 <MessageSquare />

--- a/packages/ui-components/src/table_editor/table_editor.module.css
+++ b/packages/ui-components/src/table_editor/table_editor.module.css
@@ -11,12 +11,16 @@
 .header {
     position: sticky;
     left: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
     padding: 0.4rem 0.75rem;
     background: var(--color-gray-50);
 }
 
 .label {
     margin: 0;
+    margin-right: auto;
     font-size: 1.05rem;
     font-weight: 500;
 }

--- a/packages/ui-components/src/table_editor/table_editor.stories.tsx
+++ b/packages/ui-components/src/table_editor/table_editor.stories.tsx
@@ -76,11 +76,19 @@ function toFieldValue(
 }
 
 /** Renders editable table editors backed by in-memory table specs. */
-function EditableTables(props: { initialSpecs: TableSpec[]; issues?: TableIssue[] }) {
+function EditableTables(props: {
+    initialSpecs: TableSpec[];
+    issues?: TableIssue[];
+    hideable?: boolean;
+}) {
     // Initial story data, intentionally captured on mount.
     const [specs, setSpecs] = createSignal(props.initialSpecs);
+    const [hidden, setHidden] = createSignal<ReadonlySet<string>>(new Set());
     const tables = () => specs().map(toInstanceTable);
     const focus = useChildFocus<string>(rootFocus);
+    const visibleTables = () => tables().filter((table) => !hidden().has(table.id));
+
+    const hide = (tableId: string) => setHidden((ids) => new Set([...ids, tableId]));
 
     const updateSpec = (tableId: string, update: (spec: TableSpec) => TableSpec) =>
         setSpecs((specs) => specs.map((spec) => (spec.id === tableId ? update(spec) : spec)));
@@ -116,7 +124,7 @@ function EditableTables(props: { initialSpecs: TableSpec[]; issues?: TableIssue[
 
     return (
         <div style={{ display: "flex", "flex-wrap": "wrap", gap: "1.5rem" }}>
-            <Index each={tables()}>
+            <Index each={visibleTables()}>
                 {(table) => (
                     <TableEditor
                         table={table()}
@@ -128,6 +136,7 @@ function EditableTables(props: { initialSpecs: TableSpec[]; issues?: TableIssue[
                         }
                         onAddRow={() => addRow(table().id)}
                         onDeleteRow={(row) => deleteRow(table().id, row)}
+                        onHide={props.hideable ? () => hide(table().id) : undefined}
                     />
                 )}
             </Index>
@@ -190,6 +199,20 @@ const personSpec: TableSpec = {
 export const Summary: Story = {
     render: () => <EditableTables initialSpecs={[teamSpec, personSpec]} />,
     tags: ["!autodocs", "!dev"],
+};
+
+export const HideTable: Story = {
+    render: () => <EditableTables initialSpecs={[teamSpec, personSpec]} hideable />,
+    play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+        const canvas = within(canvasElement);
+        await expect(canvas.getAllByRole("grid")).toHaveLength(2);
+
+        await userEvent.click(canvas.getAllByRole("button", { name: "Hide table" })[0]!);
+
+        await waitFor(() => expect(canvas.getAllByRole("grid")).toHaveLength(1));
+        await expect(canvas.queryByText("Team")).not.toBeInTheDocument();
+        await expect(canvas.getByText("Person")).toBeInTheDocument();
+    },
 };
 
 export const DoubleClickBooleanCell: Story = {

--- a/packages/ui-components/src/table_editor/table_editor.tsx
+++ b/packages/ui-components/src/table_editor/table_editor.tsx
@@ -1,4 +1,5 @@
 import ChevronDown from "lucide-solid/icons/chevron-down";
+import Minus from "lucide-solid/icons/minus";
 import { batch, createEffect, createMemo, createSignal, Index, onCleanup, Show } from "solid-js";
 
 import type {
@@ -10,6 +11,7 @@ import type {
     TableRow,
 } from "catcolab-documents";
 import type { Completion } from "../completions";
+import { IconButton } from "../icon_button";
 import { TextInput } from "../text_input";
 import { type FocusHandle, useChildFocus } from "../util/focus";
 
@@ -77,6 +79,9 @@ export type TableEditorProps = {
 
     /** Called when the user deletes a row. */
     onDeleteRow: (row: TableRow) => void;
+
+    /** Called when the user hides the table. Shows a hide button if provided. */
+    onHide?: () => void;
 };
 
 /** A spreadsheet-like editor for a tabular data instance.
@@ -576,6 +581,18 @@ export function TableEditor(props: TableEditorProps) {
                 <h3 class={styles.label} classList={{ [styles.unnamed]: !props.table.label }}>
                     {tableDisplayName(props.table)}
                 </h3>
+                <Show when={props.onHide}>
+                    {(onHide) => (
+                        <IconButton
+                            type="button"
+                            aria-label="Hide table"
+                            tooltip="Hide table"
+                            onClick={() => onHide()()}
+                        >
+                            <Minus size={16} />
+                        </IconButton>
+                    )}
+                </Show>
             </div>
             <table class={styles.grid} role="grid">
                 <colgroup>


### PR DESCRIPTION
Lists the tables in the sidebar.

<img width="248" height="298" alt="image" src="https://github.com/user-attachments/assets/845cb15c-6214-49d3-9c6e-449024bda177" />

They can be minimized with a "-" button.

<img width="284" height="200" alt="image" src="https://github.com/user-attachments/assets/ba139377-8466-483c-aec5-23b8d9749d87" />


I haven't decided what should happen if you click a table again that is already being shown, so for now that does nothing at all.
