### PR TITLE
Upgrade `setup-rust-toolchain` to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,10 +105,9 @@ jobs:
 
       - name: Install Rust toolchain from file
         if: github.event_name == 'release' || steps.cache-frontend-build.outputs.cache-hit != 'true'
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v2
         with:
-          # Don't override flags in cargo config files.
-          rustflags: ""
+          build-warnings: ""
 
       - name: Build for Staging
         if: (github.event_name == 'push' || github.event_name == 'pull_request') && steps.cache-frontend-build.outputs.cache-hit != 'true'
@@ -357,10 +356,9 @@ jobs:
 
       - name: Install Rust toolchain from file
         if: steps.cache-gaios-build.outputs.cache-hit != 'true'
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v2
         with:
-          # Don't override flags in cargo config files.
-          rustflags: ""
+          build-warnings: ""
 
       - name: Build gaios plugin
         if: steps.cache-gaios-build.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,10 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v2
         with:
           toolchain: ${{ matrix.toolchain }}
-          # Don't override flags in cargo config files.
-          rustflags: ""
+          build-warnings: ""
 
       - name: Tests
         run: |
@@ -42,10 +41,11 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Rust toolchain from file
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v2
         with:
           toolchain: nightly
           components: rustfmt
+          build-warnings: ""
 
       - name: Check formatting
         run: |
@@ -59,15 +59,9 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Rust toolchain from file
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          # Don't override flags in cargo config files. Warnings are denied
-          # through `CARGO_BUILD_WARNINGS` instead of `RUSTFLAGS`.
-          rustflags: ""
+        uses: actions-rust-lang/setup-rust-toolchain@v2
 
       - name: Check clippy warnings
-        env:
-          CARGO_BUILD_WARNINGS: deny
         run: |
           cargo clippy --all-targets --all-features --keep-going
 
@@ -112,10 +106,9 @@ jobs:
           pnpm install
 
       - name: Install Rust toolchain from file
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v2
         with:
-          # Don't override flags in cargo config files.
-          rustflags: ""
+          build-warnings: ""
 
       - name: Format/linting/import sorting
         run: |
@@ -158,10 +151,9 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Rust toolchain from file
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v2
         with:
-          # Don't override flags in cargo config files.
-          rustflags: ""
+          build-warnings: ""
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -190,9 +182,9 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Rust toolchain from file
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v2
         with:
-          rustflags: ""
+          build-warnings: ""
 
       - name: Start PostgreSQL
         run: |


### PR DESCRIPTION
Follow-up to #1355. This change is supposed to preserve the old behavior that the Rust linting action will fail on build warnings but no other Rust build step will.