### PR TITLE
Use deploy-rs from pkgsLinux rather than GitHub

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -253,7 +253,7 @@ jobs:
 
     - name: Deploy to catcolab-next
       run: |
-       nix run github:serokell/deploy-rs -- --skip-checks .#catcolab-next
+       nix run .#deploy-rs -- --skip-checks .#catcolab-next
 
     - name: Verify deployment
       run: |

--- a/flake.nix
+++ b/flake.nix
@@ -277,6 +277,8 @@
             };
 
           linuxOnlyPackages = {
+            deploy-rs = pkgsLinux.deploy-rs;
+
             backend = pkgsLinux.callPackage ./packages/backend/default.nix {
               inherit craneLib cargoArtifacts;
               pkgs = pkgsLinux;


### PR DESCRIPTION
This should fix [deployment issues we are having on main](https://github.com/ToposInstitute/CatColab/actions/runs/34260606323/job/102403990401). 

Looks like crates.io is refusing some dependency crate downloads  (e.g. cbitset)  when building deploy-rs from from git. I was only able to replicate that locally by clearing specific cache entries in my Nix. 

It seems we shouldn't be using "latest" deploy-rs from git anyway and the version from Nixpkgs does not need to pull from crates.io. 