### PR TITLE
Add buttons to delete orphaned data to table editor

### DIFF
--- a/packages/frontend/src/instance/instance_editor.tsx
+++ b/packages/frontend/src/instance/instance_editor.tsx
@@ -89,6 +89,16 @@ export function InstanceEditor(props: {
                                         onDeleteRow={(row) =>
                                             props.instance.deleteRow(table().id, row.id)
                                         }
+                                        onDeleteOrphanedTable={() =>
+                                            void props.instance
+                                                .deleteOrphanedTable(table().id)
+                                                .then(logError("delete table"))
+                                        }
+                                        onDeleteOrphanedColumn={(header) =>
+                                            void props.instance
+                                                .deleteOrphanedColumn(table().id, header.id)
+                                                .then(logError("delete column"))
+                                        }
                                     />
                                 )}
                             </Index>

--- a/packages/ui-components/src/button.css
+++ b/packages/ui-components/src/button.css
@@ -52,3 +52,28 @@
     background: var(--color-button-danger-hover);
     border: 1px solid var(--color-button-danger-hover);
 }
+
+/* Outline modifier: the variant's border and text color on a transparent
+background, darkening rather than filling on hover. */
+.button-outline,
+.button-outline:hover:not(:disabled) {
+    background: transparent;
+}
+
+.button-positive.button-outline {
+    color: var(--color-button-positive-base);
+}
+
+.button-positive.button-outline:hover:not(:disabled) {
+    color: color-mix(in srgb, var(--color-button-positive-base), black 20%);
+    border-color: color-mix(in srgb, var(--color-button-positive-base), black 20%);
+}
+
+.button-danger.button-outline {
+    color: var(--color-button-danger-base);
+}
+
+.button-danger.button-outline:hover:not(:disabled) {
+    color: color-mix(in srgb, var(--color-button-danger-base), black 20%);
+    border-color: color-mix(in srgb, var(--color-button-danger-base), black 20%);
+}

--- a/packages/ui-components/src/button.stories.tsx
+++ b/packages/ui-components/src/button.stories.tsx
@@ -94,6 +94,25 @@ export const Danger: Story = {
     ),
 };
 
+export const Outline: Story = {
+    render: () => (
+        <div style={{ display: "flex", gap: "8px", "flex-wrap": "wrap" }}>
+            <Button variant="positive" outline>
+                Positive
+            </Button>
+            <Button variant="utility" outline>
+                Utility
+            </Button>
+            <Button variant="danger" outline>
+                Danger
+            </Button>
+            <Button variant="danger" outline disabled>
+                Disabled
+            </Button>
+        </div>
+    ),
+};
+
 export const WithIcons: Story = {
     render: () => (
         <div style={{ display: "flex", gap: "8px", "flex-wrap": "wrap" }}>

--- a/packages/ui-components/src/button.tsx
+++ b/packages/ui-components/src/button.tsx
@@ -8,11 +8,13 @@ export function Button(
     allProps: {
         /** Visual variant of the button */
         variant?: ButtonVariant;
+        /** Render the variant as an outline: transparent until hovered. */
+        outline?: boolean;
         /** Button content - can be text, icon, or both */
         children: JSX.Element;
     } & ComponentProps<"button">,
 ) {
-    const [props, buttonProps] = splitProps(allProps, ["variant", "children", "class"]);
+    const [props, buttonProps] = splitProps(allProps, ["variant", "outline", "children", "class"]);
 
     const variantClass = () => {
         switch (props.variant) {
@@ -30,7 +32,7 @@ export function Button(
     return (
         <button
             {...buttonProps}
-            class={`button ${variantClass()}${props.class ? ` ${props.class}` : ""}`}
+            class={`button ${variantClass()}${props.outline ? " button-outline" : ""}${props.class ? ` ${props.class}` : ""}`}
             type={buttonProps.type || "button"}
         >
             {props.children}

--- a/packages/ui-components/src/table_editor/table_editor.module.css
+++ b/packages/ui-components/src/table_editor/table_editor.module.css
@@ -25,6 +25,23 @@
     font-weight: 500;
 }
 
+.deleteTable,
+.deleteColumn {
+    flex: none;
+    margin: 0;
+    font-size: 0.9rem;
+}
+
+.deleteTable {
+    padding: 0.3rem 0.75rem;
+}
+
+.deleteColumn {
+    margin: 0.5rem 0 0.3rem 0.5rem;
+    padding: 0.1rem 0.6rem;
+    line-height: 1.4;
+}
+
 .grid {
     width: max-content;
     border-collapse: collapse;
@@ -40,6 +57,18 @@
     text-align: left;
     overflow: hidden;
     white-space: nowrap;
+}
+
+.columnContent {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+
+.columnLabel {
+    min-width: 0;
+    overflow: hidden;
     text-overflow: ellipsis;
 }
 
@@ -189,6 +218,32 @@ shadow, it is painted above the cell editor input. */
     color: #d87878;
 }
 
+/* Column about to be deleted: sides on every cell, top on the header, bottom
+on the last row. Inset shadows leave the collapsed borders alone. */
+.columnDeleting {
+    box-shadow:
+        inset 3px 0 0 #d87878,
+        inset -3px 0 0 #d87878;
+}
+
+.columnHeader.columnDeleting {
+    box-shadow:
+        inset 3px 0 0 #d87878,
+        inset -3px 0 0 #d87878,
+        inset 0 3px 0 #d87878;
+}
+
+.grid tbody tr:last-child .cell.columnDeleting {
+    box-shadow:
+        inset 3px 0 0 #d87878,
+        inset -3px 0 0 #d87878,
+        inset 0 -3px 0 #d87878;
+}
+
+.grid:not(:has(tbody tr)) .columnHeader.columnDeleting {
+    box-shadow: inset 0 0 0 3px #d87878;
+}
+
 .footer {
     position: sticky;
     left: 0;
@@ -197,8 +252,18 @@ shadow, it is painted above the cell editor input. */
 }
 
 .table.unknown {
-    outline: 2px solid var(--color-button-danger-base);
     background: var(--color-icon-button-danger-hover);
+}
+
+/* Table about to be deleted, matching the row and column highlights. Drawn
+over the border rather than inset, where the sticky header would cover it. */
+.table:has(.deleteTable:hover) {
+    outline: 3px solid #d87878;
+    outline-offset: -1px;
+}
+
+.columnHeader:has(.deleteColumn) {
+    background: var(--color-form-invalid-bg);
 }
 
 .table.unknown .header,

--- a/packages/ui-components/src/table_editor/table_editor.stories.tsx
+++ b/packages/ui-components/src/table_editor/table_editor.stories.tsx
@@ -122,6 +122,19 @@ function EditableTables(props: {
             rows: spec.rows.filter((specRow) => specRow.id !== row.id),
         }));
 
+    const deleteTable = (tableId: string) =>
+        setSpecs((specs) => specs.filter((spec) => spec.id !== tableId));
+
+    const deleteColumn = (tableId: string, header: TableHeader) =>
+        updateSpec(tableId, (spec) => ({
+            ...spec,
+            columns: spec.columns.filter((column) => column.id !== header.id),
+            rows: spec.rows.map((row) => {
+                const { [header.id]: _removed, ...values } = row.values;
+                return { ...row, values };
+            }),
+        }));
+
     return (
         <div style={{ display: "flex", "flex-wrap": "wrap", gap: "1.5rem" }}>
             <Index each={visibleTables()}>
@@ -137,6 +150,8 @@ function EditableTables(props: {
                         onAddRow={() => addRow(table().id)}
                         onDeleteRow={(row) => deleteRow(table().id, row)}
                         onHide={props.hideable ? () => hide(table().id) : undefined}
+                        onDeleteOrphanedTable={() => deleteTable(table().id)}
+                        onDeleteOrphanedColumn={(header) => deleteColumn(table().id, header)}
                     />
                 )}
             </Index>
@@ -431,6 +446,61 @@ export const OrphanedTable: Story = {
         ).not.toBeInTheDocument();
         await expect(unknownRef).toHaveTextContent("Unknown table row 1");
         await expect(unknownRef).toHaveAttribute("aria-invalid", "true");
+
+        // Columns of an orphaned table go with the table, not one by one.
+        await expect(
+            canvas.queryByRole("button", { name: "Delete column" }),
+        ).not.toBeInTheDocument();
+        await userEvent.click(canvas.getByRole("button", { name: "Delete table" }));
+        await waitFor(() => expect(canvas.getAllByRole("grid")).toHaveLength(1));
+        await expect(
+            canvas.queryByRole("heading", { name: "Unknown table" }),
+        ).not.toBeInTheDocument();
+        await expect(canvas.getByRole("gridcell")).toHaveTextContent("?");
+    },
+};
+
+export const OrphanedColumn: Story = {
+    render: () => (
+        <EditableTables
+            initialSpecs={[
+                {
+                    ...teamSpec,
+                    columns: [...teamSpec.columns, { id: "stray", label: null, type: "Unknown" }],
+                    rows: teamSpec.rows.map((row) => ({
+                        ...row,
+                        values: { ...row.values, stray: "leftover" },
+                    })),
+                },
+            ]}
+            issues={teamSpec.rows.map((row) => ({
+                message: "Field `stray` does not exist in the schema",
+                path: ["team", "rows", row.id, "fields", "stray"],
+                issueType: "OrphanedField",
+            }))}
+        />
+    ),
+    play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+        const canvas = within(canvasElement);
+
+        const unknownHeader = canvas.getByRole("columnheader", { name: /Unknown column/ });
+        await expect(
+            within(unknownHeader).getByRole("button", { name: "Delete column" }),
+        ).toBeVisible();
+        await expect(
+            within(canvas.getByRole("columnheader", { name: "name" })).queryByRole("button"),
+        ).not.toBeInTheDocument();
+        await expect(canvas.getAllByRole("gridcell")[2]).toHaveTextContent("leftover");
+
+        await userEvent.click(within(unknownHeader).getByRole("button", { name: "Delete column" }));
+        await waitFor(() => expect(canvas.getAllByRole("columnheader")).toHaveLength(3));
+        await expect(
+            canvas.queryByRole("columnheader", { name: /Unknown column/ }),
+        ).not.toBeInTheDocument();
+        const cells = canvas.getAllByRole("gridcell");
+        await expect(cells).toHaveLength(6);
+        await expect(cells[0]).toHaveTextContent("Atlas");
+        await expect(cells[1]).toHaveTextContent("5");
     },
 };
 

--- a/packages/ui-components/src/table_editor/table_editor.tsx
+++ b/packages/ui-components/src/table_editor/table_editor.tsx
@@ -10,6 +10,7 @@ import type {
     TableIssue,
     TableRow,
 } from "catcolab-documents";
+import { Button } from "../button";
 import type { Completion } from "../completions";
 import { IconButton } from "../icon_button";
 import { TextInput } from "../text_input";
@@ -24,7 +25,7 @@ const COLUMN_WIDTHS = {
     Float: 100,
     String: 180,
     RowRef: 220,
-    Unknown: 180,
+    Unknown: 220,
 } as const;
 
 const DELETE_COLUMN_WIDTH = 36;
@@ -82,6 +83,13 @@ export type TableEditorProps = {
 
     /** Called when the user hides the table. Shows a hide button if provided. */
     onHide?: () => void;
+
+    /** Called when the user deletes this table, which is offered only when the
+    table has no entity in the schema. */
+    onDeleteOrphanedTable?: () => void;
+
+    /** Called when the user deletes a column that has no morphism in the schema. */
+    onDeleteOrphanedColumn?: (header: TableHeader) => void;
 };
 
 /** A spreadsheet-like editor for a tabular data instance.
@@ -92,6 +100,8 @@ export function TableEditor(props: TableEditorProps) {
     const [pendingDelete, setPendingDelete] = createSignal<PendingDelete | null>(null);
     const [suppressedFocus, setSuppressedFocus] = createSignal<CellKey | null>(null);
     const [focusRequest, setFocusRequest] = createSignal(0);
+    // Column whose delete button is hovered, highlighted like a row about to be deleted.
+    const [deletingColumnId, setDeletingColumnId] = createSignal<string | null>(null);
 
     // Forward to the prop lazily in case the handle changes.
     const parentFocus: FocusHandle = {
@@ -550,6 +560,12 @@ export function TableEditor(props: TableEditorProps) {
         props.onDeleteRow(row);
     };
 
+    const isOrphanedTable = () => props.table.label === null;
+
+    // Columns of an orphaned table are removed along with the table.
+    const isOrphanedColumn = (header: TableHeader) =>
+        !isOrphanedTable() && header.type.tag === "Unknown";
+
     return (
         <section
             class={`${styles.table}${props.class ? ` ${props.class}` : ""}`}
@@ -581,6 +597,18 @@ export function TableEditor(props: TableEditorProps) {
                 <h3 class={styles.label} classList={{ [styles.unnamed]: !props.table.label }}>
                     {tableDisplayName(props.table)}
                 </h3>
+                <Show when={isOrphanedTable() && props.onDeleteOrphanedTable}>
+                    <Button
+                        variant="danger"
+                        outline
+                        class={styles.deleteTable}
+                        onMouseDown={(evt) => evt.preventDefault()}
+                        aria-label="Delete table"
+                        onClick={() => props.onDeleteOrphanedTable?.()}
+                    >
+                        Delete
+                    </Button>
+                </Show>
                 <Show when={props.onHide}>
                     {(onHide) => (
                         <IconButton
@@ -616,19 +644,55 @@ export function TableEditor(props: TableEditorProps) {
                         >
                             <Index each={headers()}>
                                 {(header) => (
-                                    <th class={styles.columnHeader} scope="col">
-                                        <Show
-                                            when={header().label}
-                                            fallback={
-                                                <span class={styles.unnamed}>
-                                                    {header().label === null
-                                                        ? "Unknown column"
-                                                        : "Unnamed column"}
-                                                </span>
-                                            }
-                                        >
-                                            {header().label}
-                                        </Show>
+                                    <th
+                                        class={styles.columnHeader}
+                                        classList={{
+                                            [styles.columnDeleting]:
+                                                deletingColumnId() === header().id,
+                                        }}
+                                        scope="col"
+                                    >
+                                        <div class={styles.columnContent}>
+                                            <span class={styles.columnLabel}>
+                                                <Show
+                                                    when={header().label}
+                                                    fallback={
+                                                        <span class={styles.unnamed}>
+                                                            {header().label === null
+                                                                ? "Unknown column"
+                                                                : "Unnamed column"}
+                                                        </span>
+                                                    }
+                                                >
+                                                    {header().label}
+                                                </Show>
+                                            </span>
+                                            <Show
+                                                when={
+                                                    isOrphanedColumn(header()) &&
+                                                    props.onDeleteOrphanedColumn
+                                                }
+                                            >
+                                                <Button
+                                                    variant="danger"
+                                                    outline
+                                                    class={styles.deleteColumn}
+                                                    aria-label="Delete column"
+                                                    tabindex={-1}
+                                                    onMouseDown={(evt) => evt.preventDefault()}
+                                                    onMouseEnter={() =>
+                                                        setDeletingColumnId(header().id)
+                                                    }
+                                                    onMouseLeave={() => setDeletingColumnId(null)}
+                                                    onClick={() => {
+                                                        setDeletingColumnId(null);
+                                                        props.onDeleteOrphanedColumn?.(header());
+                                                    }}
+                                                >
+                                                    Delete
+                                                </Button>
+                                            </Show>
+                                        </div>
                                     </th>
                                 )}
                             </Index>
@@ -681,6 +745,8 @@ export function TableEditor(props: TableEditorProps) {
                                                     classList={{
                                                         [styles.selected]: isSelected(cell()),
                                                         [styles.invalid]: cellIsInvalid(cell()),
+                                                        [styles.columnDeleting]:
+                                                            deletingColumnId() === header().id,
                                                     }}
                                                     tabindex={
                                                         !isEditing(cell()) &&


### PR DESCRIPTION
Lets users delete the orphaned data. Also adds a new "outline" button modifier because the solidly filled one didn't look right.

https://branch-kb-delete-orphans-table-editor--catcolab.netlify.app/dev/ui-components/?path=/docs/forms-inputs-tableeditor--docs#orphaned-table
