### PR TITLE
Display row-level errors in instance editor

### DIFF
--- a/packages/documents/src/instance/equation-validation.ts
+++ b/packages/documents/src/instance/equation-validation.ts
@@ -48,7 +48,9 @@ export function validatePathEquations<S extends Shape>(
             continue; // the source object has no table
         }
         const tableLabel = sourceTable.label ?? sourceId;
-        const equationName = judgment.label.join(".") || judgment.id;
+        const equationLabel = judgment.label.join(".");
+        const equationText =
+            equationLabel === "" ? "Unnamed equation" : `Equation \`${equationLabel}\``;
 
         let violations = 0;
         for (const row of sourceTable.rows) {
@@ -62,24 +64,26 @@ export function validatePathEquations<S extends Shape>(
             if (violations <= MAX_COUNTEREXAMPLES_PER_EQUATION) {
                 issues.push({
                     message:
-                        `Equation \`${equationName}\` is violated by a row of table \`${tableLabel}\`: ` +
+                        `${equationText} is violated by a row of table \`${tableLabel}\`: ` +
                         `left-hand side yields ${describeSideValue(left)}, ` +
                         `right-hand side yields ${describeSideValue(right)}`,
                     path: [sourceId, "rows", row.id],
                     issueType: "EquationViolation",
                     equationId: judgment.id,
+                    equationLabel: judgment.label,
                 });
             }
         }
         if (violations > MAX_COUNTEREXAMPLES_PER_EQUATION) {
             issues.push({
                 message:
-                    `Equation \`${equationName}\` is violated by ` +
+                    `${equationText} is violated by ` +
                     `${violations - MAX_COUNTEREXAMPLES_PER_EQUATION} more rows of table ` +
                     `\`${tableLabel}\``,
                 path: [sourceId],
                 issueType: "EquationViolation",
                 equationId: judgment.id,
+                equationLabel: judgment.label,
             });
         }
     }

--- a/packages/documents/src/instance/errors.ts
+++ b/packages/documents/src/instance/errors.ts
@@ -1,3 +1,4 @@
+import type { QualifiedLabel } from "catlog-wasm";
 import type { Issue } from "../result";
 
 /** Path addressing a field, relative to the document's `tables` map. */
@@ -36,6 +37,8 @@ export interface EquationViolationIssue extends Issue {
     readonly issueType: "EquationViolation";
     /** Id of the violated equation in the schema. */
     readonly equationId: string;
+    /** Label of the violated equation. */
+    readonly equationLabel: QualifiedLabel;
 }
 
 /** A problem found while validating an instance's tables. */

--- a/packages/documents/test/instance-equations.test.ts
+++ b/packages/documents/test/instance-equations.test.ts
@@ -70,6 +70,7 @@ describe("instance validation of path equations", { timeout: 30000 }, () => {
                 path: [tableA.id, "rows", a1.id],
                 issueType: "EquationViolation",
                 equationId,
+                equationLabel: ["agree"],
             },
         ]);
 

--- a/packages/frontend/src/inference/system_prompt.md
+++ b/packages/frontend/src/inference/system_prompt.md
@@ -88,7 +88,7 @@ Instance issues: `issues` from `validate()` is an array of `{ message, path, iss
 - `MistypedRowRef` --- a row reference points to a row of the wrong table.
 - `OrphanedField` --- a stored field has no matching column in the schema.
 - `OrphanedTable` --- a stored table has no entity in the schema.
-- `EquationViolation` --- a row violates a path equation of the schema; `equationId` identifies the equation. At most 10 counterexamples are reported per equation, followed by a summary issue on the table.
+- `EquationViolation` --- a row violates a path equation of the schema; `equationId` identifies the equation and `equationLabel` names it, when labeled. At most 10 counterexamples are reported per equation, followed by a summary issue on the table.
 
 Column typing: a column's type comes from the schema morphism's codomain. A codomain object labeled `"Bool"`, `"Int"`, `"Float"`, or `"String"` gives a column of that literal type; any other label gives a `String` column. A codomain that is another table entity gives a row-reference column.
 

--- a/packages/ui-components/src/table_editor/table_editor.module.css
+++ b/packages/ui-components/src/table_editor/table_editor.module.css
@@ -141,6 +141,20 @@ shadow, it is painted above the cell editor input. */
     background: var(--color-form-invalid-bg);
 }
 
+.rowHeaderColumn {
+    width: 16px;
+}
+
+.rowHeader {
+    padding: 0;
+    border: 1px solid var(--color-gray-450);
+    background: var(--color-gray-50);
+}
+
+.rowHeader.invalid {
+    background: var(--color-button-danger-base);
+}
+
 .checkbox {
     display: block;
     margin: 0 auto;

--- a/packages/ui-components/src/table_editor/table_editor.module.css
+++ b/packages/ui-components/src/table_editor/table_editor.module.css
@@ -155,6 +155,16 @@ shadow, it is painted above the cell editor input. */
     background: var(--color-button-danger-base);
 }
 
+.rowIssues {
+    margin: 0;
+    padding-left: 1.2em;
+}
+
+.rowIssues:has(li:only-child) {
+    padding-left: 0;
+    list-style: none;
+}
+
 .checkbox {
     display: block;
     margin: 0 auto;

--- a/packages/ui-components/src/table_editor/table_editor.stories.tsx
+++ b/packages/ui-components/src/table_editor/table_editor.stories.tsx
@@ -234,8 +234,8 @@ export const DoubleClickBooleanCell: Story = {
             name: "active",
         }) as HTMLTableCellElement;
         const activeColumn = activeHeader.cellIndex;
-        const firstRow = canvas.getAllByRole("row")[1]!;
-        const cell = within(firstRow).getAllByRole("gridcell")[activeColumn]!;
+        const firstRow = canvas.getAllByRole("row")[1] as HTMLTableRowElement;
+        const cell = firstRow.cells[activeColumn]!;
         const checkbox = within(cell).getByRole("checkbox");
 
         await expect(checkbox).toBeChecked();
@@ -751,7 +751,7 @@ export const RemoteColumnInsertWhileEditing: Story = {
         await userEvent.type(input, "Edited");
 
         await userEvent.click(canvas.getByRole("button", { name: "Insert column before" }));
-        await waitFor(() => expect(canvas.getAllByRole("columnheader")).toHaveLength(3));
+        await waitFor(() => expect(canvas.getAllByRole("columnheader")).toHaveLength(4));
         // The editor follows its column to the new position, keeping the text.
         const editing = canvas.getByRole("textbox");
         await expect(editing).toHaveValue("Edited");

--- a/packages/ui-components/src/table_editor/table_editor.tsx
+++ b/packages/ui-components/src/table_editor/table_editor.tsx
@@ -1,6 +1,16 @@
+import Tooltip from "@corvu/tooltip";
 import ChevronDown from "lucide-solid/icons/chevron-down";
 import Minus from "lucide-solid/icons/minus";
-import { batch, createEffect, createMemo, createSignal, Index, onCleanup, Show } from "solid-js";
+import {
+    batch,
+    type ComponentProps,
+    createEffect,
+    createMemo,
+    createSignal,
+    Index,
+    onCleanup,
+    Show,
+} from "solid-js";
 
 import type {
     FieldValue,
@@ -310,8 +320,6 @@ export function TableEditor(props: TableEditorProps) {
 
     const rowIssues = (row: TableRow): TableIssue[] =>
         issuesByPath().get(pathKey([props.table.id, "rows", row.id])) ?? [];
-
-    const rowIsInvalid = (row: TableRow): boolean => rowIssues(row).length > 0;
 
     const cellIssues = (cell: Cell): TableIssue[] => {
         const field = fieldOf(cell);
@@ -647,11 +655,7 @@ export function TableEditor(props: TableEditorProps) {
                     <Index each={rows()}>
                         {(row) => (
                             <tr>
-                                <th
-                                    class={styles.rowHeader}
-                                    scope="row"
-                                    classList={{ [styles.invalid]: rowIsInvalid(row()) }}
-                                />
+                                <RowHeader issues={rowIssues(row())} />
                                 <Show
                                     when={headers().length > 0}
                                     fallback={<td class={styles.cell} role="gridcell" />}
@@ -706,7 +710,7 @@ export function TableEditor(props: TableEditorProps) {
                                                     aria-invalid={cellIsInvalid(cell())}
                                                     title={
                                                         cellIssues(cell())
-                                                            .map((issue) => issue.message)
+                                                            .map(issueMessage)
                                                             .join("\n") || undefined
                                                     }
                                                     onFocus={() => select(cell())}
@@ -808,6 +812,49 @@ export function TableEditor(props: TableEditorProps) {
             </Show>
         </section>
     );
+}
+
+function RowHeader(props: { issues: ReadonlyArray<TableIssue> }) {
+    const invalid = () => props.issues.length > 0;
+
+    const header = (triggerProps?: ComponentProps<"th">) => (
+        <th
+            {...triggerProps}
+            class={styles.rowHeader}
+            scope="row"
+            classList={{ [styles.invalid]: invalid() }}
+        />
+    );
+
+    return (
+        <Show when={invalid()} fallback={header()}>
+            <Tooltip hoverableContent={false} openOnFocus={false}>
+                <Tooltip.Trigger as={header} />
+                <Tooltip.Portal>
+                    <Tooltip.Content class="tooltip-content">
+                        <RowIssues issues={props.issues} />
+                    </Tooltip.Content>
+                </Tooltip.Portal>
+            </Tooltip>
+        </Show>
+    );
+}
+
+const RowIssues = (props: { issues: ReadonlyArray<TableIssue> }) => (
+    <ul class={styles.rowIssues}>
+        <Index each={props.issues}>{(issue) => <li>{issueMessage(issue())}</li>}</Index>
+    </ul>
+);
+
+function issueMessage(issue: TableIssue): string {
+    switch (issue.issueType) {
+        case "EquationViolation": {
+            const label = issue.equationLabel.join(".");
+            return label ? `Constraint \`${label}\` is violated` : "Unnamed constraint is violated";
+        }
+        default:
+            return issue.message;
+    }
 }
 
 /** The read-only content of a cell that is not being edited.

--- a/packages/ui-components/src/table_editor/table_editor.tsx
+++ b/packages/ui-components/src/table_editor/table_editor.tsx
@@ -292,11 +292,11 @@ export function TableEditor(props: TableEditorProps) {
     const cellText = (cell: Cell): string => fieldText(fieldOf(cell), cell.header);
 
     const issuesByPath = createMemo(() => {
-        const index = new Map<string, string[]>();
+        const index = new Map<string, TableIssue[]>();
         for (const issue of props.issues ?? []) {
             const key = pathKey(issue.path);
             const messages = index.get(key) ?? [];
-            messages.push(issue.message);
+            messages.push(issue);
             index.set(key, messages);
         }
         return index;
@@ -308,13 +308,18 @@ export function TableEditor(props: TableEditorProps) {
             .map((issue) => issue.message),
     );
 
-    const cellIssueMessages = (cell: Cell): string[] => {
+    const rowIssues = (row: TableRow): TableIssue[] =>
+        issuesByPath().get(pathKey([props.table.id, "rows", row.id])) ?? [];
+
+    const rowIsInvalid = (row: TableRow): boolean => rowIssues(row).length > 0;
+
+    const cellIssues = (cell: Cell): TableIssue[] => {
         const field = fieldOf(cell);
         return field ? (issuesByPath().get(pathKey(field.content.path)) ?? []) : [];
     };
 
     const cellIsInvalid = (cell: Cell): boolean => {
-        if (cellIssueMessages(cell).length > 0) {
+        if (cellIssues(cell).length > 0) {
             return true;
         }
         const header = cell.header;
@@ -596,6 +601,7 @@ export function TableEditor(props: TableEditorProps) {
             </div>
             <table class={styles.grid} role="grid">
                 <colgroup>
+                    <col class={styles.rowHeaderColumn} />
                     <Show
                         when={headers().length > 0}
                         fallback={<col style={{ width: `${EMPTY_COLUMN_WIDTH}px` }} />}
@@ -610,6 +616,7 @@ export function TableEditor(props: TableEditorProps) {
                 </colgroup>
                 <thead>
                     <tr>
+                        <th class={styles.columnHeader} scope="col" />
                         <Show
                             when={headers().length > 0}
                             fallback={<th class={styles.columnHeader} scope="col" />}
@@ -640,6 +647,11 @@ export function TableEditor(props: TableEditorProps) {
                     <Index each={rows()}>
                         {(row) => (
                             <tr>
+                                <th
+                                    class={styles.rowHeader}
+                                    scope="row"
+                                    classList={{ [styles.invalid]: rowIsInvalid(row()) }}
+                                />
                                 <Show
                                     when={headers().length > 0}
                                     fallback={<td class={styles.cell} role="gridcell" />}
@@ -693,8 +705,9 @@ export function TableEditor(props: TableEditorProps) {
                                                     aria-selected={isSelected(cell())}
                                                     aria-invalid={cellIsInvalid(cell())}
                                                     title={
-                                                        cellIssueMessages(cell()).join("\n") ||
-                                                        undefined
+                                                        cellIssues(cell())
+                                                            .map((issue) => issue.message)
+                                                            .join("\n") || undefined
                                                     }
                                                     onFocus={() => select(cell())}
                                                     onMouseDown={(evt) => {


### PR DESCRIPTION
The presence of errors is indicated by coloring the new row headers red and the errors themselves are displayed on hover in a tooltip.

<img width="1148" height="762" alt="image" src="https://github.com/user-attachments/assets/ce8fbf48-dbdd-4b53-9180-48ea54d7e200" />
