### PR TITLE
Fix `makeDocHandleReactive` output being affected when changing clone

### DIFF
--- a/packages/frontend/src/api/document.ts
+++ b/packages/frontend/src/api/document.ts
@@ -135,14 +135,12 @@ export function makeLiveDoc<Doc extends Document>(
 
 /** Create a Solid Store that tracks an Automerge document. */
 export function makeDocHandleReactive<T extends object>(handle: DocHandle<T>): T {
-    const init = handle.doc();
-
-    const [store, setStore] = createStore<T>(init);
+    const [store, setStore] = createStore<T>(structuredClone(handle.doc()));
 
     const onChange = (payload: DocHandleChangePayload<T>) => {
         // Use [`reconcile`](https://www.solidjs.com/tutorial/stores_immutable)
         // function to diff the data and thus avoid re-rendering the whole DOM.
-        setStore(reconcile(payload.doc));
+        setStore(reconcile(structuredClone(payload.doc)));
     };
 
     handle.on("change", onChange);

--- a/packages/frontend/src/api/document_store.test.ts
+++ b/packages/frontend/src/api/document_store.test.ts
@@ -431,6 +431,20 @@ describe("API document store", () => {
         expect((await store.getHandle(draftRef)).tag).toBe("Err");
     });
 
+    test("transaction drafts do not mutate source projections (automerge-repo#721)", async () => {
+        const { binder, schema } = await createFixtureWithSchema();
+
+        const { tx, draftDocs } = await binder.beginTransaction({ schema });
+        try {
+            draftDocs.schema.add(Type, { label: "Person" });
+
+            expect(draftDocs.schema.cellsOf(Type)).toHaveLength(1);
+            expect(schema.cellsOf(Type)).toHaveLength(0);
+        } finally {
+            tx.abort();
+        }
+    });
+
     test("reverting a commit restores deleted rich text blocks", async () => {
         const { schemaAutomergeHandle, store } = createFixture();
 


### PR DESCRIPTION
This is a manifestation of a similar issue as am-solid-primitives' https://github.com/automerge/automerge-repo/issues/721 in our own `makeDocHandleReactive`. 