### PR TITLE
Unified Tooltip component for consolidating tooltip usage

### DIFF
--- a/packages/frontend/src/components/document_picker.tsx
+++ b/packages/frontend/src/components/document_picker.tsx
@@ -1,4 +1,3 @@
-import Tooltip from "@corvu/tooltip";
 import { A } from "@solidjs/router";
 import type { DocInfo } from "catcolab-api/src/user_state";
 import Copy from "lucide-solid/icons/copy";
@@ -25,6 +24,7 @@ import {
     RelativeTime,
     TextInput,
     type TextInputOptions,
+    Tooltip,
 } from "catcolab-ui-components";
 import type { Document, Uuid } from "catlog-wasm";
 import { useApi } from "../api";
@@ -105,12 +105,12 @@ export function DocumentPicker(
     };
 
     const EditableDocLink = () => (
-        <Tooltip placement="bottom">
-            <Tooltip.Anchor>
-                <Tooltip.Trigger as={DocLink} />
-            </Tooltip.Anchor>
-            <Tooltip.Portal>
-                <Tooltip.Content class="popup document-picker-popup">
+        <Tooltip
+            placement="bottom"
+            trigger={DocLink}
+            contentClass="popup document-picker-popup"
+            content={
+                <>
                     <IconButton onClick={copyToClipboard}>
                         <Copy />
                     </IconButton>
@@ -118,9 +118,9 @@ export function DocumentPicker(
                         <Pencil />
                         {"Edit"}
                     </IconButton>
-                </Tooltip.Content>
-            </Tooltip.Portal>
-        </Tooltip>
+                </>
+            }
+        />
     );
 
     return (

--- a/packages/ui-components/src/icon_button.css
+++ b/packages/ui-components/src/icon_button.css
@@ -54,21 +54,3 @@
         background-color: var(--color-icon-button-positive-active);
     }
 }
-
-.tooltip-content {
-    border-radius: 0.5rem;
-    color: var(--color-background);
-    background-color: var(--color-tooltip-bg);
-    padding: 0.5rem;
-    font-size: smaller;
-    max-width: 500px;
-    word-wrap: break-word;
-
-    & p:first-child {
-        margin-top: 0;
-    }
-
-    & p:last-child {
-        margin-bottom: 0;
-    }
-}

--- a/packages/ui-components/src/icon_button.tsx
+++ b/packages/ui-components/src/icon_button.tsx
@@ -1,5 +1,6 @@
-import Tooltip from "@corvu/tooltip";
 import { type ComponentProps, type JSX, Show, splitProps } from "solid-js";
+
+import { Tooltip } from "./tooltip";
 
 import "./icon_button.css";
 
@@ -34,14 +35,12 @@ export function IconButton(
 
     return (
         <Show when={props.tooltip} fallback={button()}>
-            <Tooltip hoverableContent={false} openOnFocus={false}>
-                <Tooltip.Anchor>
-                    <Tooltip.Trigger as={button} />
-                </Tooltip.Anchor>
-                <Tooltip.Portal>
-                    <Tooltip.Content class="tooltip-content">{props.tooltip}</Tooltip.Content>
-                </Tooltip.Portal>
-            </Tooltip>
+            <Tooltip
+                content={props.tooltip}
+                trigger={button}
+                hoverableContent={false}
+                openOnFocus={false}
+            />
         </Show>
     );
 }

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -26,6 +26,7 @@ export * from "./simple_icon";
 export * from "./spinner";
 export * from "./table_editor";
 export * from "./text_input";
+export * from "./tooltip";
 export * from "./util/focus";
 export * from "./util/keyboard";
 export * from "./virtual_list";

--- a/packages/ui-components/src/tooltip.css
+++ b/packages/ui-components/src/tooltip.css
@@ -1,0 +1,17 @@
+.tooltip-content {
+    border-radius: 0.5rem;
+    color: var(--color-background);
+    background-color: var(--color-tooltip-bg);
+    padding: 0.5rem;
+    font-size: smaller;
+    max-width: 500px;
+    word-wrap: break-word;
+
+    & p:first-child {
+        margin-top: 0;
+    }
+
+    & p:last-child {
+        margin-bottom: 0;
+    }
+}

--- a/packages/ui-components/src/tooltip.stories.tsx
+++ b/packages/ui-components/src/tooltip.stories.tsx
@@ -1,0 +1,161 @@
+import type { Meta, StoryObj } from "storybook-solidjs-vite";
+import { expect, userEvent, within } from "storybook/test";
+
+import { Tooltip } from "./tooltip";
+
+const meta = {
+    title: "Overlays/Tooltip",
+    component: Tooltip,
+} satisfies Meta<typeof Tooltip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const TriggerButton = (triggerProps: Record<string, unknown>, label: string) => (
+    <button type="button" {...triggerProps}>
+        {label}
+    </button>
+);
+
+export const Summary: Story = {
+    render: () => (
+        <div style={{ display: "flex", gap: "1rem", "align-items": "center" }}>
+            <Tooltip
+                content="Edit the model"
+                openDelay={0}
+                trigger={(p) => TriggerButton(p, "Edit")}
+            />
+            <Tooltip
+                content={
+                    <div>
+                        <strong>Create new cell</strong>
+                        <div>Press Enter to create below this one</div>
+                    </div>
+                }
+                openDelay={0}
+                trigger={(p) => TriggerButton(p, "Insert")}
+            />
+            <Tooltip
+                content="Placement can be customized"
+                placement="left"
+                openDelay={0}
+                trigger={(p) => TriggerButton(p, "Left")}
+            />
+        </div>
+    ),
+    tags: ["!autodocs", "!dev"],
+};
+
+export const Basic: Story = {
+    render: () => (
+        <Tooltip
+            content="Tooltip text"
+            openDelay={0}
+            trigger={(p) => TriggerButton(p, "Hover me")}
+        />
+    ),
+    play: async () => {
+        const canvas = within(document.body);
+        const trigger = canvas.getByRole("button", { name: "Hover me" });
+        await expect(canvas.queryByText("Tooltip text")).toBeNull();
+        await userEvent.hover(trigger);
+        const tooltip = await canvas.findByText("Tooltip text");
+        await expect(tooltip).toBeVisible();
+        await expect(tooltip).toHaveAttribute("role", "tooltip");
+    },
+};
+
+export const FocusOpen: Story = {
+    render: () => (
+        <Tooltip
+            content="Focus tooltip"
+            openDelay={0}
+            trigger={(p) => TriggerButton(p, "Focus me")}
+        />
+    ),
+    play: async () => {
+        const canvas = within(document.body);
+        const trigger = canvas.getByRole("button", { name: "Focus me" });
+        await userEvent.tab();
+        await expect(trigger).toHaveFocus();
+        await expect(await canvas.findByText("Focus tooltip")).toBeVisible();
+    },
+};
+
+export const RichContent: Story = {
+    render: () => (
+        <Tooltip
+            content={
+                <div>
+                    <strong>Create new cell</strong>
+                    <div>Press Enter to create below this one</div>
+                </div>
+            }
+            openDelay={0}
+            trigger={(p) => TriggerButton(p, "Insert")}
+        />
+    ),
+    play: async () => {
+        const canvas = within(document.body);
+        await userEvent.hover(canvas.getByRole("button", { name: "Insert" }));
+        await expect(await canvas.findByText("Create new cell")).toBeVisible();
+        await expect(await canvas.findByText("Press Enter to create below this one")).toBeVisible();
+    },
+};
+
+export const Placement: Story = {
+    render: () => (
+        <Tooltip
+            content="Shown to the left"
+            placement="left"
+            openDelay={0}
+            trigger={(p) => TriggerButton(p, "Left")}
+        />
+    ),
+    play: async () => {
+        const canvas = within(document.body);
+        await userEvent.hover(canvas.getByRole("button", { name: "Left" }));
+        const tooltip = await canvas.findByText("Shown to the left");
+        await expect(tooltip).toHaveAttribute("data-placement", "left");
+    },
+};
+
+export const CustomTrigger: Story = {
+    render: () => (
+        <Tooltip
+            content="Open the document"
+            openDelay={0}
+            trigger={(triggerProps) => (
+                <a href="#" {...triggerProps}>
+                    Open document
+                </a>
+            )}
+        />
+    ),
+    play: async () => {
+        const canvas = within(document.body);
+        // corvu's trigger assigns `role="button"` to non-button triggers.
+        await userEvent.hover(canvas.getByRole("button", { name: "Open document" }));
+        await expect(await canvas.findByText("Open the document")).toBeVisible();
+    },
+};
+
+export const CustomContentClass: Story = {
+    render: () => (
+        <Tooltip
+            content={<button type="button">Popup actions</button>}
+            contentClass="popup custom-content"
+            placement="bottom"
+            openDelay={0}
+            trigger={(p) => TriggerButton(p, "Open popup")}
+        />
+    ),
+    play: async () => {
+        const canvas = within(document.body);
+        await userEvent.hover(canvas.getByRole("button", { name: "Open popup" }));
+        const tooltip = await canvas.findByRole("tooltip");
+        await expect(tooltip).not.toHaveClass("tooltip-content");
+        await expect(tooltip).toHaveClass("popup", "custom-content");
+        await expect(await canvas.findByText("Popup actions")).toBeVisible();
+    },
+};

--- a/packages/ui-components/src/tooltip.tsx
+++ b/packages/ui-components/src/tooltip.tsx
@@ -1,0 +1,38 @@
+import { Anchor, Content, Portal, Root, Trigger, type RootProps } from "@corvu/tooltip";
+import { type Component, type JSX, Show, splitProps } from "solid-js";
+
+import "./tooltip.css";
+
+/** A unified tooltip component.
+
+A styled wrapper around corvu's `Tooltip`: it renders the `content` in a
+floating element with the standard tooltip styling whenever the `trigger`
+component is hovered or focused. The appearance of the content element can
+be fully replaced via `contentClass` for specialized usages (e.g. popups
+with interactive content).
+ */
+export function Tooltip(
+    allProps: {
+        /** Content to display in the tooltip. */
+        content: JSX.Element | string;
+        /** Component used to render the trigger; receives the trigger props. */
+        trigger?: Component<Record<string, unknown>>;
+        /** Class of the tooltip content element. Defaults to `tooltip-content`. */
+        contentClass?: string;
+    } & Omit<RootProps, "children">,
+) {
+    const [props, rootProps] = splitProps(allProps, ["content", "trigger", "contentClass"]);
+
+    return (
+        <Root {...rootProps}>
+            <Show when={props.trigger}>
+                <Anchor>
+                    <Trigger as={props.trigger} />
+                </Anchor>
+            </Show>
+            <Portal>
+                <Content class={props.contentClass ?? "tooltip-content"}>{props.content}</Content>
+            </Portal>
+        </Root>
+    );
+}


### PR DESCRIPTION
Closes #1482

Consolidates the tooltip usage across CatColab into one unified `Tooltip` component in `ui-components`.

## Changes

- New `Tooltip` component wrapping corvu's tooltip, with the standard `tooltip-content` styling and options for placement, focus/hover behaviour, and custom content classes.
- `IconButton` now uses the unified `Tooltip` instead of embedding corvu directly (no behaviour change).
- The document picker's popup was migrated to the same component with its original placement and classes preserved.
- Tooltip styles moved from `icon_button.css` into a dedicated `tooltip.css`.
- New Storybook stories with interaction tests: hover, focus, rich content, placement, custom trigger (anchor), and custom content classes.

## Verification

- `pnpm --filter ./packages/ui-components test`: 220/220 pass (including the 7 new Tooltip interaction tests, run headless in Chromium via vitest browser).
- ui-components `ci` (tcm, tsc, oxlint --deny-warnings, oxfmt --check, stylelint) clean; frontend oxlint/oxfmt/stylelint clean.
- Storybook production build succeeds (`storybook build`); the UI Components preview will be deployed to Netlify.

Follow-up candidates (kept out of this PR to keep it focused): the rich text editor's CSS `data-tooltip` buttons and remaining native `title` attributes.