### PR TITLE
LLM conversation navigation

### DIFF
--- a/packages/frontend/src/llm_conversation/llm_conversation_pane.tsx
+++ b/packages/frontend/src/llm_conversation/llm_conversation_pane.tsx
@@ -1,13 +1,5 @@
 import Plus from "lucide-solid/icons/plus";
-import {
-    createEffect,
-    createResource,
-    createSignal,
-    For,
-    Show,
-    untrack,
-    useContext,
-} from "solid-js";
+import { createEffect, createResource, For, Show, useContext } from "solid-js";
 import invariant from "tiny-invariant";
 
 import type { UserSettings } from "catcolab-api";
@@ -46,6 +38,8 @@ export function LLMConversationPane(props: {
     documents: LiveDocWithRef[];
     createOn: LiveDocWithRef | undefined;
     focus: FocusHandle;
+    selectedRefId: string | undefined;
+    onSelect: (refId: string | undefined, replace?: boolean) => void;
 }) {
     const api = useApi();
     const binder = useBinder();
@@ -56,7 +50,6 @@ export function LLMConversationPane(props: {
     const conversations = useLLMConversationsOf(() =>
         props.documents.map((document) => document.docRef.refId),
     );
-    const [selectedRefId, setSelectedRefId] = createSignal<string | null>(null);
     const creationDocument = () => {
         const document = props.createOn;
         return document && supportsLLMConversation(document.liveDoc.doc) ? document : undefined;
@@ -64,12 +57,14 @@ export function LLMConversationPane(props: {
 
     createEffect(() => {
         const docs = conversations();
-        const selected = untrack(selectedRefId);
         if (
-            selected === null ||
-            !docs?.some(({ conversation }) => conversation.ref.id === selected)
+            props.documents.length > 0 &&
+            docs &&
+            docs.length > 0 &&
+            !conversations.loading &&
+            !docs.some(({ conversation }) => conversation.ref.id === props.selectedRefId)
         ) {
-            setSelectedRefId(docs?.[0]?.conversation.ref.id ?? null);
+            props.onSelect(docs[0]!.conversation.ref.id, true);
         }
     });
 
@@ -77,7 +72,7 @@ export function LLMConversationPane(props: {
         const document = creationDocument();
         invariant(document, "The right-most document must support LLM conversations");
         const newRefId = await createLLMConversation(api, binder, document, DEFAULT_LLM_MODEL);
-        setSelectedRefId(newRefId);
+        props.onSelect(newRefId);
     };
 
     const iconLettersOf = (document: Document): [string, string] | undefined => {
@@ -91,10 +86,13 @@ export function LLMConversationPane(props: {
         }
     };
 
-    const [liveConversation] = createResource(selectedRefId, async (refId) => {
-        const { liveConversation } = await getLiveLLMConversation(refId, api, models, binder);
-        return liveConversation;
-    });
+    const [liveConversation] = createResource(
+        () => props.selectedRefId,
+        async (refId) => {
+            const { liveConversation } = await getLiveLLMConversation(refId, api, models, binder);
+            return liveConversation;
+        },
+    );
 
     return (
         <div class={styles.pane}>
@@ -119,14 +117,14 @@ export function LLMConversationPane(props: {
                             <div
                                 class={styles.row}
                                 classList={{
-                                    [styles.active]: conversation.ref.id === selectedRefId(),
+                                    [styles.active]: conversation.ref.id === props.selectedRefId,
                                 }}
-                                onMouseDown={() => setSelectedRefId(conversation.ref.id)}
+                                onMouseDown={() => props.onSelect(conversation.ref.id)}
                             >
                                 <DocumentTypeIcon documentType="llmconversation" />
                                 <div
                                     class={styles.rowName}
-                                    onFocusIn={() => setSelectedRefId(conversation.ref.id)}
+                                    onFocusIn={() => props.onSelect(conversation.ref.id)}
                                 >
                                     <InlineInput
                                         text={conversation.docView.name}

--- a/packages/frontend/src/page/document_page.tsx
+++ b/packages/frontend/src/page/document_page.tsx
@@ -1,7 +1,7 @@
 import Resizable, { type ContextValue } from "@corvu/resizable";
 import { makeEventListener } from "@solid-primitives/event-listener";
 import { Title } from "@solidjs/meta";
-import { useNavigate, useParams } from "@solidjs/router";
+import { useLocation, useNavigate, useParams, useSearchParams } from "@solidjs/router";
 import BotMessageSquare from "lucide-solid/icons/bot-message-square";
 import ChevronsRight from "lucide-solid/icons/chevrons-right";
 import History from "lucide-solid/icons/history";
@@ -102,7 +102,9 @@ export default function DocumentPage() {
     invariant(models, "Must provide model library as context to page");
 
     const params = useParams();
+    const location = useLocation();
     const navigate = useNavigate();
+    const [searchParams, setSearchParams] = useSearchParams();
     const { settings } = useUserSettings();
     const documentIsVisible = (kind: string | undefined) =>
         kind === undefined || isDocumentVisible({ typeName: kind as DocumentType }, settings());
@@ -119,7 +121,7 @@ export default function DocumentPage() {
     // Redirect if primary and secondary refs match
     createEffect(() => {
         if (params.subref && params.ref === params.subref) {
-            navigate(`/${params.kind}/${params.ref}`, { replace: true });
+            navigate(`/${params.kind}/${params.ref}${location.search}`, { replace: true });
         }
     });
 
@@ -127,6 +129,25 @@ export default function DocumentPage() {
         () => (documentIsVisible(params.kind) ? params.ref : undefined),
         (refId) => getLiveDocument(refId, api, models, binder, params.kind as DocumentType),
     );
+
+    createEffect(() => {
+        const primary = primaryLiveDoc();
+        if (
+            params.kind !== "llmconversation" ||
+            !primary ||
+            primary.docRef.refId !== params.ref ||
+            primary.liveDoc.type !== "llmconversation"
+        ) {
+            return;
+        }
+
+        const conversationRefId = primary.docRef.refId;
+        const attachmentRefId = primary.liveDoc.liveDoc.doc.llmConversationOf._id;
+        const attachmentType = primary.liveDoc.attachment.document.type;
+        const query = new URLSearchParams(location.search);
+        query.set("llmconversation", conversationRefId);
+        navigate(`/${attachmentType}/${attachmentRefId}?${query}`, { replace: true });
+    });
 
     const [secondaryLiveDoc, { refetch: refetchSecondaryDoc }] = createResource(
         () => {
@@ -155,25 +176,48 @@ export default function DocumentPage() {
 
     const closeSidePanel = () => {
         paneFocus.setActiveChild("primary");
-        navigate(`/${params.kind}/${params.ref}`);
+        navigate(`/${params.kind}/${params.ref}${location.search}`);
     };
 
     const maximizeSidePanel = () => {
-        navigate(`/${params.subkind}/${params.subref}`);
+        navigate(`/${params.subkind}/${params.subref}${location.search}`);
     };
 
     const [primaryHistoryOpen, setPrimaryHistoryOpen] = createSignal(false);
     const togglePrimaryHistorySidebar = () => setPrimaryHistoryOpen((v) => !v);
     const [secondaryHistoryOpen, setSecondaryHistoryOpen] = createSignal(false);
     const toggleSecondaryHistorySidebar = () => setSecondaryHistoryOpen((v) => !v);
-    const [llmConversationsOpen, setLLMConversationsOpen] = createSignal(false);
+    const selectedLLMConversationRefId = () => {
+        const value = searchParams.llmconversation;
+        return typeof value === "string" ? value : undefined;
+    };
+    const llmConversationsEnabled = () =>
+        isDocumentVisible({ typeName: "llmconversation" }, settings());
+    const [llmConversationsOpen, setLLMConversationsOpen] = createSignal(
+        llmConversationsEnabled() && selectedLLMConversationRefId() !== undefined,
+    );
+    createEffect(() => {
+        const selectedRefId = selectedLLMConversationRefId();
+        const enabled = llmConversationsEnabled();
+        setLLMConversationsOpen(enabled && selectedRefId !== undefined);
+        if (!enabled && selectedRefId !== undefined) {
+            setSearchParams({ llmconversation: undefined }, { replace: true });
+        }
+    });
+    const selectLLMConversation = (refId: string | undefined, replace = false) => {
+        if (refId !== selectedLLMConversationRefId()) {
+            setSearchParams({ llmconversation: refId }, { replace });
+        }
+    };
     const toggleLLMConversationPane = () => {
-        if (llmConversationsOpen()) {
+        const open = !llmConversationsOpen();
+        if (!open) {
             (isSidePanelOpen() ? secondaryPaneFocus : primaryPaneFocus).setFocused(true);
+            selectLLMConversation(undefined, true);
         } else {
             llmConversationsFocus.setFocused(true);
         }
-        setLLMConversationsOpen((open) => !open);
+        setLLMConversationsOpen(open);
     };
 
     const llmConversationDocuments = (): LiveDocWithRef[] => {
@@ -204,10 +248,11 @@ export default function DocumentPage() {
         return undefined;
     };
     const canOpenLLMConversations = () =>
-        llmConversationsOpen() ||
-        llmConversationDocuments().some((doc) =>
-            canOpenLLMConversationPane(doc.liveDoc.doc, settings()),
-        );
+        llmConversationsEnabled() &&
+        (llmConversationsOpen() ||
+            llmConversationDocuments().some((doc) =>
+                canOpenLLMConversationPane(doc.liveDoc.doc, settings()),
+            ));
 
     const [resizableContext, setResizableContext] = createSignal<ContextValue>();
     createEffect(() => {
@@ -330,6 +375,8 @@ export default function DocumentPage() {
                                                     documents={llmConversationDocuments()}
                                                     createOn={llmConversationCreationDocument()}
                                                     focus={llmConversationsFocus}
+                                                    selectedRefId={selectedLLMConversationRefId()}
+                                                    onSelect={selectLLMConversation}
                                                 />
                                             </div>
                                         </Show>

--- a/packages/frontend/src/page/document_page_sidebar.tsx
+++ b/packages/frontend/src/page/document_page_sidebar.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "@solidjs/router";
+import { useLocation, useNavigate } from "@solidjs/router";
 import Table from "lucide-solid/icons/table";
 import { createMemo, createResource, For, Show, useContext } from "solid-js";
 import { stringify as uuidStringify } from "uuid";
@@ -239,7 +239,9 @@ function DocumentsTreeLeaf(props: {
     refetchPrimaryDoc: () => void;
     refetchSecondaryDoc: () => void;
 }) {
+    const location = useLocation();
     const navigate = useNavigate();
+    const navigateInWorkspace = (path: string) => navigate(`${path}${location.search}`);
     const theories = useContext(TheoryLibraryContext);
     const api = useApi();
 
@@ -276,10 +278,14 @@ function DocumentsTreeLeaf(props: {
             const parentOfPrimary = await getDocParent(props.primaryDoc.liveDoc.doc, api);
             if (parentOfPrimary && clickedDoc.docRef.refId === parentOfPrimary.docRef.refId) {
                 props.primaryPaneFocus.setFocused(true);
-                navigate(`/${createLinkPart(clickedDoc)}/${createLinkPart(props.primaryDoc)}`);
+                navigateInWorkspace(
+                    `/${createLinkPart(clickedDoc)}/${createLinkPart(props.primaryDoc)}`,
+                );
             } else {
                 props.secondaryPaneFocus.setFocused(true);
-                navigate(`/${createLinkPart(props.primaryDoc)}/${createLinkPart(clickedDoc)}`);
+                navigateInWorkspace(
+                    `/${createLinkPart(props.primaryDoc)}/${createLinkPart(clickedDoc)}`,
+                );
             }
         }
     };
@@ -310,7 +316,7 @@ function DocumentsTreeLeaf(props: {
                     liveDoc={props.doc.liveDoc}
                     docRef={props.doc.docRef}
                     onDocCreated={(docType, refId) => {
-                        navigate(`/${createLinkPart(props.doc)}/${docType}/${refId}`);
+                        navigateInWorkspace(`/${createLinkPart(props.doc)}/${docType}/${refId}`);
                     }}
                     onDocDeleted={() => {
                         const deletedRefId = props.doc.docRef.refId;
@@ -328,7 +334,7 @@ function DocumentsTreeLeaf(props: {
                                     // This is a root document: navigate to documents list
                                     navigate("/documents");
                                 } else {
-                                    navigate(`/${createLinkPart(parentDoc)}`);
+                                    navigateInWorkspace(`/${createLinkPart(parentDoc)}`);
                                 }
                             });
                         }


### PR DESCRIPTION
Uses a query parameter `?llmconversation=` to navigate to a conversation in the LLM conversation panel. "My documents" links to a URL of the `llmconversation-of` document with the query parameter. The panel is automatically opened and set to the right conversation. If LLM capabilities are disabled in user settings the query parameter is simply removed.