### PR TITLE
Misc. improvements for demos

### DIFF
--- a/packages/frontend/src/inference/context_exec.test.ts
+++ b/packages/frontend/src/inference/context_exec.test.ts
@@ -21,7 +21,12 @@ describe("contextExec", () => {
         const hookError = await contextExec("return 'done'", {}, async () => {
             throw new Error("validation failed");
         });
-        assert.deepStrictEqual(hookError, { tag: "Err", error: "validation failed" });
+        assert.strictEqual(hookError.tag, "Err");
+        if (hookError.tag === "Err") {
+            // The validation feedback followed by the value
+            assert.match(hookError.error, /^validation failed/);
+            assert.match(hookError.error, /Your code returned:\ndone$/);
+        }
     });
 
     test("always returns a string for successful execution", async () => {

--- a/packages/frontend/src/inference/context_exec.ts
+++ b/packages/frontend/src/inference/context_exec.ts
@@ -35,7 +35,18 @@ export async function contextExec(
         // oxlint-enable no-implied-eval
 
         const value = await fn(...bindings.map(([, value]) => value));
-        await onSuccessHook?.();
+        try {
+            await onSuccessHook?.();
+        } catch (error) {
+            // The validation feedback must reach the LLM, but it must not make
+            // the return result unobservable.
+            return {
+                tag: "Err",
+                error: truncateResult(
+                    `${errorMessage(error)}\n\nYour code returned:\n${stringify(value)}`,
+                ),
+            };
+        }
         return { tag: "Ok", value: truncateResult(stringify(value)) };
     } catch (error) {
         return { tag: "Err", error: truncateResult(errorMessage(error)) };

--- a/packages/frontend/src/inference/system_prompt.md
+++ b/packages/frontend/src/inference/system_prompt.md
@@ -4,7 +4,7 @@ You are an assistant embedded in CatColab, a tool for formal, category-theory-ba
 
 Use the `contextExec` tool to inspect, compute with, or modify the current CatColab context. It executes JavaScript (an async function in strict mode) with the context values as local bindings. Use `return` to observe a value; top-level `await` is available. Make one `contextExec` call per response and wait for its result before calling again --- several calls in one response are rejected.
 
-A returned value is truncated at 4 kB of UTF-8 text, so return only what you need --- labels, field values, and structure --- rather than whole tables or documents. Ids are opaque addressing keys, not data: pass them through programmatically, but never return them or retype them from earlier output. When the documents fail validation after an execution, their problems are reported to you in place of your returned value.
+A returned value is truncated at 4 kB of UTF-8 text, so return only what you need --- labels, field values, and structure --- rather than whole tables or documents. Ids are opaque addressing keys, not data: pass them through programmatically, but never return them or retype them from earlier output. When the documents fail validation after an execution, their problems are reported to you, followed by what your code returned: you can keep inspecting the state, but you must fix every reported problem before completing the turn.
 
 The read-only `files` binding maps attached filenames to their content: a UTF-8 string when the bytes decode as text, otherwise an array of bytes. List filenames with `Object.keys(files)`.
 
@@ -79,7 +79,7 @@ An instance binding `inst` presents data as tables generated from its schema (th
     - `await inst.updateRow(row, values)` --- set fields of one row; `values` is one value object.
     - `await inst.updateRows([{ row, values: [rowValues, ...] }, ...])` --- set fields of several rows; each entry's `values` is an array of value objects merged into that entry's row in order, so update one row as `{ row, values: [{ name: "Alice" }] }`.
     - `await inst.set(row, header, value)` --- set the field of `row` for a header object from `validate()`.
-    - `inst.deleteRow(tableId, rowId)` and `inst.deleteRows([{ tableId, rowId }, ...])` --- delete stored rows directly.
+    - `inst.deleteRow(tableId, rowId)` and `inst.deleteRows([{ tableId, rowId }, ...])` --- delete stored rows directly; deletion does not update rows that reference the deleted one, so check the tables' `RowRef` columns for referrers and repoint or delete those too.
 
 Row-editing failures: if the schema notebook has validation issues, row editing fails with those schema issues and no data is changed --- fix the schema first. Otherwise `Err` reports addressing failures: an unknown table id, an unknown or ambiguous column label, or a nonexistent row. Only the failed part is skipped: the other values of the same call are still applied, and a row is still added or updated by them, so an `Err` does not mean nothing changed. After any `Err`, call `validate()` and repair the actual state --- set the missing fields or delete leftover rows --- rather than adding replacement rows.
 
@@ -87,7 +87,7 @@ Instance issues: `issues` from `validate()` is an array of `{ message, path, iss
 
 - `MissingValue` --- a column of a row has no value; set it with `updateRow`/`set`.
 - `MistypedLiteral` --- the stored value does not have the column's type.
-- `DanglingRowRef` --- a row-reference column points to a row that no longer exists.
+- `DanglingRowRef` --- a row-reference column points to a row that no longer exists, typically one that was deleted.
 - `MistypedRowRef` --- a row reference points to a row of the wrong table.
 - `OrphanedField` --- a stored field has no matching column in the schema.
 - `OrphanedTable` --- a stored table has no entity in the schema.

--- a/packages/frontend/src/inference/system_prompt.md
+++ b/packages/frontend/src/inference/system_prompt.md
@@ -2,7 +2,9 @@ You are an assistant embedded in CatColab, a tool for formal, category-theory-ba
 
 ## Executing code
 
-Use the `contextExec` tool to inspect, compute with, or modify the current CatColab context. It executes JavaScript (an async function in strict mode) with the context values as local bindings. Use `return` to observe a value; top-level `await` is available.
+Use the `contextExec` tool to inspect, compute with, or modify the current CatColab context. It executes JavaScript (an async function in strict mode) with the context values as local bindings. Use `return` to observe a value; top-level `await` is available. Make one `contextExec` call per response and wait for its result before calling again --- several calls in one response are rejected.
+
+A returned value is truncated at 4 kB of UTF-8 text, so return only what you need --- labels, field values, and structure --- rather than whole tables or documents. Ids are opaque addressing keys, not data: pass them through programmatically, but never return them or retype them from earlier output. When the documents fail validation after an execution, their problems are reported to you in place of your returned value.
 
 The read-only `files` binding maps attached filenames to their content: a UTF-8 string when the bytes decode as text, otherwise an array of bytes. List filenames with `Object.keys(files)`.
 
@@ -68,17 +70,18 @@ An instance binding `inst` presents data as tables generated from its schema (th
 
 - `inst.title` and `inst.update({ title })`.
 - `await inst.validate()` --- validates the schema and the instance data; returns `{ modelValidation, tables, issues, get }`:
-    - `tables` --- an array of `{ id, label, headers, rows }`. Headers are `{ id, label, type }` with type tag `"Bool"`, `"Int"`, `"Float"`, `"String"`, `"RowRef"`, or `"Unknown"`. Rows are `{ id, index, fields }`; each field is `{ tag, content }` --- read a literal with `field.content.value`, a row reference with `field.content.id`, and `"Null"` fields carry no value.
+    - `tables` --- an array of `{ id, label, headers, rows }`. Headers are `{ id, label, type }` with type tag `"Bool"`, `"Int"`, `"Float"`, `"String"`, `"RowRef"`, or `"Unknown"`. Rows are `{ id, index, fields }`; a row's `fields` line up with its table's `headers`, one field per header in the same order. Each field is `{ tag, content }`: a literal is tagged with its concrete type --- `"Bool"`, `"Int"`, `"Float"`, or `"String"`, read with `field.content.value` --- a row reference is tagged `"RowRef"`, read with `field.content.id` --- and a missing value is tagged `"Null"`, carrying no value to read.
     - `modelValidation` --- the schema notebook's validation, as above.
     - `get(path)` --- read a table, row, or field: `get([tableId])`, `get([tableId, "rows", rowId])`, or `get([tableId, "rows", rowId, "fields", fieldId])`.
-- Row editing --- all async, resolving to a `Result`: `{ tag: "Ok", content }` on success, or `{ tag: "Err", content: [issues] }`:
-    - `await inst.addRow(table, values)` --- add a row to a table from `validate()`; `values` maps column labels to a literal (`boolean`, `number`, `string`, or `null`) or an existing row object (a row reference); returns the new row.
-    - `await inst.addRows([{ table, values: [rowValues, ...] }, ...])` --- the batch form of `addRow`.
-    - `await inst.updateRow(row, values)` and `await inst.updateRows([{ row, values: [...] }, ...])` --- set fields of existing rows by column label.
-    - `await inst.set(row, { id }, value)` --- set the field of `row` addressed by a header's `id`.
+- Row editing --- all async, resolving to a `Result`: `{ tag: "Ok", content }` on success, or `{ tag: "Err", content: [issues] }`. A row's values are always an object keyed by column label, mapping each label to a literal (`boolean`, `number`, `string`, or `null`) or an existing row object (a row reference); arrays and positional lists are never accepted:
+    - `await inst.addRow(table, values)` --- add one row to a table from `validate()`; `values` is one value object, omitted for an empty row; returns the new row.
+    - `await inst.addRows([{ table, values: [rowValues, ...] }, ...])` --- add several rows; each element of `values` is the value object of one new row.
+    - `await inst.updateRow(row, values)` --- set fields of one row; `values` is one value object.
+    - `await inst.updateRows([{ row, values: [rowValues, ...] }, ...])` --- set fields of several rows; each entry's `values` is an array of value objects merged into that entry's row in order, so update one row as `{ row, values: [{ name: "Alice" }] }`.
+    - `await inst.set(row, header, value)` --- set the field of `row` for a header object from `validate()`.
     - `inst.deleteRow(tableId, rowId)` and `inst.deleteRows([{ tableId, rowId }, ...])` --- delete stored rows directly.
 
-Row-editing failures: if the schema notebook has validation issues, row editing fails with those schema issues and no data is changed --- fix the schema first. Otherwise `Err` reports addressing failures: an unknown table id, an unknown or ambiguous column label, or a nonexistent row. In the batch forms, entries that fail to address are skipped while the rest are still applied.
+Row-editing failures: if the schema notebook has validation issues, row editing fails with those schema issues and no data is changed --- fix the schema first. Otherwise `Err` reports addressing failures: an unknown table id, an unknown or ambiguous column label, or a nonexistent row. Only the failed part is skipped: the other values of the same call are still applied, and a row is still added or updated by them, so an `Err` does not mean nothing changed. After any `Err`, call `validate()` and repair the actual state --- set the missing fields or delete leftover rows --- rather than adding replacement rows.
 
 Instance issues: `issues` from `validate()` is an array of `{ message, path, issueType }`, where `path` addresses the offending data using the same paths as `get` --- `[tableId]` (a table), `[tableId, "rows", rowId]` (a row), or `[tableId, "rows", rowId, "fields", fieldId]` (a field). The `issueType` values:
 
@@ -89,6 +92,8 @@ Instance issues: `issues` from `validate()` is an array of `{ message, path, iss
 - `OrphanedField` --- a stored field has no matching column in the schema.
 - `OrphanedTable` --- a stored table has no entity in the schema.
 - `EquationViolation` --- a row violates a path equation of the schema; `equationId` identifies the equation and `equationLabel` names it, when labeled. At most 10 counterexamples are reported per equation, followed by a summary issue on the table.
+
+Fix issues through their `path` --- for a field issue, `[tableId, "rows", rowId, "fields", fieldId]` --- by resolving the offending row from the current tables (the row whose `id` equals `path[2]`) and then calling `updateRow`, `set`, or `deleteRow(path[0], path[2])`. Address rows only through issue paths or row objects from `validate()`, never by index, by scanning field values, or by retyping ids from earlier output.
 
 Column typing: a column's type comes from the schema morphism's codomain. A codomain object labeled `"Bool"`, `"Int"`, `"Float"`, or `"String"` gives a column of that literal type; any other label gives a `String` column. A codomain that is another table entity gives a row-reference column.
 
@@ -154,9 +159,19 @@ return people.rows.map((row) =>
 );
 ```
 
+Example --- read one column by its header:
+
+```js
+const { tables } = await inst.validate();
+const people = tables.find((table) => table.label === "Person");
+const column = people.headers.findIndex((header) => header.label === "name");
+return people.rows.map((row) => row.fields[column]?.content.value ?? null);
+```
+
 ## Workflow
 
 - Inspect before editing: read cells, elaborated judgments, or tables, and plan the minimal set of changes.
+- After a failed call or reported problems, re-read the current state with `validate()` before editing again; fix exactly what is reported, through the reported paths.
 - Use only bindings and APIs explicitly described as available; the cell-type names and documents in scope are listed at the end of this prompt.
 - After editing, validate and fix every issue; a turn completes successfully only when all documents in scope validate without issues.
 - Answer the user's request clearly and concisely, reporting what you changed and using tool results when relevant.

--- a/packages/frontend/src/llm_conversation/document.test.ts
+++ b/packages/frontend/src/llm_conversation/document.test.ts
@@ -415,6 +415,90 @@ describe("LLM conversation turns", { timeout: 30_000 }, () => {
         assert.strictEqual(inference.runChatTurn.mock.calls.length, 1);
     });
 
+    test("persists several contextExec calls batched into one assistant message", async () => {
+        const fixture = await makeFixture();
+        inference.runChatTurn
+            .mockResolvedValueOnce({
+                content: "Done.",
+                generatedMessageDelta: [
+                    {
+                        role: "assistant",
+                        content: "Two updates.",
+                        tool_calls: [
+                            {
+                                id: "call-a",
+                                type: "function",
+                                function: {
+                                    name: "contextExec",
+                                    arguments: JSON.stringify({ code: "return 'first';" }),
+                                },
+                            },
+                            {
+                                id: "call-b",
+                                type: "function",
+                                function: {
+                                    name: "contextExec",
+                                    arguments: JSON.stringify({ code: "return 'second';" }),
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        role: "tool",
+                        tool_call_id: "call-a",
+                        content: JSON.stringify({ tag: "Ok", value: "first" }),
+                    },
+                    {
+                        role: "tool",
+                        tool_call_id: "call-b",
+                        content: JSON.stringify({ tag: "Ok", value: "second" }),
+                    },
+                    { role: "assistant", content: "Done." },
+                ],
+                termination: { tag: "FinalResponse" },
+            })
+            .mockResolvedValueOnce(response("Follow-up done."));
+
+        assert.deepStrictEqual(await runTurn(fixture), { tag: "Completed", content: "Done." });
+
+        const interactions = fixture.conversation.interactions();
+        assert.deepStrictEqual(
+            interactions.map((interaction) => interaction.tag),
+            [
+                "user-message",
+                "llm-message",
+                "llm-code-execution",
+                "llm-code-execution",
+                "llm-message",
+            ],
+        );
+        const [first, second] = interactions.slice(2);
+        assert(first?.tag === "llm-code-execution");
+        assert(second?.tag === "llm-code-execution");
+        assert.strictEqual(first.toolCallId, "call-a");
+        assert.strictEqual(first.code, "return 'first';");
+        assert.strictEqual(second.toolCallId, "call-b");
+        assert.strictEqual(second.code, "return 'second';");
+
+        // The persisted executions round-trip as one assistant/tool pair each.
+        assert.deepStrictEqual(await runTurn(fixture), {
+            tag: "Completed",
+            content: "Follow-up done.",
+        });
+        const transcript = inference.runChatTurn.mock.calls[1]![1];
+        assert.deepStrictEqual(
+            transcript.map((message) => message.role),
+            ["user", "assistant", "assistant", "tool", "assistant", "tool", "assistant", "user"],
+        );
+        const toolCallIds: Array<string | undefined> = [];
+        for (const message of transcript) {
+            if (message.role === "assistant") {
+                toolCallIds.push(message.tool_calls?.[0]?.id);
+            }
+        }
+        assert.deepStrictEqual(toolCallIds, [undefined, "call-a", "call-b", undefined]);
+    });
+
     test("retains the user message when inference fails", async () => {
         const fixture = await makeFixture();
         inference.runChatTurn.mockRejectedValue(new Error("network failed"));

--- a/packages/frontend/src/llm_conversation/document.ts
+++ b/packages/frontend/src/llm_conversation/document.ts
@@ -238,36 +238,39 @@ function generatedChatMessageDeltaToLLMInteractions(
             continue;
         }
 
-        if (toolCalls.length !== 1) {
-            return { tag: "Err", content: "Expected exactly one contextExec tool call" };
-        }
         if (typeof message.content === "string" && message.content.trim().length > 0) {
             // sometimes we have narration and tools calls together, persist the text
             interactions.push(LLMConversation.newLLMMessage(message.content));
         }
 
-        const toolCall = toolCalls[0]!;
-        if (toolCall.type !== "function" || toolCall.function.name !== "contextExec") {
-            return { tag: "Err", content: "Expected a contextExec function call" };
-        }
-        const args = parseContextExecArguments(toolCall.function.arguments);
-        if (!args) {
-            return { tag: "Err", content: "Invalid contextExec arguments" };
-        }
+        // A provider may batch several calls into one assistant message. The
+        // runner executes them serially, so their tool results follow the
+        // assistant message in call order.
+        let resultIndex = index + 1;
+        for (const toolCall of toolCalls) {
+            if (toolCall.type !== "function" || toolCall.function.name !== "contextExec") {
+                return { tag: "Err", content: "Expected a contextExec function call" };
+            }
+            const args = parseContextExecArguments(toolCall.function.arguments);
+            if (!args) {
+                return { tag: "Err", content: "Invalid contextExec arguments" };
+            }
 
-        const toolResult = messages[index + 1];
-        if (toolResult?.role !== "tool" || toolResult.tool_call_id !== toolCall.id) {
-            return {
-                tag: "Err",
-                content: "Expected the matching contextExec result immediately after its call",
-            };
+            const toolResult = messages[resultIndex];
+            if (toolResult?.role !== "tool" || toolResult.tool_call_id !== toolCall.id) {
+                return {
+                    tag: "Err",
+                    content: "Expected the matching contextExec result immediately after its call",
+                };
+            }
+            if (typeof toolResult.content !== "string") {
+                return { tag: "Err", content: "Expected the contextExec result to be a string" };
+            }
+            const result = parseContextExecResult(toolResult.content);
+            interactions.push(LLMConversation.newLLMCodeExecution(toolCall.id, args.code, result));
+            resultIndex += 1;
         }
-        if (typeof toolResult.content !== "string") {
-            return { tag: "Err", content: "Expected the contextExec result to be a string" };
-        }
-        const result = parseContextExecResult(toolResult.content);
-        interactions.push(LLMConversation.newLLMCodeExecution(toolCall.id, args.code, result));
-        index += 1;
+        index = resultIndex - 1;
     }
 
     return { tag: "Ok", content: interactions };


### PR DESCRIPTION
As expected we'll probably need to iterate on the prompt and occasionally on the inference logic.

In today's episode:
* the examples about how to do batched table editing were not clear enough
* the LLM was surprised by the tolerant behaviour
* pre-emptively avoid uuid typing/copying
* even though we disable batched tool calls (and now we tell the agent as well), it's still possible that we'll have to handle these so do so gracefully
* we were overriding the entire return result with the validation error so the LLM lost important output

